### PR TITLE
Document name search only searches first name, not last name or full name

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/letter/court/CertificateOfAttendanceListRepositoryImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/letter/court/CertificateOfAttendanceListRepositoryImpl.java
@@ -46,8 +46,8 @@ public class CertificateOfAttendanceListRepositoryImpl implements ICertificateOf
         }
 
         if (!StringUtils.isEmpty(courtLetterSearchCriteria.jurorName())) {
-            jpaQuery.where(CERTIFICATE_OF_ATTENDANCE_LETTER_LIST.firstName.concat(
-                    " " + CERTIFICATE_OF_ATTENDANCE_LETTER_LIST.lastName)
+            jpaQuery.where(CERTIFICATE_OF_ATTENDANCE_LETTER_LIST.firstName.concat(" ")
+                .concat(CERTIFICATE_OF_ATTENDANCE_LETTER_LIST.lastName)
                 .containsIgnoreCase(courtLetterSearchCriteria.jurorName()));
         }
 


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7116)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ajuror-api&pullRequest=249)

### Change description ###

Fixed issue where last name concatenation was incorrect for name search

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
