### PR TITLE
hotfix/JM-6720

### DIFF
--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorManagementControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorManagementControllerITest.java
@@ -845,7 +845,7 @@ class JurorManagementControllerITest extends AbstractIntegrationTest {
         @Sql({"/db/mod/truncate.sql", "/db/jurormanagement/UpdateAttendanceDetails.sql",
             "/db/JurorExpenseControllerITest_expenseRates.sql"})
         void updateAttendanceNoShow() {
-            UpdateAttendanceDto request = buildUpdateAttendanceDto(null);
+            UpdateAttendanceDto request = buildUpdateAttendanceDto(new ArrayList<>());
             request.getCommonData().setCheckInTime(null);
             request.getCommonData().setCheckOutTime(null);
             request.getCommonData().setStatus(UpdateAttendanceStatus.CONFIRM_ATTENDANCE);

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceImpl.java
@@ -88,7 +88,7 @@ public class JurorAppearanceServiceImpl implements JurorAppearanceService {
         processAppearance(payload, appearanceDto, true);
 
         UpdateAttendanceDto.CommonData commonData = dto.getUpdateAttendanceDtoCommonData();
-        updateConfirmAttendance(commonData, null);
+        updateConfirmAttendance(commonData, new ArrayList<>());
 
     }
 
@@ -635,7 +635,7 @@ public class JurorAppearanceServiceImpl implements JurorAppearanceService {
 
         List<Tuple> checkedInJurors = appearanceRepository.retrieveAttendanceDetails(request);
 
-        if (jurors != null) {
+        if (!jurors.isEmpty()) {
             checkedInJurors = checkedInJurors.stream()
                 .filter(tuple -> jurors.contains(tuple.get(0, String.class)))
                 .toList();

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceTest.java
@@ -63,6 +63,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
@@ -117,7 +118,7 @@ class JurorAppearanceServiceTest {
         jurorAppearanceService = spy(jurorAppearanceService);
 
         doReturn(null).when(jurorAppearanceService).processAppearance(any(), any(), anyBoolean());
-        doReturn(null).when(jurorAppearanceService).updateConfirmAttendance(any(), null);
+        doReturn(null).when(jurorAppearanceService).updateConfirmAttendance(any(), anyList());
 
         Juror juror = new Juror();
         juror.setJurorNumber(JUROR_123456789);
@@ -145,7 +146,7 @@ class JurorAppearanceServiceTest {
             .findByJurorJurorNumberAndPoolPoolNumber(JUROR_123456789, "123456789");
         verify(jurorAppearanceService, times(1)).processAppearance(payloadArgumentCaptor.capture(),
             appearanceDtoCaptor.capture(), eq(true));
-        verify(jurorAppearanceService, times(1)).updateConfirmAttendance(attendanceDtoCaptor.capture(), null);
+        verify(jurorAppearanceService, times(1)).updateConfirmAttendance(attendanceDtoCaptor.capture(), anyList());
 
         JurorAppearanceDto appearanceDto = appearanceDtoCaptor.getValue();
 
@@ -171,7 +172,7 @@ class JurorAppearanceServiceTest {
         jurorAppearanceService = spy(jurorAppearanceService);
 
         doReturn(null).when(jurorAppearanceService).processAppearance(any(), any(), anyBoolean());
-        doReturn(null).when(jurorAppearanceService).updateConfirmAttendance(any(), null);
+        doReturn(null).when(jurorAppearanceService).updateConfirmAttendance(any(), anyList());
 
         Juror juror = new Juror();
         juror.setJurorNumber(JUROR_123456789);
@@ -196,7 +197,7 @@ class JurorAppearanceServiceTest {
         verify(jurorPoolRepository, times(1))
             .findByJurorJurorNumberAndPoolPoolNumber(JUROR_123456789, "123456789");
         verify(jurorAppearanceService, never()).processAppearance(any(), any(), anyBoolean());
-        verify(jurorAppearanceService, never()).updateConfirmAttendance(any(), null);
+        verify(jurorAppearanceService, never()).updateConfirmAttendance(any(), anyList());
 
     }
 
@@ -1021,7 +1022,7 @@ class JurorAppearanceServiceTest {
         // mock request and dependencies
         LocalTime checkInTime = LocalTime.of(9, 57);
 
-        UpdateAttendanceDto request = buildUpdateAttendanceDto(null);
+        UpdateAttendanceDto request = buildUpdateAttendanceDto(new ArrayList<>());
         request.getCommonData().setStatus(UpdateAttendanceStatus.CONFIRM_ATTENDANCE);
         request.getCommonData().setCheckOutTime(null);
 

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceTest.java
@@ -117,7 +117,7 @@ class JurorAppearanceServiceTest {
         jurorAppearanceService = spy(jurorAppearanceService);
 
         doReturn(null).when(jurorAppearanceService).processAppearance(any(), any(), anyBoolean());
-        doReturn(null).when(jurorAppearanceService).updateConfirmAttendance(any());
+        doReturn(null).when(jurorAppearanceService).updateConfirmAttendance(any(), null);
 
         Juror juror = new Juror();
         juror.setJurorNumber(JUROR_123456789);
@@ -145,7 +145,7 @@ class JurorAppearanceServiceTest {
             .findByJurorJurorNumberAndPoolPoolNumber(JUROR_123456789, "123456789");
         verify(jurorAppearanceService, times(1)).processAppearance(payloadArgumentCaptor.capture(),
             appearanceDtoCaptor.capture(), eq(true));
-        verify(jurorAppearanceService, times(1)).updateConfirmAttendance(attendanceDtoCaptor.capture());
+        verify(jurorAppearanceService, times(1)).updateConfirmAttendance(attendanceDtoCaptor.capture(), null);
 
         JurorAppearanceDto appearanceDto = appearanceDtoCaptor.getValue();
 
@@ -171,7 +171,7 @@ class JurorAppearanceServiceTest {
         jurorAppearanceService = spy(jurorAppearanceService);
 
         doReturn(null).when(jurorAppearanceService).processAppearance(any(), any(), anyBoolean());
-        doReturn(null).when(jurorAppearanceService).updateConfirmAttendance(any());
+        doReturn(null).when(jurorAppearanceService).updateConfirmAttendance(any(), null);
 
         Juror juror = new Juror();
         juror.setJurorNumber(JUROR_123456789);
@@ -196,7 +196,7 @@ class JurorAppearanceServiceTest {
         verify(jurorPoolRepository, times(1))
             .findByJurorJurorNumberAndPoolPoolNumber(JUROR_123456789, "123456789");
         verify(jurorAppearanceService, never()).processAppearance(any(), any(), anyBoolean());
-        verify(jurorAppearanceService, never()).updateConfirmAttendance(any());
+        verify(jurorAppearanceService, never()).updateConfirmAttendance(any(), null);
 
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://centralgovernmentcgi.atlassian.net/browse/JM-6720


### Change description ###
- the api needed a way to update a juror confirm attendance for a single juror or jurors sent on a list as opposed to all available


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
