### PR TITLE
hotfix/JM-6670

### DIFF
--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorPaperResponseControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorPaperResponseControllerITest.java
@@ -1830,6 +1830,8 @@ public class JurorPaperResponseControllerITest extends AbstractIntegrationTest {
         JurorPool jurorPool = JurorPoolUtils.getActiveJurorPoolForUser(jurorPoolRepository,
             responseDetailDto.getJurorNumber(), owner);
 
+        assertThat(jurorPool.getOwner().equals(responseDetailDto.getCurrentOwner()));
+
         assertThat(jurorPool).isNotNull();
 
         SummonsSnapshot summonsSnapshot = summonsSnapshotRepository.findById(jurorPool.getJurorNumber())

--- a/src/main/java/uk/gov/hmcts/juror/api/bureau/controller/response/BureauJurorDetailDto.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/bureau/controller/response/BureauJurorDetailDto.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.juror.api.bureau.controller.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -359,6 +360,10 @@ public class BureauJurorDetailDto implements Serializable {
     @Schema(description = "List of change logs associated to Juror")
     private List<ChangeLogDto> changeLog;
 
+    @JsonProperty("current_owner")
+    @Schema(name = "Current Owner", description = "Current owner (3 digit code) of the juror record")
+    private String currentOwner;
+
     public BureauJurorDetailDto(final ModJurorDetail jurorDetails) {
         this.jurorNumber = jurorDetails.getJurorNumber();
         this.version = jurorDetails.getVersion();
@@ -442,6 +447,7 @@ public class BureauJurorDetailDto implements Serializable {
         this.superUrgent = jurorDetails.getSuperUrgent();
         this.slaOverdue = jurorDetails.getSlaOverdue();
         this.welsh = jurorDetails.getWelsh();
+        this.currentOwner = jurorDetails.getOwner();
         this.changeLog = jurorDetails.getChangeLogs().stream().map(cl -> {
             final List<ChangeLogItemDto> changeLogItemDtos = cl.getChangeLogItems()
                 .stream()

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/response/JurorPaperResponseDetailDto.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/response/JurorPaperResponseDetailDto.java
@@ -266,6 +266,10 @@ public class JurorPaperResponseDetailDto {
     @Schema(description = "Juror notes")
     private String notes;
 
+    @JsonProperty("current_owner")
+    @Schema(name = "Current Owner", description = "Current owner (3 digit code) of the juror record")
+    private String currentOwner;
+
     @AllArgsConstructor
     @NoArgsConstructor
     @Getter

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/JurorPaperResponseServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/JurorPaperResponseServiceImpl.java
@@ -116,6 +116,7 @@ public class JurorPaperResponseServiceImpl implements JurorPaperResponseService 
 
         jurorPaperResponseDetailDto.setJurorNumber(jurorPaperResponse.getJurorNumber());
         jurorPaperResponseDetailDto.setDateReceived(jurorPaperResponse.getDateReceived().toLocalDate());
+        jurorPaperResponseDetailDto.setCurrentOwner(jurorPool.getOwner());
 
         Juror juror = jurorPool.getJuror();
 

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/JurorPaperResponseServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/JurorPaperResponseServiceImplTest.java
@@ -152,6 +152,7 @@ public class JurorPaperResponseServiceImplTest {
 
         verifyPaperResponseIsCopiedToDto(jurorPaperResponse, responseDto);
         Assertions.assertThat(responseDto.isWelshCourt()).isFalse();
+        Assertions.assertThat(responseDto.getCurrentOwner()).isEqualTo("400");
     }
 
     @Test
@@ -214,6 +215,7 @@ public class JurorPaperResponseServiceImplTest {
         Mockito.verify(jurorPaperResponseRepository, Mockito.times(1)).findByJurorNumber("987654321");
 
         verifyPaperResponseIsCopiedToDto(jurorPaperResponse, responseDto);
+        Assertions.assertThat(responseDto.getCurrentOwner()).isEqualTo("415");
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://centralgovernmentcgi.atlassian.net/browse/JM-6670


### Change description ###
Added the current owner field on the digital response to allow front end to determine if logged in user should be able to process the response.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
