### PR TITLE
JM-6937: Fix to non-attendance day feature and associated tests.

### DIFF
--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorManagementControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorManagementControllerITest.java
@@ -1686,6 +1686,23 @@ class JurorManagementControllerITest extends AbstractIntegrationTest {
 
         }
 
+        @Test
+        @DisplayName("Add non attendance - add a non attendance record date in the future")
+        @Sql({"/db/mod/truncate.sql", "/db/jurormanagement/InitNonAttendance.sql"})
+        void addBadPayloadNonAttendanceDayInFuture() {
+            JurorNonAttendanceDto request = JurorNonAttendanceDto.builder()
+                .jurorNumber("111111111")
+                .nonAttendanceDate(now().plusDays(1))
+                .poolNumber("415230101")
+                .locationCode("415")
+                .build();
+
+            ResponseEntity<String> response =
+                restTemplate.exchange(new RequestEntity<>(request, httpHeaders, POST,
+                    URI.create("/api/v1/moj/juror-management/non-attendance")), String.class);
+
+            assertThat(response.getStatusCode()).as("HTTP status created expected").isEqualTo(BAD_REQUEST);
+        }
     }
 
 

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceImpl.java
@@ -173,8 +173,9 @@ public class JurorAppearanceServiceImpl implements JurorAppearanceService {
 
     private void checkAttendanceDateIsNotAFutureDate(LocalDate attendanceDate) {
         if (attendanceDate.isAfter(LocalDate.now())) {
-            log.error("Requested attendance date is in the future.");
-            throw new MojException.BadRequest("Requested attendance date is in the future.", null);
+            log.error("Requested date is in the future.");
+            throw new MojException.BadRequest("Requested date is in the future.",
+                null);
         }
     }
 
@@ -374,6 +375,9 @@ public class JurorAppearanceServiceImpl implements JurorAppearanceService {
         BureauJwtPayload payload = SecurityUtil.getActiveUsersBureauPayload();
         final String locationCode = request.getLocationCode();
         final LocalDate nonAttendanceDate = request.getNonAttendanceDate();
+
+        //check that the appearance date is not in the future
+        checkAttendanceDateIsNotAFutureDate(nonAttendanceDate);
 
         log.debug(String.format("User %s is adding a non attendance day for juror %s", payload.getLogin(),
             request.getJurorNumber()));

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceTest.java
@@ -2523,6 +2523,35 @@ class JurorAppearanceServiceTest {
         }
 
         @Test
+        void negativeNonAttendanceDayInFuture() {
+
+            TestUtils.setUpMockAuthentication(courtOwner, username, "1", List.of(courtOwner));
+
+            final JurorNonAttendanceDto request = JurorNonAttendanceDto.builder()
+                .jurorNumber(jurorNumber)
+                .nonAttendanceDate(now().plusDays(1))
+                .poolNumber(poolNumber)
+                .locationCode(courtLocationCode)
+                .build();
+
+            assertThatExceptionOfType(MojException.BadRequest.class).isThrownBy(() ->
+                    jurorAppearanceService.addNonAttendance(request))
+                .withMessage("Requested date is in the future.");
+
+            verify(courtLocationRepository, times(0)).findByLocCode(any());
+            verify(courtLocationRepository, times(0)).findById(anyString());
+            verify(jurorPoolRepository, times(0))
+                .findByJurorJurorNumberAndPoolPoolNumber(Mockito.anyString(), anyString());
+            verify(appearanceRepository, times(0))
+                .findByJurorNumberAndPoolNumberAndAttendanceDate(anyString(), anyString(), any());
+            verify(appearanceRepository, times(0)).saveAndFlush(any());
+        }
+
+
+
+
+
+        @Test
         void negativeNonAttendanceForbiddenCourtUser() {
 
             TestUtils.setUpMockAuthentication(courtOwner, username, "1", List.of(courtOwner));


### PR DESCRIPTION

### JIRA link (if applicable) ###
[JM-6937](https://centralgovernmentcgi.atlassian.net/browse/JM-6937)


### Change description ###
Addition of check to ensure that a non-attendance day that is in the future cannot be created. If a user attempts to create a non-attendance day for a future date, a BadRequest exception is thrown.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
