### PR TITLE
As a developer I want to refactor the message table

### DIFF
--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/AdministrationCourtRoomControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/AdministrationCourtRoomControllerITest.java
@@ -111,7 +111,6 @@ public class AdministrationCourtRoomControllerITest extends AbstractIntegrationT
                 assertThat(response.getStatusCode())
                     .as("Expect the HTTP GET request to be successful")
                     .isEqualTo(HttpStatus.OK);
-                System.out.println(response);
                 assertThat(response.getBody()).isNotNull();
                 assertThat(response.getBody()).isEqualTo(List.of(expectedResponse));
             }

--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/MessagingControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/MessagingControllerITest.java
@@ -2275,6 +2275,7 @@ class MessagingControllerITest extends AbstractIntegrationTest {
                 ResponseEntity<String> response = template.exchange(
                     new RequestEntity<>(request, httpHeaders, POST, toUri(messageType, locCode)),
                     String.class);
+                System.out.println(response);
                 assertThat(response.getStatusCode())
                     .as("Expect the HTTP GET request to be successful")
                     .isEqualTo(HttpStatus.NO_CONTENT);

--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/MessagingControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/MessagingControllerITest.java
@@ -2275,7 +2275,6 @@ class MessagingControllerITest extends AbstractIntegrationTest {
                 ResponseEntity<String> response = template.exchange(
                     new RequestEntity<>(request, httpHeaders, POST, toUri(messageType, locCode)),
                     String.class);
-                System.out.println(response);
                 assertThat(response.getStatusCode())
                     .as("Expect the HTTP GET request to be successful")
                     .isEqualTo(HttpStatus.NO_CONTENT);

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/domain/messages/Message.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/domain/messages/Message.java
@@ -20,7 +20,7 @@ import uk.gov.hmcts.juror.api.validation.JurorNumber;
 import uk.gov.hmcts.juror.api.validation.PoolNumber;
 
 import java.io.Serializable;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 /**
  * View of the JUROR Messages Table.
@@ -45,7 +45,7 @@ public class Message implements Serializable {
 
     @Id
     @Column(name = "file_datetime")
-    private LocalDate fileDatetime;
+    private LocalDateTime fileDatetime;
 
     @Id
     @Column(name = "username")

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/domain/messages/MessageKey.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/domain/messages/MessageKey.java
@@ -3,12 +3,12 @@ package uk.gov.hmcts.juror.api.moj.domain.messages;
 import lombok.EqualsAndHashCode;
 
 import java.io.Serializable;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @EqualsAndHashCode
 public class MessageKey implements Serializable {
     private String jurorNumber;
-    private LocalDate fileDatetime;
+    private LocalDateTime fileDatetime;
     private String userName;
     private String locationCode;
 }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/MessagingServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/MessagingServiceImpl.java
@@ -28,7 +28,7 @@ import uk.gov.hmcts.juror.api.moj.utils.CourtLocationUtils;
 import uk.gov.hmcts.juror.api.moj.utils.SecurityUtil;
 
 import java.time.Clock;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -229,7 +229,7 @@ public class MessagingServiceImpl implements MessagingService {
         Juror juror = getJuror(jurorAndSendType.getJurorNumber());
         Message message = Message.builder()
             .jurorNumber(juror.getJurorNumber())
-            .fileDatetime(LocalDate.now(clock))
+            .fileDatetime(LocalDateTime.now(clock))
             .userName(username)
             .locationCode(courtLocation)
             .poolNumber(jurorAndSendType.getPoolNumber())

--- a/src/main/resources/db/migration/V1_40__message_date_type_update.sql
+++ b/src/main/resources/db/migration/V1_40__message_date_type_update.sql
@@ -1,0 +1,2 @@
+ALTER TABLE juror_mod.message
+    ALTER COLUMN file_datetime TYPE timestamp(8);

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/MessagingServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/MessagingServiceImplTest.java
@@ -34,7 +34,7 @@ import uk.gov.hmcts.juror.api.moj.utils.SecurityUtil;
 
 import java.time.Clock;
 import java.time.Instant;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
@@ -1070,7 +1070,7 @@ class MessagingServiceImplTest {
 
             assertThat(message).isNotNull();
             assertThat(message.getJurorNumber()).isEqualTo(TestConstants.VALID_JUROR_NUMBER);
-            assertThat(message.getFileDatetime()).isEqualTo(LocalDate.now(clock));
+            assertThat(message.getFileDatetime()).isEqualTo(LocalDateTime.now(clock));
             assertThat(message.getUserName()).isEqualTo(username);
             assertThat(message.getLocationCode()).isEqualTo(courtLocation);
             assertThat(message.getPoolNumber()).isEqualTo(TestConstants.VALID_POOL_NUMBER);
@@ -1125,7 +1125,7 @@ class MessagingServiceImplTest {
 
             assertThat(message).isNotNull();
             assertThat(message.getJurorNumber()).isEqualTo(TestConstants.VALID_JUROR_NUMBER);
-            assertThat(message.getFileDatetime()).isEqualTo(LocalDate.now(clock));
+            assertThat(message.getFileDatetime()).isEqualTo(LocalDateTime.now(clock));
             assertThat(message.getUserName()).isEqualTo(username);
             assertThat(message.getLocationCode()).isEqualTo(courtLocation);
             assertThat(message.getPoolNumber()).isEqualTo(TestConstants.VALID_POOL_NUMBER);
@@ -1178,7 +1178,7 @@ class MessagingServiceImplTest {
 
             assertThat(message).isNotNull();
             assertThat(message.getJurorNumber()).isEqualTo(TestConstants.VALID_JUROR_NUMBER);
-            assertThat(message.getFileDatetime()).isEqualTo(LocalDate.now(clock));
+            assertThat(message.getFileDatetime()).isEqualTo(LocalDateTime.now(clock));
             assertThat(message.getUserName()).isEqualTo(username);
             assertThat(message.getLocationCode()).isEqualTo(courtLocation);
             assertThat(message.getPoolNumber()).isEqualTo(TestConstants.VALID_POOL_NUMBER);
@@ -1235,7 +1235,7 @@ class MessagingServiceImplTest {
 
             assertThat(message).isNotNull();
             assertThat(message.getJurorNumber()).isEqualTo(TestConstants.VALID_JUROR_NUMBER);
-            assertThat(message.getFileDatetime()).isEqualTo(LocalDate.now(clock));
+            assertThat(message.getFileDatetime()).isEqualTo(LocalDateTime.now(clock));
             assertThat(message.getUserName()).isEqualTo(username);
             assertThat(message.getLocationCode()).isEqualTo(courtLocation);
             assertThat(message.getPoolNumber()).isEqualTo(TestConstants.VALID_POOL_NUMBER);
@@ -1293,7 +1293,7 @@ class MessagingServiceImplTest {
 
             assertThat(message).isNotNull();
             assertThat(message.getJurorNumber()).isEqualTo(TestConstants.VALID_JUROR_NUMBER);
-            assertThat(message.getFileDatetime()).isEqualTo(LocalDate.now(clock));
+            assertThat(message.getFileDatetime()).isEqualTo(LocalDateTime.now(clock));
             assertThat(message.getUserName()).isEqualTo(username);
             assertThat(message.getLocationCode()).isEqualTo(courtLocation);
             assertThat(message.getPoolNumber()).isEqualTo(TestConstants.VALID_POOL_NUMBER);


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-6691)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ajuror-api&pullRequest=113)


### Change description ###
FILE_DATETIME column data type needs updating

In Heritage the Format is YYYYMMDD_HHMISS where HH is hours in 24 hour format 

e.g. 20240325_151025 for 10 minutes and 25 seconds past 3pm on 25th of March 2025

In the new schema we will preserve the data accuracy using a timestamp(8) data type (mapping to LocaDateTime in the backend API)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
