### PR TITLE
Bug (JM-6975) fix superurgent nulls breaking response report listing

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/juror/domain/JurorResponseQueries.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/juror/domain/JurorResponseQueries.java
@@ -97,7 +97,7 @@ public class JurorResponseQueries {
      */
 
     private static BooleanExpression backlogUrgent() {
-        return jurorResponse.urgent.isTrue().and(jurorResponse.superUrgent.isFalse());
+        return jurorResponse.urgent.isTrue().and(jurorResponse.superUrgent.isNull());
     }
 
 

--- a/src/main/java/uk/gov/hmcts/juror/api/juror/domain/JurorResponseQueries.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/juror/domain/JurorResponseQueries.java
@@ -97,7 +97,8 @@ public class JurorResponseQueries {
      */
 
     private static BooleanExpression backlogUrgent() {
-        return jurorResponse.urgent.isTrue().and(jurorResponse.superUrgent.isNull());
+        return jurorResponse.urgent.isTrue().and(jurorResponse.superUrgent.isNull()
+                                                     .or(jurorResponse.superUrgent.isFalse()));
     }
 
 

--- a/src/main/java/uk/gov/hmcts/juror/api/juror/domain/JurorResponseQueries.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/juror/domain/JurorResponseQueries.java
@@ -28,7 +28,7 @@ public class JurorResponseQueries {
      * @return QueryDSL filter
      */
     public static BooleanExpression backlog() {
-        return jurorResponse.urgent.isFalse().and(jurorResponse.superUrgent.isFalse())
+        return nonUrgent()
             .and(jurorResponse.processingStatus.eq(
                 ProcessingStatus.TODO)).and(jurorResponse.staff.isNull());
     }
@@ -48,6 +48,10 @@ public class JurorResponseQueries {
 
     private static BooleanExpression urgent() {
         return jurorResponse.urgent.isTrue().or(jurorResponse.superUrgent.isTrue());
+    }
+
+    private static BooleanExpression nonUrgent() {
+        return jurorResponse.urgent.isTrue().not().and(jurorResponse.superUrgent.isTrue().not());
     }
 
 
@@ -87,7 +91,7 @@ public class JurorResponseQueries {
         } else {
             return byMemberOfStaffAssigned(staffLogin)
                 .and(byStatus(statuses))
-                .and(urgent().not());
+                .and(nonUrgent());
         }
     }
 
@@ -97,8 +101,7 @@ public class JurorResponseQueries {
      */
 
     private static BooleanExpression backlogUrgent() {
-        return jurorResponse.urgent.isTrue().and(jurorResponse.superUrgent.isNull()
-                                                     .or(jurorResponse.superUrgent.isFalse()));
+        return jurorResponse.urgent.isTrue().and(jurorResponse.superUrgent.isTrue().not());
     }
 
 
@@ -107,7 +110,7 @@ public class JurorResponseQueries {
      * @returns a response - Super Urgent
      */
     private static BooleanExpression backlogSuperUrgent() {
-        return jurorResponse.superUrgent.isTrue().and(jurorResponse.urgent.isFalse());
+        return jurorResponse.superUrgent.isTrue().and(jurorResponse.urgent.isTrue().not());
     }
 
     /**
@@ -148,7 +151,7 @@ public class JurorResponseQueries {
     public static BooleanExpression byAssignedNonUrgent(User staffMember) {
         return jurorResponse.staff.isNotNull()
             .and(notClosed())
-            .and(backlogUrgent().not()).and(backlogSuperUrgent().not())
+            .and(nonUrgent())
             .and(assignedTo(staffMember));
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://centralgovernmentcgi.atlassian.net/browse/JM-6975

### Change description ###

This page was checking `superurgent == false` for several checks, which since superurgent got removed and is now always null was failing all the time.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
