### PR TITLE
Pool Overview -- When i click history as a court user I get redirected to the pool request screen

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/PoolHistoryServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/PoolHistoryServiceImpl.java
@@ -58,7 +58,7 @@ public class PoolHistoryServiceImpl implements PoolHistoryService {
     }
 
     private void checkAccessForCurrentUser(String owner, PoolRequest poolRequest) {
-        if (!owner.equalsIgnoreCase(JurorDigitalApplication.JUROR_OWNER) && poolRequest.getOwner() != owner) {
+        if (!owner.equalsIgnoreCase(JurorDigitalApplication.JUROR_OWNER) && !poolRequest.getOwner().equals(owner)) {
             throw new MojException.Forbidden("Court user does not have access to this pool request",
                                              null);
         }


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-6933)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ajuror-api&pullRequest=187)


### Change description ###
When I click history on the pool overview page as a court user i get redirected to the pool records screen.

When I do the same action as a bureau user I can see the correct history

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
