### PR TITLE
hotfix/JM-6951: Adding panel members fails when a juror has more than one attendance

### DIFF
--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorExpenseControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorExpenseControllerITest.java
@@ -1236,6 +1236,7 @@ class JurorExpenseControllerITest extends AbstractIntegrationTest {
                 assertThat(financialLoss.getOtherCostsDescription()).isEqualTo(otherDescription);
             }
 
+            @SuppressWarnings("PMD.ExcessiveParameterList")
             private void validateTravel(DailyExpenseTravel travel,
                                         Boolean travelByCar, Integer jurorsByCar,
                                         Boolean travelByMotorcycle, Integer jurorsByMotorcycle,
@@ -2376,10 +2377,6 @@ class JurorExpenseControllerITest extends AbstractIntegrationTest {
         public static final String URL = BASE_URL + "/approve";
 
         private static final String JUROR_NUMBER = "641500020";
-
-        protected ApproveExpenses() {
-
-        }
 
         @Nested
         class Positive {

--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorExpenseControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorExpenseControllerITest.java
@@ -2378,6 +2378,10 @@ class JurorExpenseControllerITest extends AbstractIntegrationTest {
 
         private static final String JUROR_NUMBER = "641500020";
 
+        protected ApproveExpenses() {
+
+        }
+
         @Nested
         class Positive {
             protected ResponseEntity<String> triggerValid(ApproveExpenseDto... expenseDto) throws Exception {

--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorExpenseControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorExpenseControllerITest.java
@@ -2582,8 +2582,9 @@ class JurorExpenseControllerITest extends AbstractIntegrationTest {
                     new BigDecimal("57.00"), new BigDecimal("90.00"));
             }
 
-            private void assertApproved(Appearance appearance) {
-                assertThat(appearance).isNotNull();
+            private void assertApproved(Optional<Appearance> appearanceOpt) {
+                assertThat(appearanceOpt.isPresent()).isTrue();
+                Appearance appearance = appearanceOpt.get();
                 assertThat(appearance.getAppearanceStage())
                     .isEqualTo(AppearanceStage.EXPENSE_AUTHORISED);
             }

--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorManagementControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorManagementControllerITest.java
@@ -36,6 +36,7 @@ import uk.gov.hmcts.juror.api.moj.enumeration.AppearanceStage;
 import uk.gov.hmcts.juror.api.moj.enumeration.HistoryCodeMod;
 import uk.gov.hmcts.juror.api.moj.enumeration.jurormanagement.RetrieveAttendanceDetailsTag;
 import uk.gov.hmcts.juror.api.moj.enumeration.jurormanagement.UpdateAttendanceStatus;
+import uk.gov.hmcts.juror.api.moj.exception.MojException;
 import uk.gov.hmcts.juror.api.moj.exception.RestResponseEntityExceptionHandler;
 import uk.gov.hmcts.juror.api.moj.repository.AppearanceRepository;
 import uk.gov.hmcts.juror.api.moj.repository.JurorHistoryRepository;
@@ -992,13 +993,15 @@ class JurorManagementControllerITest extends AbstractIntegrationTest {
             // verify attendance details have been updated x 2 checked in
             Appearance appearance1 =
                 appearanceRepository.findByJurorNumberAndAttendanceDate(JUROR1, request.getCommonData()
-                    .getAttendanceDate());
+                    .getAttendanceDate()).orElseThrow(() ->
+                    new MojException.NotFound("No appearance record found", null));
             assertThat(appearance1.getAppearanceStage()).isEqualTo(EXPENSE_ENTERED);
             assertThat(appearance1.getAttendanceAuditNumber()).isEqualTo("P10000000");
 
             Appearance appearance2 =
                 appearanceRepository.findByJurorNumberAndAttendanceDate(JUROR6, request.getCommonData()
-                    .getAttendanceDate());
+                    .getAttendanceDate()).orElseThrow(() ->
+                    new MojException.NotFound("No appearance record found", null));
             assertThat(appearance2.getAppearanceStage()).isEqualTo(EXPENSE_ENTERED);
             assertThat(appearance2.getAttendanceAuditNumber()).isEqualTo("P10000000");
         }

--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorManagementControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorManagementControllerITest.java
@@ -76,7 +76,7 @@ import static uk.gov.hmcts.juror.api.utils.DataConversionUtil.getExceptionDetail
  */
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@SuppressWarnings("PMD.TooManyMethods")
+@SuppressWarnings({"PMD.TooManyMethods", "PMD.ExcessiveImports"})
 class JurorManagementControllerITest extends AbstractIntegrationTest {
 
     private static final String JUROR1 = "111111111";
@@ -117,7 +117,8 @@ class JurorManagementControllerITest extends AbstractIntegrationTest {
         initHeaders();
     }
 
-    private void initHeaders() throws Exception {
+    @SuppressWarnings("PMD.LawOfDemeter")
+    private void initHeaders() {
         final String bureauJwt = mintBureauJwt(BureauJwtPayload.builder()
             .userLevel("99")
             .passwordWarning(false)

--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/PanelControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/PanelControllerITest.java
@@ -25,12 +25,14 @@ import uk.gov.hmcts.juror.api.moj.domain.Appearance;
 import uk.gov.hmcts.juror.api.moj.domain.JurorHistory;
 import uk.gov.hmcts.juror.api.moj.domain.trial.Panel;
 import uk.gov.hmcts.juror.api.moj.enumeration.trial.PanelResult;
+import uk.gov.hmcts.juror.api.moj.exception.MojException;
 import uk.gov.hmcts.juror.api.moj.repository.AppearanceRepository;
 import uk.gov.hmcts.juror.api.moj.repository.JurorHistoryRepository;
 import uk.gov.hmcts.juror.api.moj.repository.JurorPoolRepository;
 import uk.gov.hmcts.juror.api.moj.repository.trial.PanelRepository;
 
 import java.net.URI;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -368,7 +370,9 @@ public class PanelControllerITest extends AbstractIntegrationTest {
                 "Expected history code to be VRET")
             .isEqualTo("VRET");
         Appearance appearance =
-            appearanceRepository.findByJurorNumber(panelMember.getJurorPool().getJurorNumber());
+            appearanceRepository.findByJurorNumberAndAttendanceDate(panelMember.getJurorPool().getJurorNumber(),
+                LocalDate.now()).orElseThrow(() ->
+                new MojException.NotFound("No appearance record found", null));
         assertThat(appearance.getPoolNumber())
             .as("Expected value to be the current juror's pool number")
             .isEqualTo(panelMember.getJurorPool().getPoolNumber());

--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/TrialControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/TrialControllerITest.java
@@ -30,6 +30,7 @@ import uk.gov.hmcts.juror.api.moj.domain.trial.Panel;
 import uk.gov.hmcts.juror.api.moj.domain.trial.Trial;
 import uk.gov.hmcts.juror.api.moj.enumeration.trial.PanelResult;
 import uk.gov.hmcts.juror.api.moj.enumeration.trial.TrialType;
+import uk.gov.hmcts.juror.api.moj.exception.MojException;
 import uk.gov.hmcts.juror.api.moj.repository.AppearanceRepository;
 import uk.gov.hmcts.juror.api.moj.repository.JurorHistoryRepository;
 import uk.gov.hmcts.juror.api.moj.repository.JurorPoolRepository;
@@ -566,7 +567,10 @@ public class TrialControllerITest extends AbstractIntegrationTest {
                 .isEqualTo(1);
             assertThat(panel.isCompleted()).as("Expected panel completed status to be true").isTrue();
 
-            Appearance appearance = appearanceRepository.findByJurorNumber(panel.getJurorPool().getJurorNumber());
+            Appearance appearance =
+                appearanceRepository.findByJurorNumberAndAttendanceDate(panel.getJurorPool().getJurorNumber(),
+                    LocalDate.now()).orElseThrow(() ->
+                    new MojException.NotFound("No appearance record found", null));
 
             assertThat(appearance.getTimeIn()).as("Expect time in to not be null").isNotNull();
             assertThat(appearance.getTimeIn()).as("Expect time in to be 09:00").isEqualTo(LocalTime.parse(
@@ -608,13 +612,14 @@ public class TrialControllerITest extends AbstractIntegrationTest {
                 jurorHistoryRepository.findByJurorNumber(panel.getJurorPool().getJurorNumber()).size())
                 .as("Expect one history item for juror " + panel.getJurorPool().getJurorNumber())
                 .isEqualTo(1);
-            assertThat(
-                appearanceRepository.findByJurorNumber(panel.getJurorPool().getJurorNumber()).getTimeIn())
-                .as("Expect time to be null").isNull();
-            assertThat(panel.isCompleted()).as("Expected panel completed status to be true").isTrue();
 
-            Appearance appearance = appearanceRepository.findByJurorNumber(panel.getJurorPool().getJurorNumber());
+            Appearance appearance =
+                appearanceRepository.findByJurorNumberAndAttendanceDate(panel.getJurorPool().getJurorNumber(),
+                    LocalDate.now()).orElseThrow(() ->
+                    new MojException.NotFound("No appearance record found", null));
             assertThat(appearance.getTimeIn()).as("Expect time in to be null").isNull();
+            assertThat(appearance.getTimeIn()).as("Expect time to be null").isNull();
+            assertThat(panel.isCompleted()).as("Expected panel completed status to be true").isTrue();
             assertThat(appearance.getTimeOut()).as("Expect time out to be null").isNull();
             assertThat(appearance.getSatOnJury()).isTrue();
         }
@@ -652,7 +657,10 @@ public class TrialControllerITest extends AbstractIntegrationTest {
             assertThat(panel.getJurorPool().getJuror().getCompletionDate()).as(
                 "Expect completion date to be " + LocalDate.now()).isEqualTo(LocalDate.now());
 
-            Appearance appearance = appearanceRepository.findByJurorNumber(panel.getJurorPool().getJurorNumber());
+            Appearance appearance =
+                appearanceRepository.findByJurorNumberAndAttendanceDate(panel.getJurorPool().getJurorNumber(),
+                    LocalDate.now()).orElseThrow(() ->
+                    new MojException.NotFound("No appearance record found", null));
 
             assertThat(appearance.getTimeIn()).as("Expect time in to not be null").isNotNull();
             assertThat(appearance.getTimeIn()).as("Expect time in to be 09:00").isEqualTo(LocalTime.parse(

--- a/src/integration-test/resources/db/trial/Panel.sql
+++ b/src/integration-test/resources/db/trial/Panel.sql
@@ -88,6 +88,41 @@ values
 ('415', '415000031', '415231105', 3, true,'415',0),
 ('415', '415000032', '415231105', 4, true,'415',0);
 
+-- include multiple appearance records when testing - add appearance for yesterday
+insert into juror_mod.appearance (attendance_date,juror_number,loc_code, time_in, time_out, misc_total_paid, appearance_stage, non_attendance) values
+(current_date - 1, '415000001', '415', '09:30', '16:30', 0, 'EXPENSE_ENTERED', false),
+(current_date - 1, '415000002', '415', '09:30', '16:30', 0, 'EXPENSE_ENTERED', false),
+(current_date - 1, '415000003', '415', '09:30', '16:30', 0, 'EXPENSE_ENTERED', false),
+(current_date - 1, '415000004', '415', '09:30', '16:30', 0, 'EXPENSE_ENTERED', false),
+(current_date - 1, '415000005', '415', '09:30', '16:30', 0, 'EXPENSE_ENTERED', false),
+(current_date - 1, '415000006', '415', '09:30', '16:30', 0, 'EXPENSE_ENTERED', false),
+(current_date - 1, '415000007', '415', '09:30', '16:30', 0, 'EXPENSE_ENTERED', false),
+(current_date - 1, '415000008', '415', '09:30', '16:30', 0, 'EXPENSE_ENTERED', false),
+(current_date - 1, '415000009', '415', '09:30', '16:30', 0, 'EXPENSE_ENTERED', false),
+(current_date - 1, '415000010', '415', '09:30', '16:30', 0, 'EXPENSE_ENTERED', false),
+(current_date - 1, '415000011', '415', '09:30', '16:30', 0, 'EXPENSE_ENTERED', false),
+(current_date - 1, '415000012', '415', '09:30', '16:30', 0, 'EXPENSE_ENTERED', false),
+(current_date - 1, '415000013', '415', '09:30', '16:30', 0, 'EXPENSE_ENTERED', false),
+(current_date - 1, '415000014', '415', '09:30', '16:30', 0, 'EXPENSE_ENTERED', false),
+(current_date - 1, '415000015', '415', '09:30', '16:30', 0, 'EXPENSE_ENTERED', false),
+(current_date - 1, '415000016', '415', '09:30', '16:30', 0, 'EXPENSE_ENTERED', false),
+(current_date - 1, '415000017', '415', '09:30', '16:30', 0, 'EXPENSE_ENTERED', false),
+(current_date - 1, '415000018', '415', '09:30', '16:30', 0, 'EXPENSE_ENTERED', false),
+(current_date - 1, '415000019', '415', '09:30', '16:30', 0, 'EXPENSE_ENTERED', false),
+(current_date - 1, '415000020', '415', '09:30', '16:30', 0, 'EXPENSE_ENTERED', false),
+(current_date - 1, '415000021', '415', '09:30', '16:30', 0, 'EXPENSE_ENTERED', false),
+(current_date - 1, '415000022', '415', '09:30', '16:30', 0, 'EXPENSE_ENTERED', false),
+(current_date - 1, '415000023', '415', '09:30', '16:30', 0, 'EXPENSE_ENTERED', false),
+(current_date - 1, '415000024', '415', '09:30', '16:30', 0, 'EXPENSE_ENTERED', false),
+(current_date - 1, '415000025', '415', '09:30', '16:30', 0, 'EXPENSE_ENTERED', false),
+(current_date - 1, '415000026', '415', '09:30', '16:30', 0, 'EXPENSE_ENTERED', false),
+(current_date - 1, '415000027', '415', '09:30', '16:30', 0, 'EXPENSE_ENTERED', false),
+(current_date - 1, '415000028', '415', '09:30', '16:30', 0, 'EXPENSE_ENTERED', false),
+(current_date - 1, '415000029', '415', '09:30', '16:30', 0, 'EXPENSE_ENTERED', false),
+(current_date - 1, '415000030', '415', '09:30', '16:30', 0, 'EXPENSE_ENTERED', false),
+(current_date - 1, '415000031', '415', '09:30', '16:30', 0, 'EXPENSE_ENTERED', false),
+(current_date - 1, '415000032', '415', '09:30', '16:30', 0,'EXPENSE_ENTERED',false);
+-- add appearance for today
 insert into juror_mod.appearance (attendance_date,juror_number,loc_code, time_in, misc_total_paid, appearance_stage, non_attendance) values
 (current_date, '415000001', '415', current_time,0,'CHECKED_IN',false),
 (current_date, '415000002', '415', current_time,0,'CHECKED_IN',false),

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/AppearanceRepository.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/AppearanceRepository.java
@@ -15,15 +15,14 @@ import java.util.Set;
 
 
 @Repository
-public interface AppearanceRepository extends
-    IAppearanceRepository, JpaRepository<Appearance, AppearanceId>,
+public interface AppearanceRepository extends IAppearanceRepository, JpaRepository<Appearance, AppearanceId>,
     RevisionRepository<Appearance, AppearanceId, Long> {
 
     long countByJurorNumber(String jurorNumber);
 
     Appearance findByJurorNumber(String jurorNumber);
 
-    Appearance findByJurorNumberAndAttendanceDate(String jurorNumber, LocalDate attendanceDate);
+    Optional<Appearance> findByJurorNumberAndAttendanceDate(String jurorNumber, LocalDate attendanceDate);
 
     List<Appearance> findAllByJurorNumberAndPoolNumber(String jurorNumber, String poolNumber);
 

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/AppearanceRepository.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/AppearanceRepository.java
@@ -20,8 +20,6 @@ public interface AppearanceRepository extends IAppearanceRepository, JpaReposito
 
     long countByJurorNumber(String jurorNumber);
 
-    Appearance findByJurorNumber(String jurorNumber);
-
     Optional<Appearance> findByJurorNumberAndAttendanceDate(String jurorNumber, LocalDate attendanceDate);
 
     List<Appearance> findAllByJurorNumberAndPoolNumber(String jurorNumber, String poolNumber);

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceImpl.java
@@ -128,19 +128,21 @@ public class JurorAppearanceServiceImpl implements JurorAppearanceService {
         final JurorPool jurorPool = validateJurorStatus(juror);
 
 
-        Appearance appearance = appearanceRepository.findByJurorNumberAndAttendanceDate(jurorNumber,
+        Optional<Appearance> appearanceOpt = appearanceRepository.findByJurorNumberAndAttendanceDate(jurorNumber,
             appearanceDate);
+        Appearance appearance;
 
-        if (appearance == null) {
+        if (appearanceOpt.isPresent()) {
+            appearance = appearanceOpt.get();
+            // validate the current record and the new appearance stage
+            validateAppearanceStage(jurorNumber, appearanceStage, appearance);
+        } else {
             appearance = Appearance.builder()
                 .jurorNumber(jurorNumber)
                 .attendanceDate(appearanceDate)
                 .courtLocation(courtLocation)
                 .poolNumber(jurorPool.getPool().getPoolNumber())
                 .build();
-        } else {
-            // validate the current record and the new appearance stage
-            validateAppearanceStage(jurorNumber, appearanceStage, appearance);
         }
 
         if (appearanceStage == AppearanceStage.CHECKED_IN || allowBothCheckInAndOut) {
@@ -478,22 +480,18 @@ public class JurorAppearanceServiceImpl implements JurorAppearanceService {
             // validate the juror record exists and user has ownership of the record
             validateJuror(owner, jurorNumber);
 
-            // get the juror appearance record if it exists
-            Appearance appearance = appearanceRepository.findByJurorNumberAndAttendanceDate(jurorNumber,
-                request.getCommonData().getAttendanceDate());
-
             JurorPool jurorPool = JurorPoolUtils.getActiveJurorPool(jurorPoolRepository, jurorNumber,
                 courtLocation);
 
-            if (appearance == null) {
-                // create a new appearance record
-                appearance = Appearance.builder()
+            // get the juror appearance record if it exists
+            Appearance appearance = appearanceRepository.findByJurorNumberAndAttendanceDate(jurorNumber,
+                request.getCommonData().getAttendanceDate())
+                .orElse(Appearance.builder()
                     .jurorNumber(jurorNumber)
                     .attendanceDate(request.getCommonData().getAttendanceDate())
                     .courtLocation(courtLocation)
                     .poolNumber(jurorPool.getPool().getPoolNumber())
-                    .build();
-            }
+                    .build());
 
             // update the check-in time if there is none
             if (appearance.getTimeIn() == null) {

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/trial/TrialServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/trial/TrialServiceImpl.java
@@ -179,7 +179,8 @@ public class TrialServiceImpl implements TrialService {
         jurorStatus.setStatus(IJurorStatus.RESPONDED);
         for (Panel panel : juryMembersToBeReturned) {
             final String jurorNumber = panel.getJurorPool().getJurorNumber();
-            Appearance appearance = appearanceRepository.findByJurorNumber(panel.getJurorPool().getJurorNumber());
+            Appearance appearance = RepositoryUtils.unboxOptionalRecord(
+                appearanceRepository.findByJurorNumberAndAttendanceDate(jurorNumber, LocalDate.now()), jurorNumber);
             // only apply check in time for those that have not been checked in yet
             if (appearance.getTimeIn() == null && StringUtils.isNotEmpty(returnJuryDto.getCheckIn())) {
                 appearance.setTimeIn(LocalTime.parse(returnJuryDto.getCheckIn()));

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceTest.java
@@ -550,7 +550,8 @@ class JurorAppearanceServiceTest {
         Appearance appearance = new Appearance();
         appearance.setJurorNumber(JUROR_123456789);
         appearance.setAppearanceStage(CHECKED_IN);
-        doReturn(appearance).when(appearanceRepository).findByJurorNumberAndAttendanceDate(JUROR_123456789, now());
+        doReturn(Optional.of(appearance)).when(appearanceRepository)
+            .findByJurorNumberAndAttendanceDate(JUROR_123456789, now());
 
         assertThatExceptionOfType(MojException.BadRequest.class).isThrownBy(() ->
                 jurorAppearanceService.processAppearance(buildPayload(OWNER_415, List.of(LOC_415)),
@@ -582,7 +583,8 @@ class JurorAppearanceServiceTest {
         Appearance appearance = new Appearance();
         appearance.setJurorNumber(JUROR_123456789);
         appearance.setAppearanceStage(CHECKED_OUT);
-        doReturn(appearance).when(appearanceRepository).findByJurorNumberAndAttendanceDate(JUROR_123456789, now());
+        doReturn(Optional.of(appearance)).when(appearanceRepository)
+            .findByJurorNumberAndAttendanceDate(JUROR_123456789, now());
 
         assertThatExceptionOfType(MojException.BadRequest.class).isThrownBy(() ->
                 jurorAppearanceService.processAppearance(buildPayload(OWNER_415, List.of(LOC_415)),
@@ -614,7 +616,8 @@ class JurorAppearanceServiceTest {
         Appearance appearance = new Appearance();
         appearance.setJurorNumber(JUROR_123456789);
         appearance.setAppearanceStage(EXPENSE_ENTERED);
-        doReturn(appearance).when(appearanceRepository).findByJurorNumberAndAttendanceDate(JUROR_123456789, now());
+        doReturn(Optional.of(appearance)).when(appearanceRepository)
+            .findByJurorNumberAndAttendanceDate(JUROR_123456789, now());
 
         assertThatExceptionOfType(MojException.BadRequest.class).isThrownBy(() ->
                 jurorAppearanceService.processAppearance(buildPayload(OWNER_415, List.of(LOC_415)),
@@ -643,13 +646,13 @@ class JurorAppearanceServiceTest {
         juror.setAssociatedPools(Collections.singleton(jurorPool));
         doReturn(Optional.of(juror)).when(jurorRepository).findById(JUROR_123456789);
         doReturn(Collections.singletonList(jurorPool)).when(jurorPoolRepository)
-            .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(
-                JUROR_123456789, true);
+            .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(JUROR_123456789, true);
         doReturn(Optional.of(courtLocation)).when(courtLocationRepository).findById(anyString());
         Appearance appearance = new Appearance();
         appearance.setJurorNumber(JUROR_123456789);
         appearance.setAppearanceStage(CHECKED_OUT);
-        doReturn(appearance).when(appearanceRepository).findByJurorNumberAndAttendanceDate(JUROR_123456789, now());
+        doReturn(Optional.of(appearance)).when(appearanceRepository)
+            .findByJurorNumberAndAttendanceDate(JUROR_123456789, now());
 
         assertThatExceptionOfType(MojException.BadRequest.class).isThrownBy(() ->
                 jurorAppearanceService.processAppearance(buildPayload(OWNER_415, List.of(LOC_415)),
@@ -684,7 +687,8 @@ class JurorAppearanceServiceTest {
         Appearance appearance = new Appearance();
         appearance.setJurorNumber(JUROR_123456789);
         appearance.setAppearanceStage(EXPENSE_ENTERED);
-        doReturn(appearance).when(appearanceRepository).findByJurorNumberAndAttendanceDate(JUROR_123456789, now());
+        doReturn(Optional.of(appearance)).when(appearanceRepository)
+            .findByJurorNumberAndAttendanceDate(JUROR_123456789, now());
 
         assertThatExceptionOfType(MojException.BadRequest.class).isThrownBy(() ->
                 jurorAppearanceService.processAppearance(buildPayload(OWNER_415, List.of(LOC_415)),

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceTest.java
@@ -2548,9 +2548,6 @@ class JurorAppearanceServiceTest {
         }
 
 
-
-
-
         @Test
         void negativeNonAttendanceForbiddenCourtUser() {
 
@@ -3024,9 +3021,9 @@ class JurorAppearanceServiceTest {
                 .build();
 
             when(appearanceRepository.findByJurorNumberAndAttendanceDate(JUROR1,
-                now().minusDays(1))).thenReturn(appearance1);
+                now().minusDays(1))).thenReturn(Optional.of(appearance1));
             when(appearanceRepository.findByJurorNumberAndAttendanceDate(JUROR2,
-                now().minusDays(1))).thenReturn(appearance2);
+                now().minusDays(1))).thenReturn(Optional.of(appearance2));
             when(appearanceRepository.getNextAttendanceAuditNumber()).thenReturn(123456L);
 
             jurorAppearanceService.confirmJuryAttendance(request);

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceTest.java
@@ -2874,7 +2874,7 @@ class JurorAppearanceServiceTest {
 
         @Test
         @DisplayName("Get Jurors On Trials happy path")
-        void getJurorsOnTrialHappy() {
+        void jurorsOnTrialHappy() {
 
 
             final String locationCode = "415";
@@ -2922,7 +2922,7 @@ class JurorAppearanceServiceTest {
 
         @Test
         @DisplayName("Get Jurors On Trials - wrong court")
-        void getJurorsOnTrialWrongCourt() {
+        void jurorsOnTrialWrongCourt() {
 
 
             final String locationCode = "416";
@@ -2947,7 +2947,7 @@ class JurorAppearanceServiceTest {
 
         @Test
         @DisplayName("Get Jurors On Trials No Records found")
-        void getJurorsOnTrialNoRecordsFound() {
+        void jurorsOnTrialNoRecordsFound() {
 
 
             final String locationCode = "415";
@@ -3046,7 +3046,7 @@ class JurorAppearanceServiceTest {
                 now().minusDays(1))).thenReturn(Optional.of(appearance1));
             when(appearanceRepository.findByJurorNumberAndAttendanceDate(JUROR2,
                 now().minusDays(1))).thenReturn(Optional.of(appearance2));
-            when(appearanceRepository.getNextAttendanceAuditNumber()).thenReturn(10123456L);
+            when(appearanceRepository.getNextAttendanceAuditNumber()).thenReturn(10_123_456L);
 
             jurorAppearanceService.confirmJuryAttendance(request);
 
@@ -3072,9 +3072,9 @@ class JurorAppearanceServiceTest {
 
             Appearance capturedAppearance1 =
                 appearanceCaptor.getAllValues().stream()
-                    .filter(app -> app.getJurorNumber().equalsIgnoreCase(JUROR1))
+                    .filter(app -> JUROR1.equalsIgnoreCase(app.getJurorNumber()))
                     .findFirst().get();
-            assertThat(capturedAppearance1.getJurorNumber()).isEqualTo(JUROR1);
+            assertThat(JUROR1).isEqualTo(capturedAppearance1.getJurorNumber());
             assertThat(capturedAppearance1.getAttendanceDate()).isEqualTo(request.getCommonData().getAttendanceDate());
             assertThat(capturedAppearance1.getCourtLocation()).isEqualTo(courtLocation);
             assertThat(capturedAppearance1.getPoolNumber()).isEqualTo(jurorPool1.getPool().getPoolNumber());
@@ -3086,9 +3086,9 @@ class JurorAppearanceServiceTest {
 
             Appearance capturedAppearance2 =
                 appearanceCaptor.getAllValues().stream()
-                    .filter(app -> app.getJurorNumber().equalsIgnoreCase(JUROR2))
+                    .filter(app -> JUROR2.equalsIgnoreCase(app.getJurorNumber()))
                     .findFirst().get();
-            assertThat(capturedAppearance2.getJurorNumber()).isEqualTo(JUROR2);
+            assertThat(JUROR2).isEqualTo(capturedAppearance2.getJurorNumber());
             assertThat(capturedAppearance2.getAttendanceDate()).isEqualTo(request.getCommonData().getAttendanceDate());
             assertThat(capturedAppearance2.getCourtLocation()).isEqualTo(courtLocation);
             assertThat(capturedAppearance2.getPoolNumber()).isEqualTo(jurorPool1.getPool().getPoolNumber());

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/trial/PanelServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/trial/PanelServiceImplTest.java
@@ -547,7 +547,7 @@ class PanelServiceImplTest {
 
                 verify(trialRepository, times(2))
                     .findByTrialNumberAndCourtLocationLocCode("T100000025", "415");
-                verify(panelRepository, times(2))
+                verify(panelRepository, times(1))
                     .findByTrialTrialNumberAndTrialCourtLocationLocCode("T100000025", "415");
                 verify(appearanceRepository, never()).getJurorsInPools(locCode, new ArrayList<>());
                 verify(appearanceRepository, times(1)).retrieveAllJurors(locCode);
@@ -613,7 +613,7 @@ class PanelServiceImplTest {
 
                 verify(trialRepository, times(2))
                     .findByTrialNumberAndCourtLocationLocCode("T100000025", locCode);
-                verify(panelRepository, times(2))
+                verify(panelRepository, times(1))
                     .findByTrialTrialNumberAndTrialCourtLocationLocCode("T100000025", locCode);
                 verify(appearanceRepository, times(1)).getJurorsInPools(locCode,
                     Collections.singletonList("415231201"));
@@ -787,7 +787,7 @@ class PanelServiceImplTest {
 
                 verify(trialRepository, times(1))
                     .findByTrialNumberAndCourtLocationLocCode("T100000025", locCode);
-                verify(panelRepository, times(2))
+                verify(panelRepository, times(1))
                     .findByTrialTrialNumberAndTrialCourtLocationLocCode("T100000025", locCode);
                 verify(appearanceRepository, never())
                     .getJurorsInPools(locCode, Collections.singletonList(""));
@@ -860,7 +860,7 @@ class PanelServiceImplTest {
 
                 verify(trialRepository, times(1))
                     .findByTrialNumberAndCourtLocationLocCode("T100000025", locCode);
-                verify(panelRepository, times(2))
+                verify(panelRepository, times(1))
                     .findByTrialTrialNumberAndTrialCourtLocationLocCode("T100000025", locCode);
                 verify(appearanceRepository, times(1))
                     .getJurorsInPools(locCode, Collections.singletonList("1"));

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/trial/PanelServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/trial/PanelServiceImplTest.java
@@ -133,11 +133,11 @@ class PanelServiceImplTest {
         doReturn(createJurorPool(jurorNumbers, poolNumbers.get(0))).when(appearanceRepository)
             .getJurorsInPools(locCode, poolNumbers);
         doReturn(Optional.of(createAppearance("121212121"))).when(appearanceRepository)
-            .findByJurorNumberAndAttendanceDate("121212121", LocalDate.now());
+            .findByJurorNumberAndAttendanceDate("121212121", now());
         doReturn(Optional.of(createAppearance("121212121"))).when(appearanceRepository)
-            .findByJurorNumberAndAttendanceDate("121212121", LocalDate.now());
+            .findByJurorNumberAndAttendanceDate("121212121", now());
         doReturn(Optional.of(createAppearance("111111111"))).when(appearanceRepository)
-            .findByJurorNumberAndAttendanceDate("111111111", LocalDate.now());
+            .findByJurorNumberAndAttendanceDate("111111111", now());
 
         List<PanelListDto> dtoList = panelService.createPanel(2,
             "T100000025",
@@ -170,9 +170,9 @@ class PanelServiceImplTest {
 
         doReturn(createJurorPool(jurorNumbers, "415231201")).when(appearanceRepository).retrieveAllJurors(locCode);
         doReturn(Optional.of(createAppearance("111111111"))).when(appearanceRepository)
-            .findByJurorNumberAndAttendanceDate("111111111", LocalDate.now());
+            .findByJurorNumberAndAttendanceDate("111111111", now());
         doReturn(Optional.of(createAppearance("121212121"))).when(appearanceRepository)
-            .findByJurorNumberAndAttendanceDate("121212121", LocalDate.now());
+            .findByJurorNumberAndAttendanceDate("121212121", now());
 
         List<PanelListDto> dtoList = panelService.createPanel(2,
             "T100000025",
@@ -206,9 +206,9 @@ class PanelServiceImplTest {
         doReturn(createJurorPool(jurorNumbers, "415231201")).when(appearanceRepository)
             .retrieveAllJurors(locCode);
         doReturn(Optional.of(createAppearance("121212121"))).when(appearanceRepository)
-            .findByJurorNumberAndAttendanceDate("121212121", LocalDate.now());
+            .findByJurorNumberAndAttendanceDate("121212121", now());
         doReturn(Optional.of(createAppearance("111111111"))).when(appearanceRepository)
-            .findByJurorNumberAndAttendanceDate("111111111", LocalDate.now());
+            .findByJurorNumberAndAttendanceDate("111111111", now());
 
         ArrayList<String> poolNumbers = new ArrayList<>();
         List<PanelListDto> dtoList = panelService.createPanel(2,
@@ -392,7 +392,7 @@ class PanelServiceImplTest {
                 member.getJurorPool().getJurorNumber());
             doReturn(Optional.of(createAppearance(member.getJurorPool().getJurorNumber())))
                 .when(appearanceRepository).findByJurorNumberAndAttendanceDate(member.getJurorPool().getJurorNumber(),
-                    LocalDate.now());
+                    now());
             if (member.getResult() != PanelResult.JUROR) {
                 totalUnusedJurors++;
             }
@@ -536,7 +536,7 @@ class PanelServiceImplTest {
                     String jurorNumber = jurorNumbers.get(i);
                     Appearance appearance = createAppearance(jurorNumber);
                     doReturn(Optional.of(appearance)).when(appearanceRepository)
-                        .findByJurorNumberAndAttendanceDate(jurorNumber, LocalDate.now());
+                        .findByJurorNumberAndAttendanceDate(jurorNumber, now());
                     appearanceList.add(appearance);
                 }
 
@@ -602,7 +602,7 @@ class PanelServiceImplTest {
                     String jurorNumber = jurorNumbers.get(i);
                     Appearance appearance = createAppearance(jurorNumber);
                     doReturn(Optional.of(appearance)).when(appearanceRepository)
-                        .findByJurorNumberAndAttendanceDate(jurorNumber, LocalDate.now());
+                        .findByJurorNumberAndAttendanceDate(jurorNumber, now());
                     appearanceList.add(appearance);
                 }
 
@@ -845,7 +845,7 @@ class PanelServiceImplTest {
                 doReturn(createJurorPool(Collections.singletonList("111111111"), "415231201")).when(
                     appearanceRepository).retrieveAllJurors(locCode);
                 doReturn(Optional.of(createAppearance("111111111"))).when(appearanceRepository)
-                    .findByJurorNumberAndAttendanceDate("111111111", LocalDate.now());
+                    .findByJurorNumberAndAttendanceDate("111111111", now());
 
                 MojException.BusinessRuleViolation exception = assertThrows(MojException.BusinessRuleViolation.class,
                     () -> {
@@ -959,6 +959,7 @@ class PanelServiceImplTest {
         return listDto;
     }
 
+    @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
     private List<JurorPool> createJurorPool(List<String> jurorNumbers, String poolNumber) {
         PoolRequest poolRequest = new PoolRequest();
         poolRequest.setPoolNumber(poolNumber);

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/trial/PanelServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/trial/PanelServiceImplTest.java
@@ -132,8 +132,12 @@ class PanelServiceImplTest {
 
         doReturn(createJurorPool(jurorNumbers, poolNumbers.get(0))).when(appearanceRepository)
             .getJurorsInPools(locCode, poolNumbers);
-        doReturn(createAppearance("121212121")).when(appearanceRepository).findByJurorNumber("121212121");
-        doReturn(createAppearance("111111111")).when(appearanceRepository).findByJurorNumber("111111111");
+        doReturn(Optional.of(createAppearance("121212121"))).when(appearanceRepository)
+            .findByJurorNumberAndAttendanceDate("121212121", LocalDate.now());
+        doReturn(Optional.of(createAppearance("121212121"))).when(appearanceRepository)
+            .findByJurorNumberAndAttendanceDate("121212121", LocalDate.now());
+        doReturn(Optional.of(createAppearance("111111111"))).when(appearanceRepository)
+            .findByJurorNumberAndAttendanceDate("111111111", LocalDate.now());
 
         List<PanelListDto> dtoList = panelService.createPanel(2,
             "T100000025",
@@ -165,8 +169,10 @@ class PanelServiceImplTest {
         jurorNumbers.add("111111111");
 
         doReturn(createJurorPool(jurorNumbers, "415231201")).when(appearanceRepository).retrieveAllJurors(locCode);
-        doReturn(createAppearance("111111111")).when(appearanceRepository).findByJurorNumber("111111111");
-        doReturn(createAppearance("121212121")).when(appearanceRepository).findByJurorNumber("121212121");
+        doReturn(Optional.of(createAppearance("111111111"))).when(appearanceRepository)
+            .findByJurorNumberAndAttendanceDate("111111111", LocalDate.now());
+        doReturn(Optional.of(createAppearance("121212121"))).when(appearanceRepository)
+            .findByJurorNumberAndAttendanceDate("121212121", LocalDate.now());
 
         List<PanelListDto> dtoList = panelService.createPanel(2,
             "T100000025",
@@ -199,8 +205,10 @@ class PanelServiceImplTest {
 
         doReturn(createJurorPool(jurorNumbers, "415231201")).when(appearanceRepository)
             .retrieveAllJurors(locCode);
-        doReturn(createAppearance("121212121")).when(appearanceRepository).findByJurorNumber("121212121");
-        doReturn(createAppearance("111111111")).when(appearanceRepository).findByJurorNumber("111111111");
+        doReturn(Optional.of(createAppearance("121212121"))).when(appearanceRepository)
+            .findByJurorNumberAndAttendanceDate("121212121", LocalDate.now());
+        doReturn(Optional.of(createAppearance("111111111"))).when(appearanceRepository)
+            .findByJurorNumberAndAttendanceDate("111111111", LocalDate.now());
 
         ArrayList<String> poolNumbers = new ArrayList<>();
         List<PanelListDto> dtoList = panelService.createPanel(2,
@@ -382,8 +390,9 @@ class PanelServiceImplTest {
             doReturn(member).when(panelRepository).findByTrialTrialNumberAndJurorPoolJurorJurorNumber(
                 "T100000025",
                 member.getJurorPool().getJurorNumber());
-            doReturn(createAppearance(member.getJurorPool().getJurorNumber()))
-                .when(appearanceRepository).findByJurorNumber(member.getJurorPool().getJurorNumber());
+            doReturn(Optional.of(createAppearance(member.getJurorPool().getJurorNumber())))
+                .when(appearanceRepository).findByJurorNumberAndAttendanceDate(member.getJurorPool().getJurorNumber(),
+                    LocalDate.now());
             if (member.getResult() != PanelResult.JUROR) {
                 totalUnusedJurors++;
             }
@@ -400,7 +409,6 @@ class PanelServiceImplTest {
         verify(appearanceRepository, times(totalUnusedJurors)).saveAndFlush(any());
         verify(panelRepository, times(totalPanelMembers)).saveAndFlush(any());
         verify(jurorHistoryRepository, times(totalPanelMembers)).save(any());
-
     }
 
     @Test
@@ -527,7 +535,8 @@ class PanelServiceImplTest {
                 for (int i = 0; i < maxJurors; i++) {
                     String jurorNumber = jurorNumbers.get(i);
                     Appearance appearance = createAppearance(jurorNumber);
-                    doReturn(appearance).when(appearanceRepository).findByJurorNumber(jurorNumber);
+                    doReturn(Optional.of(appearance)).when(appearanceRepository)
+                        .findByJurorNumberAndAttendanceDate(jurorNumber, LocalDate.now());
                     appearanceList.add(appearance);
                 }
 
@@ -592,7 +601,8 @@ class PanelServiceImplTest {
                      i++) {
                     String jurorNumber = jurorNumbers.get(i);
                     Appearance appearance = createAppearance(jurorNumber);
-                    doReturn(appearance).when(appearanceRepository).findByJurorNumber(jurorNumber);
+                    doReturn(Optional.of(appearance)).when(appearanceRepository)
+                        .findByJurorNumberAndAttendanceDate(jurorNumber, LocalDate.now());
                     appearanceList.add(appearance);
                 }
 
@@ -834,7 +844,8 @@ class PanelServiceImplTest {
                     .findByTrialTrialNumberAndTrialCourtLocationLocCode(anyString(), anyString());
                 doReturn(createJurorPool(Collections.singletonList("111111111"), "415231201")).when(
                     appearanceRepository).retrieveAllJurors(locCode);
-                doReturn(createAppearance("111111111")).when(appearanceRepository).findByJurorNumber("111111111");
+                doReturn(Optional.of(createAppearance("111111111"))).when(appearanceRepository)
+                    .findByJurorNumberAndAttendanceDate("111111111", LocalDate.now());
 
                 MojException.BusinessRuleViolation exception = assertThrows(MojException.BusinessRuleViolation.class,
                     () -> {

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/trial/TrialServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/trial/TrialServiceImplTest.java
@@ -43,6 +43,7 @@ import uk.gov.hmcts.juror.api.moj.repository.trial.PanelRepository;
 import uk.gov.hmcts.juror.api.moj.repository.trial.TrialRepository;
 import uk.gov.hmcts.juror.api.moj.service.CompleteServiceServiceImpl;
 
+import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -301,8 +302,8 @@ class TrialServiceImplTest {
                 appearance.setTimeOut(LocalTime.parse(checkInTime));
             }
 
-            when(appearanceRepository.findByJurorNumber(panel.getJurorPool().getJurorNumber()))
-                .thenReturn(appearance);
+            when(appearanceRepository.findByJurorNumberAndAttendanceDate(panel.getJurorPool().getJurorNumber(),
+                LocalDate.now())).thenReturn(Optional.of(appearance));
         }
 
         trialService.returnJury(payload, trialNumber, "415",
@@ -329,8 +330,8 @@ class TrialServiceImplTest {
         for (Panel panel : panelMembers) {
             Appearance appearance = createAppearance(panel.getJurorPool().getJurorNumber());
             appearance.setTimeIn(null);
-            when(appearanceRepository.findByJurorNumber(panel.getJurorPool().getJurorNumber()))
-                .thenReturn(appearance);
+            when(appearanceRepository.findByJurorNumberAndAttendanceDate(panel.getJurorPool().getJurorNumber(),
+                LocalDate.now())).thenReturn(Optional.of(appearance));
         }
 
         trialService
@@ -356,8 +357,8 @@ class TrialServiceImplTest {
         for (Panel panel : panelMembers) {
             Appearance appearance = createAppearance(panel.getJurorPool().getJurorNumber());
             appearance.setTimeIn(null);
-            when(appearanceRepository.findByJurorNumber(panel.getJurorPool().getJurorNumber()))
-                .thenReturn(appearance);
+            when(appearanceRepository.findByJurorNumberAndAttendanceDate(panel.getJurorPool().getJurorNumber(),
+                LocalDate.now())).thenReturn(Optional.of(appearance));
         }
 
         trialService
@@ -382,8 +383,8 @@ class TrialServiceImplTest {
 
         for (Panel panel : panelMembers) {
             Appearance appearance = createAppearance(panel.getJurorPool().getJurorNumber());
-            when(appearanceRepository.findByJurorNumber(panel.getJurorPool().getJurorNumber()))
-                .thenReturn(appearance);
+            when(appearanceRepository.findByJurorNumberAndAttendanceDate(panel.getJurorPool().getJurorNumber(),
+                LocalDate.now())).thenReturn(Optional.of(appearance));
         }
 
         trialService.returnJury(payload, trialNumber, "415",


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://centralgovernmentcgi.atlassian.net/browse/JM-6951


### Change description ###
- remove findByJurorNumber() JPA method from Appearance Repository
- update code to use findByJurorNumberAndAttendanceDate() instead
- refactor AppearanceRepository to make findByJurorNumberAndAttendanceDate() return an Optional object (to avoid null pointer exceptions)
- refactor/optimise logic so Panel repository query is only invoked once instead of twice for the "adding panel members" user journey
- update tests


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
