### PR TITLE
Reassigning a juror to new pool clears attendance records.

### DIFF
--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorRecordControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorRecordControllerITest.java
@@ -3355,7 +3355,7 @@ class JurorRecordControllerITest extends AbstractIntegrationTest {
         void getJurorAttendanceHappy() {
             ResponseEntity<JurorAttendanceDetailsResponseDto> response =
                 restTemplate.exchange(new RequestEntity<Void>(httpHeaders, HttpMethod.GET,
-                        URI.create("/api/v1/moj/juror-record/attendance-detail/111111111/415230101")),
+                        URI.create("/api/v1/moj/juror-record/attendance-detail/415/111111111")),
                     JurorAttendanceDetailsResponseDto.class);
 
             assertThat(response.getStatusCode())
@@ -3425,7 +3425,7 @@ class JurorRecordControllerITest extends AbstractIntegrationTest {
         void getJurorAttendanceOnCall() {
             ResponseEntity<JurorAttendanceDetailsResponseDto> response =
                 restTemplate.exchange(new RequestEntity<Void>(httpHeaders, HttpMethod.GET,
-                        URI.create("/api/v1/moj/juror-record/attendance-detail/222222222/415230101")),
+                        URI.create("/api/v1/moj/juror-record/attendance-detail/415/222222222")),
                     JurorAttendanceDetailsResponseDto.class);
 
             assertThat(response.getStatusCode())

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/JurorRecordController.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/JurorRecordController.java
@@ -62,8 +62,8 @@ import uk.gov.hmcts.juror.api.moj.exception.MojException;
 import uk.gov.hmcts.juror.api.moj.service.BulkService;
 import uk.gov.hmcts.juror.api.moj.service.JurorRecordService;
 import uk.gov.hmcts.juror.api.moj.utils.SecurityUtil;
+import uk.gov.hmcts.juror.api.validation.CourtLocationCode;
 import uk.gov.hmcts.juror.api.validation.JurorNumber;
-import uk.gov.hmcts.juror.api.validation.PoolNumber;
 
 import java.util.List;
 
@@ -414,22 +414,21 @@ public class JurorRecordController {
     }
 
     /**
-     * Get the Attendance details for a given Juror in a pool.
+     * Get the Attendance details for a given Juror in a given court.
      *
      * @param jurorNumber Unique Juror number of the juror
-     * @param poolNumber  a complete (min 9 digit) pool number that identifies a unique pool entry
+     * @param locCode  a court location code to retrieve attendance details for
      * @return Fully populated DTO of a juror's attendance details in a pool
      */
-    @GetMapping(path = "/attendance-detail/{jurorNumber}/{poolNumber}")
+    @GetMapping(path = "/attendance-detail/{locCode}/{jurorNumber}")
     @Operation(summary = "Get attendance details for juror number in a pool")
     public ResponseEntity<JurorAttendanceDetailsResponseDto> getJurorAttendanceDetails(
         @Parameter(hidden = true) @AuthenticationPrincipal BureauJwtPayload payload,
         @PathVariable("jurorNumber") @Valid @JurorNumber
         @Parameter(description = "Valid juror number", required = true) String jurorNumber,
-        @Valid @PathVariable("poolNumber") @PoolNumber
-        @Parameter(description = "Valid pool number", required = true) String poolNumber) {
+        @Valid @PathVariable("locCode") @CourtLocationCode String locCode) {
         final JurorAttendanceDetailsResponseDto details =
-            jurorRecordService.getJurorAttendanceDetails(jurorNumber, poolNumber, payload);
+            jurorRecordService.getJurorAttendanceDetails(locCode, jurorNumber, payload);
 
         return ResponseEntity.ok().body(details);
     }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/AppearanceRepository.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/AppearanceRepository.java
@@ -24,6 +24,8 @@ public interface AppearanceRepository extends IAppearanceRepository, JpaReposito
 
     List<Appearance> findAllByJurorNumberAndPoolNumber(String jurorNumber, String poolNumber);
 
+    List<Appearance> findAllByCourtLocationLocCodeAndJurorNumber(String locCode, String jurorNumber);
+
     @SuppressWarnings("checkstyle:LineLength")
     List<Appearance> findAllByJurorNumberAndAppearanceStageInAndCourtLocationOwnerAndIsDraftExpenseTrueOrderByAttendanceDateDesc(
         String jurorNumber,

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/JurorPoolRepository.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/JurorPoolRepository.java
@@ -37,6 +37,8 @@ public interface JurorPoolRepository extends IJurorPoolRepository, JpaRepository
 
     JurorPool findByJurorJurorNumberAndPoolPoolNumber(String jurorNumber, String poolNumber);
 
+    JurorPool findByPoolCourtLocationLocCodeAndJurorJurorNumberAndIsActiveTrue(String locCode, String jurorNumber);
+
     JurorPool findByJurorJurorNumberAndStatusAndIsActive(String jurorNumber, JurorStatus status, boolean isActive);
 
     JurorPool findByJurorJurorNumberAndPoolPoolNumberAndStatus(String jurorNumber, String poolNumber,

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/JurorRecordService.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/JurorRecordService.java
@@ -77,8 +77,9 @@ public interface JurorRecordService {
 
     void undoUpdateJurorToFailedToAttend(String jurorNumber, String poolNumber);
 
-    JurorAttendanceDetailsResponseDto getJurorAttendanceDetails(String jurorNumber,
-                                                                String poolNumber, BureauJwtPayload payload);
+    JurorAttendanceDetailsResponseDto getJurorAttendanceDetails(String locCode,
+                                                                String jurorNumber,
+                                                                BureauJwtPayload payload);
 
     PendingJurorsResponseDto getPendingJurors(String locCode, PendingJurorStatus status);
 

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/JurorRecordServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/JurorRecordServiceTest.java
@@ -971,7 +971,7 @@ class JurorRecordServiceTest {
         jurorPools.add(createValidJurorPool(VALID_JUROR_NUMBER, COURT_OWNER));
 
         ContactCode contactEnquiryType = new ContactCode(IContactCode.GENERAL.getCode(),
-                                                         IContactCode.GENERAL.getDescription());
+            IContactCode.GENERAL.getDescription());
         ContactLogRequestDto requestDto = createContactLogRequestDto(VALID_JUROR_NUMBER, IContactCode.GENERAL);
         LocalDateTime startCall = LocalDateTime.now();
         requestDto.setStartCall(startCall);
@@ -3104,8 +3104,9 @@ class JurorRecordServiceTest {
             final JurorPool jurorPool = createValidJurorPool(TestConstants.VALID_POOL_NUMBER, owner);
 
             doReturn(jurorPool).when(jurorPoolRepository)
-                .findByJurorJurorNumberAndPoolPoolNumber(TestConstants.VALID_JUROR_NUMBER,
-                    TestConstants.VALID_POOL_NUMBER);
+                .findByPoolCourtLocationLocCodeAndJurorJurorNumberAndIsActiveTrue(
+                    TestConstants.VALID_COURT_LOCATION,
+                    TestConstants.VALID_JUROR_NUMBER);
 
             List<Appearance> appearances = new ArrayList<>();
             Appearance appearance =
@@ -3121,21 +3122,22 @@ class JurorRecordServiceTest {
                     .build();
             appearances.add(appearance);
 
-            doReturn(appearances).when(appearanceRepository).findAllByJurorNumberAndPoolNumber(
-                TestConstants.VALID_JUROR_NUMBER, TestConstants.VALID_POOL_NUMBER);
+            doReturn(appearances).when(appearanceRepository).findAllByCourtLocationLocCodeAndJurorNumber(
+                TestConstants.VALID_COURT_LOCATION, TestConstants.VALID_JUROR_NUMBER);
 
             JurorAttendanceDetailsResponseDto jurorAttendanceDetailsResponseDto =
-                jurorRecordService.getJurorAttendanceDetails(TestConstants.VALID_JUROR_NUMBER,
-                    TestConstants.VALID_POOL_NUMBER, buildPayload(owner));
+                jurorRecordService.getJurorAttendanceDetails(TestConstants.VALID_COURT_LOCATION,
+                    TestConstants.VALID_JUROR_NUMBER, buildPayload(owner));
 
             assertEquals(1, jurorAttendanceDetailsResponseDto.getData().size(),
                 "One attendance record should be returned");
 
-            verify(jurorPoolRepository, times(1)).findByJurorJurorNumberAndPoolPoolNumber(
-                TestConstants.VALID_JUROR_NUMBER, TestConstants.VALID_POOL_NUMBER);
+            verify(jurorPoolRepository, times(1)).findByPoolCourtLocationLocCodeAndJurorJurorNumberAndIsActiveTrue(
+                TestConstants.VALID_COURT_LOCATION, TestConstants.VALID_JUROR_NUMBER);
 
             verify(appearanceRepository, times(1))
-                .findAllByJurorNumberAndPoolNumber(TestConstants.VALID_JUROR_NUMBER, TestConstants.VALID_POOL_NUMBER);
+                .findAllByCourtLocationLocCodeAndJurorNumber(TestConstants.VALID_COURT_LOCATION,
+                    TestConstants.VALID_JUROR_NUMBER);
 
         }
 
@@ -3148,20 +3150,20 @@ class JurorRecordServiceTest {
             final JurorPool jurorPool = createValidJurorPool(TestConstants.VALID_POOL_NUMBER, owner);
 
             doReturn(jurorPool).when(jurorPoolRepository)
-                .findByJurorJurorNumberAndPoolPoolNumber(TestConstants.VALID_JUROR_NUMBER,
-                    TestConstants.VALID_POOL_NUMBER);
+                .findByPoolCourtLocationLocCodeAndJurorJurorNumberAndIsActiveTrue(
+                    TestConstants.VALID_COURT_LOCATION, TestConstants.VALID_JUROR_NUMBER);
 
             MojException.Forbidden exception =
                 assertThrows(MojException.Forbidden.class,
-                    () -> jurorRecordService.getJurorAttendanceDetails(TestConstants.VALID_JUROR_NUMBER,
-                        TestConstants.VALID_POOL_NUMBER, buildPayload(userOwner)), // a different owner to expected
+                    () -> jurorRecordService.getJurorAttendanceDetails(TestConstants.VALID_COURT_LOCATION,
+                        TestConstants.VALID_JUROR_NUMBER, buildPayload(userOwner)), // a different owner to expected
                     "Current user does not have sufficient permission to view the juror pool record(s)");
             assertEquals("Current user does not have sufficient permission to view the juror pool record(s)",
                 exception.getMessage(),
                 "Exception message must match");
 
-            verify(jurorPoolRepository, times(1)).findByJurorJurorNumberAndPoolPoolNumber(anyString(),
-                anyString());
+            verify(jurorPoolRepository, times(1))
+                .findByPoolCourtLocationLocCodeAndJurorJurorNumberAndIsActiveTrue(anyString(), anyString());
             verifyNoInteractions(appearanceRepository);
 
         }
@@ -3173,25 +3175,28 @@ class JurorRecordServiceTest {
             final JurorPool jurorPool = createValidJurorPool(TestConstants.VALID_POOL_NUMBER, owner);
 
             doReturn(jurorPool).when(jurorPoolRepository)
-                .findByJurorJurorNumberAndPoolPoolNumber(anyString(),
-                    anyString());
+                .findByPoolCourtLocationLocCodeAndJurorJurorNumberAndIsActiveTrue(
+                    anyString(), anyString());
 
             List<Appearance> appearances = new ArrayList<>();
 
-            doReturn(appearances).when(appearanceRepository).findAllByJurorNumberAndPoolNumber(
-                TestConstants.VALID_JUROR_NUMBER, TestConstants.VALID_POOL_NUMBER);
+            doReturn(appearances).when(appearanceRepository)
+                .findAllByCourtLocationLocCodeAndJurorNumber(
+                    TestConstants.VALID_COURT_LOCATION, TestConstants.VALID_JUROR_NUMBER);
 
             JurorAttendanceDetailsResponseDto jurorAttendanceDetailsResponseDto =
-                jurorRecordService.getJurorAttendanceDetails(TestConstants.VALID_JUROR_NUMBER,
-                    TestConstants.VALID_POOL_NUMBER, buildPayload(owner));
+                jurorRecordService.getJurorAttendanceDetails(TestConstants.VALID_COURT_LOCATION,
+                    TestConstants.VALID_JUROR_NUMBER, buildPayload(owner));
 
             assertEquals(0, jurorAttendanceDetailsResponseDto.getData().size(),
                 "No attendance records should be returned");
 
-            verify(jurorPoolRepository, times(1)).findByJurorJurorNumberAndPoolPoolNumber(anyString(),
+            verify(jurorPoolRepository, times(1)).findByPoolCourtLocationLocCodeAndJurorJurorNumberAndIsActiveTrue(
+                anyString(),
                 anyString());
             verify(appearanceRepository, times(1))
-                .findAllByJurorNumberAndPoolNumber(TestConstants.VALID_JUROR_NUMBER, TestConstants.VALID_POOL_NUMBER);
+                .findAllByCourtLocationLocCodeAndJurorNumber(TestConstants.VALID_COURT_LOCATION,
+                    TestConstants.VALID_JUROR_NUMBER);
         }
 
         @Test
@@ -3201,8 +3206,8 @@ class JurorRecordServiceTest {
             final JurorPool jurorPool = createValidJurorPool(TestConstants.VALID_POOL_NUMBER, owner);
 
             doReturn(jurorPool).when(jurorPoolRepository)
-                .findByJurorJurorNumberAndPoolPoolNumber(TestConstants.VALID_JUROR_NUMBER,
-                    TestConstants.VALID_POOL_NUMBER);
+                .findByPoolCourtLocationLocCodeAndJurorJurorNumberAndIsActiveTrue(TestConstants.VALID_COURT_LOCATION,
+                    TestConstants.VALID_JUROR_NUMBER);
 
             List<Appearance> appearances = new ArrayList<>();
             Appearance appearance1 = buildAppearance();
@@ -3216,21 +3221,22 @@ class JurorRecordServiceTest {
             appearance3.setAppearanceStage(AppearanceStage.CHECKED_OUT);
             appearances.add(appearance3);
 
-            doReturn(appearances).when(appearanceRepository).findAllByJurorNumberAndPoolNumber(
-                TestConstants.VALID_JUROR_NUMBER, TestConstants.VALID_POOL_NUMBER);
+            doReturn(appearances).when(appearanceRepository).findAllByCourtLocationLocCodeAndJurorNumber(
+                TestConstants.VALID_COURT_LOCATION, TestConstants.VALID_JUROR_NUMBER);
 
             JurorAttendanceDetailsResponseDto jurorAttendanceDetailsResponseDto =
-                jurorRecordService.getJurorAttendanceDetails(TestConstants.VALID_JUROR_NUMBER,
-                    TestConstants.VALID_POOL_NUMBER, buildPayload(owner));
+                jurorRecordService.getJurorAttendanceDetails(TestConstants.VALID_COURT_LOCATION,
+                    TestConstants.VALID_JUROR_NUMBER, buildPayload(owner));
 
             assertEquals(1, jurorAttendanceDetailsResponseDto.getData().size(),
                 "One attendance record should be returned");
 
-            verify(jurorPoolRepository, times(1)).findByJurorJurorNumberAndPoolPoolNumber(
-                TestConstants.VALID_JUROR_NUMBER, TestConstants.VALID_POOL_NUMBER);
+            verify(jurorPoolRepository, times(1)).findByPoolCourtLocationLocCodeAndJurorJurorNumberAndIsActiveTrue(
+                TestConstants.VALID_COURT_LOCATION, TestConstants.VALID_JUROR_NUMBER);
 
             verify(appearanceRepository, times(1))
-                .findAllByJurorNumberAndPoolNumber(TestConstants.VALID_JUROR_NUMBER, TestConstants.VALID_POOL_NUMBER);
+                .findAllByCourtLocationLocCodeAndJurorNumber(TestConstants.VALID_COURT_LOCATION,
+                    TestConstants.VALID_JUROR_NUMBER);
         }
 
         @Test
@@ -3240,8 +3246,8 @@ class JurorRecordServiceTest {
             final JurorPool jurorPool = createValidJurorPool(TestConstants.VALID_POOL_NUMBER, owner);
 
             doReturn(jurorPool).when(jurorPoolRepository)
-                .findByJurorJurorNumberAndPoolPoolNumber(TestConstants.VALID_JUROR_NUMBER,
-                    TestConstants.VALID_POOL_NUMBER);
+                .findByPoolCourtLocationLocCodeAndJurorJurorNumberAndIsActiveTrue(
+                    TestConstants.VALID_COURT_LOCATION, TestConstants.VALID_JUROR_NUMBER);
 
             List<Appearance> appearances = new ArrayList<>();
             Appearance appearance1 = buildAppearance();
@@ -3252,21 +3258,22 @@ class JurorRecordServiceTest {
             appearance2.setAttendanceType(AttendanceType.ABSENT);
             appearances.add(appearance2);
 
-            doReturn(appearances).when(appearanceRepository).findAllByJurorNumberAndPoolNumber(
-                TestConstants.VALID_JUROR_NUMBER, TestConstants.VALID_POOL_NUMBER);
+            doReturn(appearances).when(appearanceRepository).findAllByCourtLocationLocCodeAndJurorNumber(
+                TestConstants.VALID_COURT_LOCATION, TestConstants.VALID_JUROR_NUMBER);
 
             JurorAttendanceDetailsResponseDto jurorAttendanceDetailsResponseDto =
-                jurorRecordService.getJurorAttendanceDetails(TestConstants.VALID_JUROR_NUMBER,
-                    TestConstants.VALID_POOL_NUMBER, buildPayload(owner));
+                jurorRecordService.getJurorAttendanceDetails(TestConstants.VALID_COURT_LOCATION,
+                    TestConstants.VALID_JUROR_NUMBER, buildPayload(owner));
 
             assertEquals(2, jurorAttendanceDetailsResponseDto.getData().size(),
                 "Two attendance record should be returned");
 
-            verify(jurorPoolRepository, times(1)).findByJurorJurorNumberAndPoolPoolNumber(
-                TestConstants.VALID_JUROR_NUMBER, TestConstants.VALID_POOL_NUMBER);
+            verify(jurorPoolRepository, times(1)).findByPoolCourtLocationLocCodeAndJurorJurorNumberAndIsActiveTrue(
+                TestConstants.VALID_COURT_LOCATION, TestConstants.VALID_JUROR_NUMBER);
 
             verify(appearanceRepository, times(1))
-                .findAllByJurorNumberAndPoolNumber(TestConstants.VALID_JUROR_NUMBER, TestConstants.VALID_POOL_NUMBER);
+                .findAllByCourtLocationLocCodeAndJurorNumber(
+                    TestConstants.VALID_COURT_LOCATION, TestConstants.VALID_JUROR_NUMBER);
         }
 
         private Appearance buildAppearance() {


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7119)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ajuror-api&pullRequest=243)


### Change description ###
**Steps:**

Create attendance and expenses on juror record
Reassign to another pool

**Outcome:**

Attendance records are cleared

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
