### PR TITLE
UAT - when sorting by name in an active pool it kicks you back to pool requests

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/request/PoolMemberFilterRequestQuery.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/request/PoolMemberFilterRequestQuery.java
@@ -83,10 +83,10 @@ public class PoolMemberFilterRequestQuery implements IsPageable {
     @Getter
     public enum SortField implements SortMethod.HasComparableExpression {
         JUROR_NUMBER(QJurorPool.jurorPool.juror.jurorNumber),
-        FIRST_NAME(QJuror.juror.firstName),
-        LAST_NAME(QJuror.juror.lastName),
+        FIRST_NAME(QJurorPool.jurorPool.juror.firstName),
+        LAST_NAME(QJurorPool.jurorPool.juror.lastName),
         NEXT_DATE(QJurorPool.jurorPool.nextDate),
-        POSTCODE(QJuror.juror.postcode),
+        POSTCODE(QJurorPool.jurorPool.juror.postcode),
         ATTENDANCE(Expressions.stringPath("attendance")),
         CHECKED_IN(Expressions.booleanPath("checked_in_today")),
         STATUS(QJurorStatus.jurorStatus.statusDesc);

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/request/PoolMemberFilterRequestQuery.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/request/PoolMemberFilterRequestQuery.java
@@ -11,7 +11,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
 import org.hibernate.validator.constraints.Length;
-import uk.gov.hmcts.juror.api.moj.domain.QJuror;
 import uk.gov.hmcts.juror.api.moj.domain.QJurorPool;
 import uk.gov.hmcts.juror.api.moj.domain.QJurorStatus;
 import uk.gov.hmcts.juror.api.moj.domain.SortMethod;

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/ActivePoolsCourtRepositoryImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/ActivePoolsCourtRepositoryImpl.java
@@ -96,6 +96,8 @@ public class ActivePoolsCourtRepositoryImpl implements IActivePoolsCourtReposito
             case "courtNamedesc" -> activePoolsQuery.orderBy(COURT_LOCATION.name.desc());
             case "serviceStartDateasc" -> activePoolsQuery.orderBy(POOL_REQUEST.returnDate.asc());
             case "serviceStartDatedesc" -> activePoolsQuery.orderBy(POOL_REQUEST.returnDate.desc());
+            case "poolTypeasc" -> activePoolsQuery.orderBy(POOL_TYPE.description.asc());
+            case "poolTypedesc" -> activePoolsQuery.orderBy(POOL_TYPE.description.desc());
             default -> throw new IllegalArgumentException(
                 "Unable to run active pools at court query without a valid sort criteria");
         };

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/JurorPoolRepositoryImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/JurorPoolRepositoryImpl.java
@@ -274,10 +274,10 @@ public class JurorPoolRepositoryImpl implements IJurorPoolRepository {
             partialQuery.where(JUROR.jurorNumber.like(search.getJurorNumber() + "%"));
         }
         if (null != search.getFirstName()) {
-            partialQuery.where(JUROR.firstName.like(search.getFirstName().toUpperCase() + "%"));
+            partialQuery.where(JUROR.firstName.startsWithIgnoreCase(search.getFirstName()));
         }
         if (null != search.getLastName()) {
-            partialQuery.where(JUROR.lastName.like(search.getLastName().toUpperCase() + "%"));
+            partialQuery.where(JUROR.lastName.startsWithIgnoreCase(search.getLastName()));
         }
         if (null != search.getCheckedIn() && search.getCheckedIn()) {
             partialQuery.where(getCheckedInBoolean());

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/repository/JurorPoolRepositoryImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/repository/JurorPoolRepositoryImplTest.java
@@ -313,7 +313,7 @@ class JurorPoolRepositoryImplTest {
             Mockito.verify(jpaQuery, Mockito.times(4))
                 .where(Mockito.any(Predicate.class));
             Mockito.verify(jpaQuery, Mockito.times(1))
-                .where(JUROR.firstName.like("TEST%"));
+                .where(JUROR.firstName.startsWithIgnoreCase("Test"));
         }
 
         @Test
@@ -322,7 +322,7 @@ class JurorPoolRepositoryImplTest {
             Mockito.verify(jpaQuery, Mockito.times(4))
                 .where(Mockito.any(Predicate.class));
             Mockito.verify(jpaQuery, Mockito.times(1))
-                .where(JUROR.lastName.like("PERSON%"));
+                .where(JUROR.lastName.startsWithIgnoreCase("Person"));
         }
 
         @Test


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7132)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ajuror-api&pullRequest=256)


### Change description ###
When trying to filter on an active pool it kicks you out to pool requests 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
