### PR TITLE
JM-6742: Generate attendance audit number when confirming Jury Attendance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -284,7 +284,7 @@ pmdTest {
     maxFailures = 381
 }
 pmdMain {
-    maxFailures = 1137
+    maxFailures = 1136
 }
 pmd {
     maxFailures = 0

--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorManagementControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorManagementControllerITest.java
@@ -1688,22 +1688,24 @@ class JurorManagementControllerITest extends AbstractIntegrationTest {
                 .isEqualTo(2);
 
             JurorsOnTrialResponseDto.JurorsOnTrialResponseData first = jurorsOnTrialResponseDto.getTrialsList().get(0);
-            assertThat(first.getTrialNumber()).isEqualTo("T10000000");
+            assertThat(first.getTrialNumber()).isEqualTo("T10000001");
             assertThat(first.getParties()).isEqualTo("test trial");
             assertThat(first.getTrialType()).isEqualTo("Civil");
-            assertThat(first.getJudge()).isEqualTo("judge dredd");
-            assertThat(first.getCourtroom()).isEqualTo("big room");
-            assertThat(first.getNumberAttended()).isEqualTo(8);
-            assertThat(first.getTotalJurors()).isEqualTo(13);
+            assertThat(first.getJudge()).isEqualTo("judge jose");
+            assertThat(first.getCourtroom()).isEqualTo("small room");
+            assertThat(first.getNumberAttended()).isEqualTo(2);
+            assertThat(first.getTotalJurors()).isEqualTo(4);
+            assertThat(first.getAttendanceAudit()).isEqualTo("J00000002");
 
             JurorsOnTrialResponseDto.JurorsOnTrialResponseData second = jurorsOnTrialResponseDto.getTrialsList().get(1);
-            assertThat(second.getTrialNumber()).isEqualTo("T10000001");
+            assertThat(second.getTrialNumber()).isEqualTo("T10000002");
             assertThat(second.getParties()).isEqualTo("test trial");
             assertThat(second.getTrialType()).isEqualTo("Civil");
-            assertThat(second.getJudge()).isEqualTo("judge jose");
-            assertThat(second.getCourtroom()).isEqualTo("small room");
-            assertThat(second.getNumberAttended()).isEqualTo(0);
-            assertThat(second.getTotalJurors()).isEqualTo(4);
+            assertThat(second.getJudge()).isEqualTo("judge June");
+            assertThat(second.getCourtroom()).isEqualTo("other room");
+            assertThat(second.getNumberAttended()).isEqualTo(2);
+            assertThat(second.getTotalJurors()).isEqualTo(3);
+            assertThat(second.getAttendanceAudit()).isEqualTo("J00000003");
         }
 
         @Test

--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorManagementControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorManagementControllerITest.java
@@ -1756,12 +1756,12 @@ class JurorManagementControllerITest extends AbstractIntegrationTest {
 
             // verify juror history records have been created
             assertThat(jurorHistoryRepository.findByJurorNumber("222222222")
-                .stream().anyMatch(jh -> jh.getHistoryCode().equals(HistoryCodeMod.JURY_ATTENDANCE) &&
-                    jh.getOtherInformation().equalsIgnoreCase("J00123456"))).isTrue();
+                .stream().anyMatch(jh -> jh.getHistoryCode().equals(HistoryCodeMod.JURY_ATTENDANCE)
+                    && jh.getOtherInformation().equalsIgnoreCase("J00123456"))).isTrue();
 
             assertThat(jurorHistoryRepository.findByJurorNumber("333333333")
-                .stream().anyMatch(jh -> jh.getHistoryCode().equals(HistoryCodeMod.JURY_ATTENDANCE) &&
-                    jh.getOtherInformation().equalsIgnoreCase("J00123456"))).isTrue();
+                .stream().anyMatch(jh -> jh.getHistoryCode().equals(HistoryCodeMod.JURY_ATTENDANCE)
+                    && jh.getOtherInformation().equalsIgnoreCase("J00123456"))).isTrue();
         }
 
         @Test

--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorManagementControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorManagementControllerITest.java
@@ -33,10 +33,12 @@ import uk.gov.hmcts.juror.api.moj.controller.response.jurormanagement.Attendance
 import uk.gov.hmcts.juror.api.moj.domain.Appearance;
 import uk.gov.hmcts.juror.api.moj.domain.IJurorStatus;
 import uk.gov.hmcts.juror.api.moj.enumeration.AppearanceStage;
+import uk.gov.hmcts.juror.api.moj.enumeration.HistoryCodeMod;
 import uk.gov.hmcts.juror.api.moj.enumeration.jurormanagement.RetrieveAttendanceDetailsTag;
 import uk.gov.hmcts.juror.api.moj.enumeration.jurormanagement.UpdateAttendanceStatus;
 import uk.gov.hmcts.juror.api.moj.exception.RestResponseEntityExceptionHandler;
 import uk.gov.hmcts.juror.api.moj.repository.AppearanceRepository;
+import uk.gov.hmcts.juror.api.moj.repository.JurorHistoryRepository;
 import uk.gov.hmcts.juror.api.moj.repository.JurorPoolRepository;
 import uk.gov.hmcts.juror.api.moj.service.jurormanagement.JurorAppearanceService;
 
@@ -101,6 +103,9 @@ class JurorManagementControllerITest extends AbstractIntegrationTest {
 
     @Autowired
     private JurorAppearanceService jurorAppearanceService;
+
+    @Autowired
+    private JurorHistoryRepository jurorHistoryRepository;
 
     private HttpHeaders httpHeaders;
 
@@ -1738,6 +1743,7 @@ class JurorManagementControllerITest extends AbstractIntegrationTest {
             assertThat(appearance.getTimeIn()).isEqualTo(LocalTime.of(9, 30));
             assertThat(appearance.getTimeOut()).isEqualTo(LocalTime.of(17, 00));
             assertThat(appearance.getAppearanceStage()).isEqualTo(EXPENSE_ENTERED);
+            assertThat(appearance.getAttendanceAuditNumber()).isEqualTo("J00123456");
 
             appearanceOpt = appearanceRepository.findByJurorNumberAndPoolNumberAndAttendanceDate(
                 "333333333", "415230101", now().minusDays(2));
@@ -1746,7 +1752,16 @@ class JurorManagementControllerITest extends AbstractIntegrationTest {
             assertThat(appearance.getTimeIn()).isEqualTo(LocalTime.of(9, 30));
             assertThat(appearance.getTimeOut()).isEqualTo(LocalTime.of(17, 00));
             assertThat(appearance.getAppearanceStage()).isEqualTo(EXPENSE_ENTERED);
+            assertThat(appearance.getAttendanceAuditNumber()).isEqualTo("J00123456");
 
+            // verify juror history records have been created
+            assertThat(jurorHistoryRepository.findByJurorNumber("222222222")
+                .stream().anyMatch(jh -> jh.getHistoryCode().equals(HistoryCodeMod.JURY_ATTENDANCE) &&
+                    jh.getOtherInformation().equalsIgnoreCase("J00123456"))).isTrue();
+
+            assertThat(jurorHistoryRepository.findByJurorNumber("333333333")
+                .stream().anyMatch(jh -> jh.getHistoryCode().equals(HistoryCodeMod.JURY_ATTENDANCE) &&
+                    jh.getOtherInformation().equalsIgnoreCase("J00123456"))).isTrue();
         }
 
         @Test

--- a/src/integration-test/resources/db/jurormanagement/ConfirmJuryAttendance.sql
+++ b/src/integration-test/resources/db/jurormanagement/ConfirmJuryAttendance.sql
@@ -82,3 +82,5 @@ VALUES (current_date - interval '2 days','666666666', '415230101','415','09:30:0
 
 INSERT INTO juror_mod.appearance (attendance_date,juror_number,pool_number,loc_code,time_in,time_out,non_attendance,appearance_stage,attendance_type)
 VALUES (current_date - interval '2 days','777777777', '415230101','415','15:53','12:30',false,'CHECKED_IN','FULL_DAY');
+
+ALTER SEQUENCE attendance_audit_seq RESTART WITH 123456;

--- a/src/integration-test/resources/db/jurormanagement/JurorsOnTrial.sql
+++ b/src/integration-test/resources/db/jurormanagement/JurorsOnTrial.sql
@@ -38,7 +38,10 @@ insert into juror_mod.juror (juror_number,last_name,first_name,address_line_1,re
 ('415000014','LNAME','FNAME','ADDRESS LINE 1', true),
 ('415000015','LNAME','FNAME','ADDRESS LINE 1', true),
 ('415000016','LNAME','FNAME','ADDRESS LINE 1', true),
-('415000017','LNAME','FNAME','ADDRESS LINE 1', true);
+('415000017','LNAME','FNAME','ADDRESS LINE 1', true),
+('415000018','LNAME','FNAME','ADDRESS LINE 1', true),
+('415000019','LNAME','FNAME','ADDRESS LINE 1', true),
+('415000020','LNAME','FNAME','ADDRESS LINE 1', true);
 
 insert into juror_mod.juror_pool(owner, juror_number, pool_number, status, is_active, location) values
 ('415', '415000001', '415231101', 3, true,'415'),
@@ -57,87 +60,67 @@ insert into juror_mod.juror_pool(owner, juror_number, pool_number, status, is_ac
 ('415', '415000014', '415231104', 4, true,'415'),
 ('415', '415000015', '415231104', 4, true,'415'),
 ('415', '415000016', '415231104', 4, true,'415'),
-('415', '415000017', '415231104', 4, true,'415');
-
-insert into juror_mod.appearance (attendance_date, juror_number,loc_code, time_in, time_out, non_attendance, attendance_type) values
-(current_date, '415000001', '415', current_time,null,false,null),
-(current_date, '415000002', '415', current_time,null,false,null),
-(current_date, '415000003', '415', current_time,null,false,null),
-(current_date, '415000004', '415', current_time,null,false,null),
-(current_date, '415000005', '415', current_time,null,false,null),
-(current_date, '415000006', '415', current_time,current_time,false,'FULL_DAY'),
-(current_date, '415000007', '415', current_time,current_time,false,'FULL_DAY'),
-(current_date, '415000008', '415', current_time,current_time,false,'FULL_DAY'),
-(current_date, '415000009', '415', current_time,current_time,false,'FULL_DAY'),
-(current_date, '415000010', '415', current_time,current_time,false,'FULL_DAY'),
-(current_date, '415000011', '415', current_time,current_time,false,'FULL_DAY'),
-(current_date, '415000012', '415', current_time,current_time,false,'FULL_DAY'),
-(current_date, '415000013', '415', current_time,current_time,false,'FULL_DAY'),
-(current_date, '415000014', '415', null,null,false,null),
-(current_date, '415000015', '415', null,null,false,null),
-(current_date, '415000016', '415', null,null,false,null),
-(current_date, '415000017', '415', null,null,false,null);
+('415', '415000017', '415231104', 4, true,'415'),
+('415', '415000018', '415231104', 4, true,'415'),
+('415', '415000019', '415231104', 4, true,'415'),
+('415', '415000020', '415231104', 4, true,'415');
 
 insert into juror_mod.judge (owner, code, description) values
 ('415', '0001', 'judge dredd'),
-('415', '0002', 'judge jose');
+('415', '0002', 'judge jose'),
+('415', '0003', 'judge June');
 
 insert into juror_mod.courtroom (loc_code, room_number, description) values
 ('415', '1', 'big room'),
-('415', '2', 'small room');
+('415', '2', 'small room'),
+('415', '3', 'other room');
 
 insert into juror_mod.trial (trial_number,loc_code,description,courtroom,judge,trial_type,trial_start_date,anonymous) values
 ('T10000000', '415', 'test trial', 1, 1, 'CIV', current_date, false),
-('T10000001', '415', 'test trial', 2, 2, 'CIV', current_date, false);
+('T10000001', '415', 'test trial', 2, 2, 'CIV', current_date, false),
+('T10000002', '415', 'test trial', 3, 3, 'CIV', current_date, false);
 
-INSERT INTO juror_mod.juror_trial
-(loc_code, juror_number, trial_number, pool_number, rand_number, date_selected, "result", completed)
-VALUES('415', '415000001','T10000000', '415231101', 10, current_date - 30, 'P', false);
-INSERT INTO juror_mod.juror_trial
-(loc_code, juror_number, trial_number, pool_number, rand_number, date_selected, "result", completed)
-VALUES('415', '415000002','T10000000', '415231101', 5, current_date - 30, 'P', false);
-INSERT INTO juror_mod.juror_trial
-(loc_code, juror_number, trial_number, pool_number, rand_number, date_selected, "result", completed)
-VALUES('415', '415000003','T10000000', '415231101', 11, current_date - 30, 'P', false);
-INSERT INTO juror_mod.juror_trial
-(loc_code, juror_number, trial_number, pool_number, rand_number, date_selected, "result", completed)
-VALUES('415', '415000004','T10000000', '415231102', 1, current_date - 30, 'P', false);
-INSERT INTO juror_mod.juror_trial
-(loc_code, juror_number, trial_number, pool_number, rand_number, date_selected, "result", completed)
-VALUES('415', '415000005','T10000000', '415231102', 3, current_date - 30, 'P', false);
-INSERT INTO juror_mod.juror_trial
-(loc_code, juror_number, trial_number, pool_number, rand_number, date_selected, "result", completed)
-VALUES('415', '415000006','T10000000', '415231102', 4, current_date - 30, 'P', false);
-INSERT INTO juror_mod.juror_trial
-(loc_code, juror_number, trial_number, pool_number, rand_number, date_selected, "result", completed)
-VALUES('415', '415000007','T10000000', '415231102', 7, current_date - 30, 'P', false);
-INSERT INTO juror_mod.juror_trial
-(loc_code, juror_number, trial_number, pool_number, rand_number, date_selected, "result", completed)
-VALUES('415', '415000008','T10000000', '415231102', 8, current_date - 30, 'P', false);
-INSERT INTO juror_mod.juror_trial
-(loc_code, juror_number, trial_number, pool_number, rand_number, date_selected, "result", completed)
-VALUES('415', '415000009','T10000000', '415231103', 13, current_date - 30, 'P', false);
-INSERT INTO juror_mod.juror_trial
-(loc_code, juror_number, trial_number, pool_number, rand_number, date_selected, "result", completed)
-VALUES('415', '415000010','T10000000', '415231103', 12, current_date - 30, 'P', false);
-INSERT INTO juror_mod.juror_trial
-(loc_code, juror_number, trial_number, pool_number, rand_number, date_selected, "result", completed)
-VALUES('415', '415000011','T10000000', '415231103', 6, current_date - 30, 'P', false);
-INSERT INTO juror_mod.juror_trial
-(loc_code, juror_number, trial_number, pool_number, rand_number, date_selected, "result", completed)
-VALUES('415', '415000012','T10000000', '415231103', 2, current_date - 30, 'P', false);
-INSERT INTO juror_mod.juror_trial
-(loc_code, juror_number, trial_number, pool_number, rand_number, date_selected, "result", completed)
-VALUES('415', '415000013','T10000000', '415231103', 9, current_date - 30, 'P', false);
-INSERT INTO juror_mod.juror_trial
-(loc_code, juror_number, trial_number, pool_number, rand_number, date_selected, "result", completed)
-VALUES('415', '415000014','T10000001', '415231104', 9, current_date - 30, 'J', false);
-INSERT INTO juror_mod.juror_trial
-(loc_code, juror_number, trial_number, pool_number, rand_number, date_selected, "result", completed)
-VALUES('415', '415000015','T10000001', '415231104', 9, current_date - 30, 'J', false);
-INSERT INTO juror_mod.juror_trial
-(loc_code, juror_number, trial_number, pool_number, rand_number, date_selected, "result", completed)
-VALUES('415', '415000016','T10000001', '415231104', 9, current_date - 30, 'J', false);
-INSERT INTO juror_mod.juror_trial
-(loc_code, juror_number, trial_number, pool_number, rand_number, date_selected, "result", completed)
-VALUES('415', '415000017','T10000001', '415231104', 9, current_date - 30, 'J', false);
+insert into juror_mod.appearance (attendance_date, juror_number, loc_code, time_in, time_out, non_attendance,
+attendance_type, trial_number, appearance_stage, attendance_audit_number) values
+(current_date, '415000001', '415', current_time,null,false,null,null,'CHECKED_IN',null),
+(current_date, '415000002', '415', current_time,null,false,null,null,'CHECKED_IN',null),
+(current_date, '415000003', '415', current_time,null,false,null,null,'CHECKED_IN',null),
+(current_date, '415000004', '415', current_time,null,false,null,null,'CHECKED_IN',null),
+(current_date, '415000005', '415', current_time,null,false,null,null,'CHECKED_IN',null),
+(current_date, '415000006', '415', current_time,current_time,false,'FULL_DAY',null,'EXPENSE_ENTERED','P00000001'),
+(current_date, '415000007', '415', current_time,current_time,false,'FULL_DAY',null,'EXPENSE_ENTERED','P00000001'),
+(current_date, '415000008', '415', current_time,current_time,false,'FULL_DAY',null,'EXPENSE_ENTERED','P00000001'),
+(current_date, '415000009', '415', current_time,current_time,false,'FULL_DAY',null,'EXPENSE_ENTERED','P00000001'),
+(current_date, '415000010', '415', current_time,current_time,false,'FULL_DAY',null,'EXPENSE_ENTERED','P00000001'),
+(current_date, '415000011', '415', current_time,current_time,false,'FULL_DAY',null,'EXPENSE_ENTERED','P00000001'),
+(current_date, '415000012', '415', current_time,current_time,false,'FULL_DAY',null,'EXPENSE_ENTERED','P00000001'),
+(current_date, '415000013', '415', current_time,current_time,false,'FULL_DAY',null,'EXPENSE_ENTERED','P00000001'),
+(current_date, '415000014', '415', current_time,current_time,true,'NON_ATTENDANCE','T10000001','EXPENSE_ENTERED',null),
+(current_date, '415000015', '415', current_time,current_time,false,'HALF_DAY','T10000001','EXPENSE_ENTERED','J00000002'),
+(current_date, '415000016', '415', null,null,false,'ABSENT','T10000001','EXPENSE_ENTERED',null),
+(current_date, '415000017', '415', current_time,current_time,false,'FULL_DAY','T10000001','EXPENSE_ENTERED','J00000002'),
+(current_date, '415000018', '415', current_time,current_time,false,'HALF_DAY_LONG_TRIAL','T10000002','EXPENSE_ENTERED','J00000003'),
+(current_date, '415000019', '415', current_time,current_time,false,'FULL_DAY_LONG_TRIAL','T10000002','EXPENSE_ENTERED','J00000003'),
+(current_date, '415000020', '415', current_time,current_time,true,'NON_ATTENDANCE_LONG_TRIAL','T10000002','EXPENSE_ENTERED',null);
+
+
+insert into juror_mod.juror_trial (loc_code, juror_number, trial_number, pool_number, rand_number, date_selected, "result", completed) values
+('415', '415000001','T10000000', '415231101', 10, current_date - 30, 'P', false),
+('415', '415000003','T10000000', '415231101', 11, current_date - 30, 'P', false),
+('415', '415000004','T10000000', '415231102', 1, current_date - 30, 'P', false),
+('415', '415000005','T10000000', '415231102', 3, current_date - 30, 'P', false),
+('415', '415000006','T10000000', '415231102', 4, current_date - 30, 'P', false),
+('415', '415000007','T10000000', '415231102', 7, current_date - 30, 'P', false),
+('415', '415000008','T10000000', '415231102', 8, current_date - 30, 'P', false),
+('415', '415000009','T10000000', '415231103', 13, current_date - 30, 'P', false),
+('415', '415000010','T10000000', '415231103', 12, current_date - 30, 'P', false),
+('415', '415000011','T10000000', '415231103', 6, current_date - 30, 'P', false),
+('415', '415000012','T10000000', '415231103', 2, current_date - 30, 'P', false),
+('415', '415000013','T10000000', '415231103', 9, current_date - 30, 'P', false),
+('415', '415000014','T10000001', '415231104', 14, current_date - 30, 'J', false),
+('415', '415000015','T10000001', '415231104', 15, current_date - 30, 'J', false),
+('415', '415000016','T10000001', '415231104', 16, current_date - 30, 'J', false),
+('415', '415000017','T10000001', '415231104', 17, current_date - 30, 'J', false),
+('415', '415000018','T10000002', '415231104', 18, current_date - 30, 'J', false),
+('415', '415000019','T10000002', '415231104', 20, current_date - 30, 'J', false),
+('415', '415000020','T10000002', '415231104', 19, current_date - 30, 'J', false);

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/IAppearanceRepositoryImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/IAppearanceRepositoryImpl.java
@@ -22,6 +22,7 @@ import uk.gov.hmcts.juror.api.moj.domain.QJurorTrial;
 import uk.gov.hmcts.juror.api.moj.enumeration.AppearanceStage;
 import uk.gov.hmcts.juror.api.moj.enumeration.AttendanceType;
 import uk.gov.hmcts.juror.api.moj.enumeration.jurormanagement.RetrieveAttendanceDetailsTag;
+import uk.gov.hmcts.juror.api.moj.enumeration.trial.PanelResult;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -249,10 +250,10 @@ public class IAppearanceRepositoryImpl implements IAppearanceRepository {
     public long countPendingApproval(String locCode, boolean isCash) {
         JPAQueryFactory queryFactory = new JPAQueryFactory(entityManager);
         return queryFactory
-            .select(APPEARANCE.jurorNumber,APPEARANCE.poolNumber,APPEARANCE.appearanceStage)
+            .select(APPEARANCE.jurorNumber, APPEARANCE.poolNumber, APPEARANCE.appearanceStage)
             .from(APPEARANCE)
             .where(APPEARANCE.courtLocation.locCode.eq(locCode))
-            .where(APPEARANCE.appearanceStage.in(AppearanceStage.EXPENSE_ENTERED,AppearanceStage.EXPENSE_EDITED))
+            .where(APPEARANCE.appearanceStage.in(AppearanceStage.EXPENSE_ENTERED, AppearanceStage.EXPENSE_EDITED))
             .where(APPEARANCE.isDraftExpense.isFalse())
             .where(APPEARANCE.payCash.eq(isCash))
             .groupBy(APPEARANCE.jurorNumber)
@@ -277,6 +278,7 @@ public class IAppearanceRepositoryImpl implements IAppearanceRepository {
             .where(APPEARANCE.appearanceStage.in(AppearanceStage.EXPENSE_ENTERED, AppearanceStage.EXPENSE_AUTHORISED,
                 AppearanceStage.EXPENSE_EDITED))
             .where(APPEARANCE.courtLocation.locCode.eq(locationCode))
+            .where(JUROR_TRIAL.result.equalsIgnoreCase(PanelResult.JUROR.getCode()))
             .groupBy(JUROR_TRIAL.trialNumber,
                 APPEARANCE.attendanceAuditNumber)
             .fetch();

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/IAppearanceRepositoryImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/IAppearanceRepositoryImpl.java
@@ -265,13 +265,20 @@ public class IAppearanceRepositoryImpl implements IAppearanceRepository {
     public List<Tuple> getTrialsWithAttendanceCount(String locationCode, LocalDate attendanceDate) {
         JPAQueryFactory queryFactory = new JPAQueryFactory(entityManager);
 
-        return queryFactory.select(JUROR_TRIAL.trialNumber, APPEARANCE.jurorNumber.count())
+        return queryFactory.select(JUROR_TRIAL.trialNumber,
+                APPEARANCE.jurorNumber.count(),
+                APPEARANCE.attendanceAuditNumber)
             .from(APPEARANCE)
-            .join(JUROR_TRIAL).on(APPEARANCE.jurorNumber.eq(JUROR_TRIAL.juror.jurorNumber))
+            .join(JUROR_TRIAL).on(APPEARANCE.jurorNumber.eq(JUROR_TRIAL.juror.jurorNumber)
+                .and(APPEARANCE.trialNumber.eq(JUROR_TRIAL.trialNumber)))
             .where(APPEARANCE.attendanceDate.eq(attendanceDate))
-            .where(APPEARANCE.attendanceType.notIn(AttendanceType.ABSENT, AttendanceType.NON_ATTENDANCE))
+            .where(APPEARANCE.attendanceType.notIn(AttendanceType.ABSENT, AttendanceType.NON_ATTENDANCE,
+                AttendanceType.NON_ATTENDANCE_LONG_TRIAL))
+            .where(APPEARANCE.appearanceStage.in(AppearanceStage.EXPENSE_ENTERED, AppearanceStage.EXPENSE_AUTHORISED,
+                AppearanceStage.EXPENSE_EDITED))
             .where(APPEARANCE.courtLocation.locCode.eq(locationCode))
-            .groupBy(JUROR_TRIAL.trialNumber)
+            .groupBy(JUROR_TRIAL.trialNumber,
+                APPEARANCE.attendanceAuditNumber)
             .fetch();
     }
 }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/trial/ITrialRepositoryImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/trial/ITrialRepositoryImpl.java
@@ -12,6 +12,7 @@ import org.springframework.data.jpa.repository.support.Querydsl;
 import uk.gov.hmcts.juror.api.moj.domain.QJurorTrial;
 import uk.gov.hmcts.juror.api.moj.domain.trial.QTrial;
 import uk.gov.hmcts.juror.api.moj.domain.trial.Trial;
+import uk.gov.hmcts.juror.api.moj.enumeration.trial.PanelResult;
 
 import java.time.LocalDate;
 import java.util.Collections;
@@ -82,6 +83,7 @@ public class ITrialRepositoryImpl implements ITrialRepository {
             .on(TRIAL.trialNumber.eq(JUROR_TRIAL.trialNumber))
             .where(TRIAL.trialEndDate.isNull().and(TRIAL.courtLocation.locCode.eq(locationCode)))
             .where(TRIAL.trialStartDate.loe(attendanceDate))
+            .where(JUROR_TRIAL.result.equalsIgnoreCase(PanelResult.JUROR.getCode()))
             .groupBy(TRIAL.trialNumber, TRIAL.description, TRIAL.trialType.stringValue(), TRIAL.courtroom.description,
                 TRIAL.judge.name)
             .fetch();

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/JurorHistoryService.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/JurorHistoryService.java
@@ -64,4 +64,6 @@ public interface JurorHistoryService {
     void createPostponementLetterHistory(JurorPool jurorPool, String otherInfo);
 
     void createSummonsLetterHistory(JurorPool jurorPool, String otherInfo);
+
+    void createJuryAttendanceHistory(JurorPool jurorPool, String otherInfo);
 }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/JurorHistoryServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/JurorHistoryServiceImpl.java
@@ -232,6 +232,10 @@ public class JurorHistoryServiceImpl implements JurorHistoryService {
         registerHistorySystem(jurorPool, HistoryCodeMod.PRINT_SUMMONS, otherInfo);
     }
 
+    public void createJuryAttendanceHistory(JurorPool jurorPool, String otherInfo) {
+        registerHistorySystem(jurorPool, HistoryCodeMod.JURY_ATTENDANCE, otherInfo);
+    }
+
     private void save(JurorHistory jurorHistory) {
         jurorHistoryRepository.save(jurorHistory);
     }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceService.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceService.java
@@ -15,6 +15,7 @@ import uk.gov.hmcts.juror.api.moj.controller.response.jurormanagement.Attendance
 
 import java.time.LocalDate;
 
+@SuppressWarnings("PMD.TooManyMethods")
 public interface JurorAppearanceService {
 
     void addAttendanceDay(BureauJwtPayload payload, AddAttendanceDayDto dto);

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceImpl.java
@@ -501,7 +501,6 @@ public class JurorAppearanceServiceImpl implements JurorAppearanceService {
             jurorPool.setNextDate(request.getCommonData().getAttendanceDate());
             jurorPool.setOnCall(false);
             jurorPoolRepository.saveAndFlush(jurorPool);
-
         });
     }
 
@@ -511,7 +510,7 @@ public class JurorAppearanceServiceImpl implements JurorAppearanceService {
         // get the next available attendance number from the database sequence
         final long attendanceAuditNumber = appearanceRepository.getNextAttendanceAuditNumber();
 
-        // pad to 8 digits and add 'J' prefix for Jury Attendance
+        // left pad with 0's up to 8 digits and add 'J' prefix for Jury Attendance
         return juryAttendancePrefix + String.format("%08d", attendanceAuditNumber);
     }
 

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceImpl.java
@@ -37,6 +37,7 @@ import uk.gov.hmcts.juror.api.moj.repository.CourtLocationRepository;
 import uk.gov.hmcts.juror.api.moj.repository.JurorPoolRepository;
 import uk.gov.hmcts.juror.api.moj.repository.JurorRepository;
 import uk.gov.hmcts.juror.api.moj.repository.trial.TrialRepository;
+import uk.gov.hmcts.juror.api.moj.service.JurorHistoryServiceImpl;
 import uk.gov.hmcts.juror.api.moj.service.expense.JurorExpenseService;
 import uk.gov.hmcts.juror.api.moj.utils.CourtLocationUtils;
 import uk.gov.hmcts.juror.api.moj.utils.JurorPoolUtils;
@@ -69,6 +70,7 @@ public class JurorAppearanceServiceImpl implements JurorAppearanceService {
     private final CourtLocationRepository courtLocationRepository;
     private final JurorRepository jurorRepository;
     private final JurorExpenseService jurorExpenseService;
+    private final JurorHistoryServiceImpl jurorHistoryService;
 
     @Override
     public void addAttendanceDay(BureauJwtPayload payload, AddAttendanceDayDto dto) {
@@ -448,11 +450,14 @@ public class JurorAppearanceServiceImpl implements JurorAppearanceService {
 
         final String owner = SecurityUtil.getActiveOwner();
 
+        // one attendance audit number applies to ALL jurors in this batch of attendances being confirmed
+        final String juryAttendanceNumber = setJuryAttendanceNumber();
+
         CourtLocation courtLocation =
             courtLocationRepository.findByLocCode(request.getCommonData().getLocationCode())
                 .orElseThrow(() -> new MojException.NotFound("Court location not found", null));
 
-        request.getJuror().stream().forEach(jurorNumber -> {
+        request.getJuror().forEach(jurorNumber -> {
             // validate the juror record exists and user has ownership of the record
             validateJuror(owner, jurorNumber);
 
@@ -486,6 +491,9 @@ public class JurorAppearanceServiceImpl implements JurorAppearanceService {
             appearance.setAppearanceStage(AppearanceStage.EXPENSE_ENTERED);
             realignAttendanceType(appearance);
 
+            appearance.setAttendanceAuditNumber(juryAttendanceNumber);
+            jurorHistoryService.createJuryAttendanceHistory(jurorPool, appearance.getAttendanceAuditNumber());
+
             appearanceRepository.saveAndFlush(appearance);
             jurorExpenseService.applyDefaultExpenses(appearance, jurorPool.getJuror());
 
@@ -495,6 +503,16 @@ public class JurorAppearanceServiceImpl implements JurorAppearanceService {
             jurorPoolRepository.saveAndFlush(jurorPool);
 
         });
+    }
+
+    private String setJuryAttendanceNumber() {
+        final String juryAttendancePrefix = "J";
+
+        // get the next available attendance number from the database sequence
+        final long attendanceAuditNumber = appearanceRepository.getNextAttendanceAuditNumber();
+
+        // pad to 8 digits and add 'J' prefix for Jury Attendance
+        return juryAttendancePrefix + String.format("%08d", attendanceAuditNumber);
     }
 
     private void checkExistingAttendance(JurorNonAttendanceDto request, LocalDate nonAttendanceDate) {

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceImpl.java
@@ -436,6 +436,7 @@ public class JurorAppearanceServiceImpl implements JurorAppearanceService {
             jurorsAttendanceCounts.forEach(tuple -> {
                 if (jurorsOnTrialData.getTrialNumber().equals(tuple.get(0, String.class))) {
                     jurorsOnTrialData.setNumberAttended(tuple.get(1, Long.class));
+                    jurorsOnTrialData.setAttendanceAudit(tuple.get(2, String.class));
                 }
             });
         });

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceImpl.java
@@ -451,7 +451,7 @@ public class JurorAppearanceServiceImpl implements JurorAppearanceService {
         final String owner = SecurityUtil.getActiveOwner();
 
         // one attendance audit number applies to ALL jurors in this batch of attendances being confirmed
-        final String juryAttendanceNumber = setJuryAttendanceNumber();
+        final String juryAttendanceNumber = getJuryAttendanceNumber();
 
         CourtLocation courtLocation =
             courtLocationRepository.findByLocCode(request.getCommonData().getLocationCode())
@@ -504,7 +504,7 @@ public class JurorAppearanceServiceImpl implements JurorAppearanceService {
         });
     }
 
-    private String setJuryAttendanceNumber() {
+    private String getJuryAttendanceNumber() {
         final String juryAttendancePrefix = "J";
 
         // get the next available attendance number from the database sequence

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceImpl.java
@@ -995,7 +995,7 @@ public class JurorAppearanceServiceImpl implements JurorAppearanceService {
     private void validateTheNumberOfJurorsToUpdate(UpdateAttendanceDto request) {
         UpdateAttendanceDto.CommonData commonData = request.getCommonData();
 
-        if (commonData.getSingleJuror().equals(Boolean.TRUE) && (request.getJuror().size() > 1)) {
+        if (commonData.getSingleJuror().equals(Boolean.TRUE) && request.getJuror().size() > 1) {
             throw new MojException.BadRequest("Multiple jurors not allowed for single record "
                 + "update", null);
         }

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/JurorHistoryServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/JurorHistoryServiceImplTest.java
@@ -468,6 +468,22 @@ class JurorHistoryServiceImplTest {
                 "Reminder letter printed"));
     }
 
+    @Test
+    void createJuryAttendanceHistory() {
+        String attendanceAuditNumber = "J00000001";
+        JurorPool jurorPool = createJurorPool();
+        jurorPool.setIsActive(true);
+
+        JurorStatus jurorStatus = mock(JurorStatus.class);
+        when(jurorStatus.getStatus()).thenReturn(IJurorStatus.JUROR);
+        jurorPool.setStatus(jurorStatus);
+
+        jurorHistoryService.createJuryAttendanceHistory(jurorPool, attendanceAuditNumber);
+        assertValuesAdditional(jurorPool, "SYSTEM", null, null,
+            new JurorHistoryPartHistoryJurorHistoryExpectedValues(HistoryCodeMod.JURY_ATTENDANCE,
+                attendanceAuditNumber));
+    }
+
     private void assertValuesAdditional(JurorPool jurorPool, String userId,
                                         LocalDate additionalDateInfo, String additionalReferenceInfo,
                                         JurorHistoryPartHistoryJurorHistoryExpectedValues... expectedValues) {

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/JurorHistoryServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/JurorHistoryServiceImplTest.java
@@ -470,7 +470,6 @@ class JurorHistoryServiceImplTest {
 
     @Test
     void createJuryAttendanceHistory() {
-        String attendanceAuditNumber = "J00000001";
         JurorPool jurorPool = createJurorPool();
         jurorPool.setIsActive(true);
 
@@ -478,6 +477,7 @@ class JurorHistoryServiceImplTest {
         when(jurorStatus.getStatus()).thenReturn(IJurorStatus.JUROR);
         jurorPool.setStatus(jurorStatus);
 
+        String attendanceAuditNumber = "J00000001";
         jurorHistoryService.createJuryAttendanceHistory(jurorPool, attendanceAuditNumber);
         assertValuesAdditional(jurorPool, "SYSTEM", null, null,
             new JurorHistoryPartHistoryJurorHistoryExpectedValues(HistoryCodeMod.JURY_ATTENDANCE,

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceTest.java
@@ -43,6 +43,7 @@ import uk.gov.hmcts.juror.api.moj.repository.CourtLocationRepository;
 import uk.gov.hmcts.juror.api.moj.repository.JurorPoolRepository;
 import uk.gov.hmcts.juror.api.moj.repository.JurorRepository;
 import uk.gov.hmcts.juror.api.moj.repository.trial.TrialRepository;
+import uk.gov.hmcts.juror.api.moj.service.JurorHistoryServiceImpl;
 import uk.gov.hmcts.juror.api.moj.service.expense.JurorExpenseService;
 
 import java.math.BigDecimal;
@@ -98,6 +99,8 @@ class JurorAppearanceServiceTest {
     private JurorExpenseService jurorExpenseService;
     @Mock
     private TrialRepository trialRepository;
+    @Mock
+    private JurorHistoryServiceImpl jurorHistoryService;
 
     @InjectMocks
     JurorAppearanceServiceImpl jurorAppearanceService;
@@ -2909,49 +2912,79 @@ class JurorAppearanceServiceTest {
 
             doReturn(Optional.of(courtLocation)).when(courtLocationRepository).findByLocCode(locationCode);
 
-            final Juror juror = new Juror();
-            juror.setJurorNumber(JUROR_123456789);
+            final Juror juror1 = new Juror();
+            juror1.setJurorNumber(JUROR1);
+
+            final Juror juror2 = new Juror();
+            juror2.setJurorNumber(JUROR2);
 
             final PoolRequest poolRequest = new PoolRequest();
             poolRequest.setPoolNumber("987654321");
             poolRequest.setOwner("415");
 
-            final JurorPool jurorPool = getJurorPool(juror, IJurorStatus.RESPONDED);
-            jurorPool.setPool(poolRequest);
-            jurorPool.setOwner("415");
+            final JurorPool jurorPool1 = getJurorPool(juror1, IJurorStatus.RESPONDED);
+            jurorPool1.setPool(poolRequest);
+            jurorPool1.setOwner("415");
 
-            doReturn(jurorPool).when(jurorPoolRepository).findByJurorNumberAndIsActiveAndCourt(
-                    JUROR_123456789, true, courtLocation);
-            Set<JurorPool> jurorPools = new HashSet<>();
-            jurorPools.add(jurorPool);
-            juror.setAssociatedPools(jurorPools);
-            doReturn(Optional.of(juror)).when(jurorRepository).findById(JUROR_123456789);
+            final JurorPool jurorPool2 = getJurorPool(juror2, IJurorStatus.RESPONDED);
+            jurorPool2.setPool(poolRequest);
+            jurorPool2.setOwner("415");
 
-            doReturn(Collections.singletonList(jurorPool)).when(jurorPoolRepository)
+            doReturn(jurorPool1).when(jurorPoolRepository).findByJurorNumberAndIsActiveAndCourt(
+                JUROR1, true, courtLocation);
+            doReturn(jurorPool2).when(jurorPoolRepository).findByJurorNumberAndIsActiveAndCourt(
+                JUROR2, true, courtLocation);
+
+            juror1.setAssociatedPools(Set.of(jurorPool1));
+            juror2.setAssociatedPools(Set.of(jurorPool2));
+            doReturn(Optional.of(juror1)).when(jurorRepository).findById(JUROR1);
+            doReturn(Optional.of(juror2)).when(jurorRepository).findById(JUROR2);
+
+            doReturn(Collections.singletonList(jurorPool1)).when(jurorPoolRepository)
                 .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(
-                JUROR_123456789, true);
+                    JUROR1, true);
+            doReturn(Collections.singletonList(jurorPool2)).when(jurorPoolRepository)
+                .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(
+                    JUROR2, true);
 
             final UpdateAttendanceDto request = buildUpdateAttendanceDto(locationCode);
+            request.setJuror(Arrays.asList(JUROR1, JUROR2));
 
-            Appearance appearance = Appearance.builder()
-                .jurorNumber(JUROR_123456789)
+            Appearance appearance1 = Appearance.builder()
+                .jurorNumber(JUROR1)
                 .attendanceDate(request.getCommonData().getAttendanceDate())
                 .courtLocation(courtLocation)
-                .poolNumber(jurorPool.getPool().getPoolNumber())
+                .poolNumber(jurorPool1.getPool().getPoolNumber())
                 .build();
 
-            when(appearanceRepository.findByJurorNumberAndAttendanceDate(JUROR_123456789,
-                now().minusDays(1))).thenReturn(appearance);
+            Appearance appearance2 = Appearance.builder()
+                .jurorNumber(JUROR2)
+                .attendanceDate(request.getCommonData().getAttendanceDate())
+                .courtLocation(courtLocation)
+                .poolNumber(jurorPool2.getPool().getPoolNumber())
+                .build();
+
+            when(appearanceRepository.findByJurorNumberAndAttendanceDate(JUROR1,
+                now().minusDays(1))).thenReturn(appearance1);
+            when(appearanceRepository.findByJurorNumberAndAttendanceDate(JUROR2,
+                now().minusDays(1))).thenReturn(appearance2);
+            when(appearanceRepository.getNextAttendanceAuditNumber()).thenReturn(123456L);
 
             jurorAppearanceService.confirmJuryAttendance(request);
 
             verify(courtLocationRepository, times(1)).findByLocCode(locationCode);
-            verify(jurorRepository, times(2)).findById(JUROR_123456789);
-            verify(jurorPoolRepository, times(2))
-                .findByJurorNumberAndIsActiveAndCourt(JUROR_123456789, true, courtLocation);
+            verify(jurorRepository, times(1)).findById(JUROR1);
+            verify(jurorRepository, times(1)).findById(JUROR2);
+            verify(jurorPoolRepository, times(1))
+                .findByJurorNumberAndIsActiveAndCourt(JUROR1, true, courtLocation);
+            verify(jurorPoolRepository, times(1))
+                .findByJurorNumberAndIsActiveAndCourt(JUROR2, true, courtLocation);
 
-            verify(appearanceRepository, times(2)).findByJurorNumberAndAttendanceDate(
-                JUROR_123456789, now().minusDays(1));
+            verify(appearanceRepository, times(1)).getNextAttendanceAuditNumber();
+            verify(appearanceRepository, times(1)).findByJurorNumberAndAttendanceDate(
+                JUROR1, now().minusDays(1));
+            verify(appearanceRepository, times(1)).findByJurorNumberAndAttendanceDate(
+                JUROR2, now().minusDays(1));
 
             ArgumentCaptor<Appearance> appearanceCaptor = ArgumentCaptor.forClass(Appearance.class);
 
@@ -2959,15 +2992,36 @@ class JurorAppearanceServiceTest {
             verify(jurorExpenseService, times(2)).applyDefaultExpenses(
                 appearanceCaptor.capture(), Mockito.any());
 
-            Appearance appearance1 = appearanceCaptor.getAllValues().get(0);
-            assertThat(appearance1.getJurorNumber()).isEqualTo(JUROR_123456789);
-            assertThat(appearance1.getAttendanceDate()).isEqualTo(request.getCommonData().getAttendanceDate());
-            assertThat(appearance1.getCourtLocation()).isEqualTo(courtLocation);
-            assertThat(appearance1.getPoolNumber()).isEqualTo(jurorPool.getPool().getPoolNumber());
-            assertThat(appearance1.getAttendanceType()).isEqualTo(AttendanceType.FULL_DAY);
-            assertThat(appearance1.getAppearanceStage()).isEqualTo(EXPENSE_ENTERED);
+            Appearance capturedAppearance1 =
+                appearanceCaptor.getAllValues().stream()
+                    .filter(app -> app.getJurorNumber().equalsIgnoreCase(JUROR1))
+                    .findFirst().get();
+            assertThat(capturedAppearance1.getJurorNumber()).isEqualTo(JUROR1);
+            assertThat(capturedAppearance1.getAttendanceDate()).isEqualTo(request.getCommonData().getAttendanceDate());
+            assertThat(capturedAppearance1.getCourtLocation()).isEqualTo(courtLocation);
+            assertThat(capturedAppearance1.getPoolNumber()).isEqualTo(jurorPool1.getPool().getPoolNumber());
+            assertThat(capturedAppearance1.getAttendanceType()).isEqualTo(AttendanceType.FULL_DAY);
+            assertThat(capturedAppearance1.getAppearanceStage()).isEqualTo(EXPENSE_ENTERED);
+            assertThat(capturedAppearance1.getAttendanceAuditNumber()).isEqualTo("J00123456");
+
+            Appearance capturedAppearance2 =
+                appearanceCaptor.getAllValues().stream()
+                    .filter(app -> app.getJurorNumber().equalsIgnoreCase(JUROR2))
+                    .findFirst().get();
+            assertThat(capturedAppearance2.getJurorNumber()).isEqualTo(JUROR2);
+            assertThat(capturedAppearance2.getAttendanceDate()).isEqualTo(request.getCommonData().getAttendanceDate());
+            assertThat(capturedAppearance2.getCourtLocation()).isEqualTo(courtLocation);
+            assertThat(capturedAppearance2.getPoolNumber()).isEqualTo(jurorPool1.getPool().getPoolNumber());
+            assertThat(capturedAppearance2.getAttendanceType()).isEqualTo(AttendanceType.FULL_DAY);
+            assertThat(capturedAppearance2.getAppearanceStage()).isEqualTo(EXPENSE_ENTERED);
+            assertThat(capturedAppearance2.getAttendanceAuditNumber()).isEqualTo("J00123456");
+
             verify(jurorPoolRepository, times(2)).saveAndFlush(Mockito.any());
 
+            verify(jurorHistoryService, times(1)).createJuryAttendanceHistory(jurorPool1,
+                capturedAppearance1.getAttendanceAuditNumber());
+            verify(jurorHistoryService, times(1)).createJuryAttendanceHistory(jurorPool2,
+                capturedAppearance1.getAttendanceAuditNumber());
         }
 
         @Test
@@ -3004,10 +3058,13 @@ class JurorAppearanceServiceTest {
                 .withMessageContaining("User does not have ownership of the supplied "
                     + "juror record");
 
+            verify(appearanceRepository, times(1)).getNextAttendanceAuditNumber();
             verify(courtLocationRepository, times(1)).findByLocCode(locationCode);
             verify(jurorRepository, times(1)).findById(JUROR_123456789);
             verifyNoInteractions(jurorPoolRepository);
-            verifyNoInteractions(appearanceRepository);
+            verifyNoInteractions(jurorHistoryService);
+            verify(appearanceRepository, never()).findByJurorNumberAndAttendanceDate(JUROR_123456789,
+                request.getCommonData().getAttendanceDate());
         }
 
         @Test
@@ -3031,10 +3088,13 @@ class JurorAppearanceServiceTest {
                 .withMessageContaining("Unable to find valid juror record for Juror Number: "
                     + JUROR_123456789);
 
+            verify(appearanceRepository, times(1)).getNextAttendanceAuditNumber();
             verify(courtLocationRepository, times(1)).findByLocCode(locationCode);
             verify(jurorRepository, times(1)).findById(JUROR_123456789);
             verifyNoInteractions(jurorPoolRepository);
-            verifyNoInteractions(appearanceRepository);
+            verifyNoInteractions(jurorHistoryService);
+            verify(appearanceRepository, never()).findByJurorNumberAndAttendanceDate(JUROR_123456789,
+                request.getCommonData().getAttendanceDate());
         }
 
         @Test
@@ -3051,10 +3111,13 @@ class JurorAppearanceServiceTest {
                     jurorAppearanceService.confirmJuryAttendance(request))
                 .as("Court location not found").withMessageContaining("Court location not found");
 
+            verify(appearanceRepository, times(1)).getNextAttendanceAuditNumber();
             verify(courtLocationRepository, times(1)).findByLocCode(locationCode);
             verifyNoInteractions(jurorRepository);
             verifyNoInteractions(jurorPoolRepository);
-            verifyNoInteractions(appearanceRepository);
+            verifyNoInteractions(jurorHistoryService);
+            verify(appearanceRepository, never()).findByJurorNumberAndAttendanceDate(JUROR_123456789,
+                request.getCommonData().getAttendanceDate());
         }
 
         private UpdateAttendanceDto buildUpdateAttendanceDto(String locationCode) {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://centralgovernmentcgi.atlassian.net/browse/JM-6742


### Change description ###
- add logic when confirming jury attendances to also generate a jury attendance audit number and apply the same number to all jurors in confirmation batch
- add new helper method to create jury attendance history event
- update queries to retrieve jurors on trials summary data
- update unit tests
- update integration tests


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
