### PR TITLE
Fixed issue where calculate totals would fail when smart card is null

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/moj/domain/Appearance.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/domain/Appearance.java
@@ -381,9 +381,10 @@ public class Appearance implements Serializable {
         addExpenseToErrors(errors, "total", this.getTotalDue(), this.getTotalPaid());
         if ((AppearanceStage.EXPENSE_EDITED.equals(this.getAppearanceStage())
             || AppearanceStage.EXPENSE_AUTHORISED.equals(this.getAppearanceStage()))) {
-            if (BigDecimalUtils.isLessThan(this.getSmartCardAmountPaid(), this.getSmartCardAmountDue())) {
+            if (BigDecimalUtils.isLessThan(getOrZero(this.getSmartCardAmountPaid()),
+                getOrZero(this.getSmartCardAmountDue()))) {
                 errors.put("smartCardAmount",
-                    "Must be at most " + BigDecimalUtils.currencyFormat(this.getSmartCardAmountPaid()));
+                    "Must be at most " + BigDecimalUtils.currencyFormat(getOrZero(this.getSmartCardAmountPaid())));
             }
         }
         return errors;


### PR DESCRIPTION
### Change description ###
Fixed issue where calculate totals would fail when smart card is null


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
