### PR TITLE
hotfix/JM-7016: Confirm attendance for Panelled jurors

### DIFF
--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorManagementControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorManagementControllerITest.java
@@ -447,7 +447,7 @@ class JurorManagementControllerITest extends AbstractIntegrationTest {
             assertThat(summary)
                 .as("Expect 2 jurors to be checked in")
                 .extracting(AttendanceDetailsResponse.Summary::getCheckedIn)
-                .isEqualTo(2L);
+                .isEqualTo(3L);
 
             assertThat(summary)
                 .as("Expect 2 jurors to be absent")
@@ -917,7 +917,7 @@ class JurorManagementControllerITest extends AbstractIntegrationTest {
             AttendanceDetailsResponse.Summary summary = response.getBody().getSummary();
             assertThat(summary)
                 .extracting(AttendanceDetailsResponse.Summary::getCheckedIn)
-                .isEqualTo(3L);
+                .isEqualTo(4L);
 
             assertThat(summary)
                 .extracting(AttendanceDetailsResponse.Summary::getAbsent)

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/IAppearanceRepositoryImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/IAppearanceRepositoryImpl.java
@@ -116,7 +116,7 @@ public class IAppearanceRepositoryImpl implements IAppearanceRepository {
 
     private List<Integer> sqlFilterQueryJurorStatus(@NotNull RetrieveAttendanceDetailsTag tag) {
         if (tag.equals(RetrieveAttendanceDetailsTag.CONFIRM_ATTENDANCE)) {
-            return List.of(IJurorStatus.RESPONDED);
+            return List.of(IJurorStatus.RESPONDED, IJurorStatus.PANEL);
         } else if (tag.equals(RetrieveAttendanceDetailsTag.PANELLED)) {
             return List.of(IJurorStatus.PANEL);
         } else {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://centralgovernmentcgi.atlassian.net/browse/JM-7016

### Change description ###
- include juror status of panel when confirming attendance - jurors on a panel are not yet on a jury/trial so cannot be confirmed by jury attendance and therefore need to be confirmed as jurors in waiting
- update tests

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
