### PR TITLE
Chore (JM-7046) add check exception for validating postponement from deferral maintenance

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/request/JurorManagementRequestDto.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/request/JurorManagementRequestDto.java
@@ -2,14 +2,11 @@ package uk.gov.hmcts.juror.api.moj.controller.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.hibernate.validator.constraints.Length;
 import uk.gov.hmcts.juror.api.validation.NumericString;
 
 import java.time.LocalDate;
@@ -69,7 +66,7 @@ public class JurorManagementRequestDto {
     @NumericString
     private String sendingCourtLocCode;
 
-    @JsonProperty("deferralMaintenance")
+    @JsonProperty("deferral_maintenance")
     @Schema(description = "Deferral is occurring from deferral maintenance")
     public Boolean deferralMaintenance;
 

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/request/JurorManagementRequestDto.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/request/JurorManagementRequestDto.java
@@ -2,11 +2,14 @@ package uk.gov.hmcts.juror.api.moj.controller.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.validator.constraints.Length;
 import uk.gov.hmcts.juror.api.validation.NumericString;
 
 import java.time.LocalDate;
@@ -65,6 +68,10 @@ public class JurorManagementRequestDto {
     @Size(min = 3, max = 3)
     @NumericString
     private String sendingCourtLocCode;
+
+    @JsonProperty("deferralMaintenance")
+    @Schema(description = "Deferral is occurring from deferral maintenance")
+    public Boolean deferralMaintenance;
 
     //constructor to handle transfer jurors requests
     public JurorManagementRequestDto(String sourcePoolNumber, String sendingCourtLocCode, String receivingCourtLocCode,

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/poolmanagement/JurorManagementServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/poolmanagement/JurorManagementServiceImpl.java
@@ -422,7 +422,8 @@ public class JurorManagementServiceImpl implements JurorManagementService {
 
         sourceJurorPools.forEach(jurorPool -> {
             // status validation (acceptable status values are 1 (summoned) or 2 (responded)
-            if (jurorPool.getStatus().getStatus() > 2) {
+            if (jurorPool.getStatus().getStatus() > 2 && !(jurorPool.getStatus().getStatus() == 7
+                && requestDto.getDeferralMaintenance() != null && requestDto.getDeferralMaintenance().equals(true))) {
                 failedTransfers.put(jurorPool.getJurorNumber(),
                     new Triple<>(String.format(JurorManagementConstants.INVALID_STATUS_MESSAGE, jurorPool.getStatus()
                         .getStatusDesc()), jurorPool.getJuror().getFirstName(), jurorPool.getJuror().getLastName()));


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://centralgovernmentcgi.atlassian.net/browse/JM-7046

### Change description ###

Currently, the validate movement API doesn't allow postponement for jurors who are deferred. In this case, we need to postpone from deferral maintenance, where everyone is deferred, so add a flag to skip this check.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
