### PR TITLE
Jurors who have been reassigned pools appear in export contact details search by old pool number

### DIFF
--- a/src/integration-test/resources/db/MessagingControllerITest_postSearchSetup.sql
+++ b/src/integration-test/resources/db/MessagingControllerITest_postSearchSetup.sql
@@ -123,7 +123,7 @@ values ('415', '1', 'large room fits 100 people'),
 
 insert into juror_mod.trial (trial_number, loc_code, description, judge, trial_type, trial_start_date, trial_end_date,
                              anonymous, courtroom)
-values ('T100000000', '415', 'TEST DEFENDANT', 22, 'CIV', current_date, current_date, false, 67),
+values ('T100000000', '415', 'TEST DEFENDANT', 22, 'CIV', current_date, null, false, 67),
        ('T100000001', '415', 'TEST DEFENDANT', 21, 'CIV', current_date, null, false, 66);
 
 INSERT INTO juror_mod.juror_trial

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/MessageTemplateRepositoryImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/MessageTemplateRepositoryImpl.java
@@ -81,15 +81,20 @@ public class MessageTemplateRepositoryImpl implements IMessageTemplateRepository
         JPAQuery<Tuple> query = queryFactory.select(returnFields.toArray(new Expression<?>[0]))
             .from(JUROR)
             .join(JUROR_POOL)
-            .on(JUROR.eq(JUROR_POOL.juror));
+            .on(JUROR.eq(JUROR_POOL.juror))
+            .where(JUROR_POOL.isActive.isTrue());
         if (isCourt || !locCode.equals("400")) {
             query.where(JUROR_POOL.pool.courtLocation.locCode.eq(locCode));
+            if (isCourt) {
+                query.where(JUROR_POOL.pool.owner.ne("400"));
+            }
         }
 
         if (search.getTrialNumber() != null || !simpleResponse) {
             query.leftJoin(PANEL).on(
                 JUROR.eq(PANEL.juror),
-                PANEL.result.in(PanelResult.JUROR),
+                PANEL.result.notIn(PanelResult.RETURNED, PanelResult.NOT_USED, PanelResult.CHALLENGED),
+                TRIAL.trialEndDate.isNull(),
                 TRIAL.courtLocation.locCode.eq(JUROR_POOL.pool.courtLocation.locCode),
                 JUROR_POOL.status.status.in(IJurorStatus.PANEL, IJurorStatus.JUROR)
             );

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/MessageTemplateRepositoryImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/MessageTemplateRepositoryImpl.java
@@ -92,11 +92,10 @@ public class MessageTemplateRepositoryImpl implements IMessageTemplateRepository
 
         if (search.getTrialNumber() != null || !simpleResponse) {
             query.leftJoin(PANEL).on(
-                JUROR.eq(PANEL.juror),
-                PANEL.result.notIn(PanelResult.RETURNED, PanelResult.NOT_USED, PanelResult.CHALLENGED),
-                TRIAL.trialEndDate.isNull(),
-                TRIAL.courtLocation.locCode.eq(JUROR_POOL.pool.courtLocation.locCode),
-                JUROR_POOL.status.status.in(IJurorStatus.PANEL, IJurorStatus.JUROR)
+                JUROR.eq(PANEL.juror)
+                    .and(PANEL.result.notIn(PanelResult.RETURNED, PanelResult.NOT_USED, PanelResult.CHALLENGED))
+                    .and(PANEL.trial.courtLocation.locCode.eq(JUROR_POOL.pool.courtLocation.locCode))
+                    .and(JUROR_POOL.status.status.in(IJurorStatus.PANEL, IJurorStatus.JUROR))
             );
         }
 

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/repository/MessageTemplateRepositoryImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/repository/MessageTemplateRepositoryImplTest.java
@@ -140,6 +140,7 @@ class MessageTemplateRepositoryImplTest {
             new OrderSpecifier<?>[]{SortMethod.ASC.from(MessageSearch.SortField.JUROR_NUMBER)});
         verify(jpaQuery, times(1)).fetchResults();
 
+        verify(jpaQuery, times(1)).where(JUROR_POOL.isActive.isTrue());
 
         verify(queryFactory, times(1))
             .select(
@@ -205,11 +206,12 @@ class MessageTemplateRepositoryImplTest {
 
         verify(jpaQuery, times(1)).leftJoin(PANEL);
         verify(jpaQuery, times(1)).on(
-            JUROR.eq(PANEL.juror),
-            PANEL.result.in(PanelResult.JUROR),
-            TRIAL.courtLocation.locCode.eq(JUROR_POOL.pool.courtLocation.locCode),
-            JUROR_POOL.status.status.in(IJurorStatus.PANEL, IJurorStatus.JUROR));
+            JUROR.eq(PANEL.juror)
+                .and(PANEL.result.notIn(PanelResult.RETURNED, PanelResult.NOT_USED, PanelResult.CHALLENGED))
+                .and(PANEL.trial.courtLocation.locCode.eq(JUROR_POOL.pool.courtLocation.locCode))
+                .and(JUROR_POOL.status.status.in(IJurorStatus.PANEL, IJurorStatus.JUROR)));
 
+        verify(jpaQuery, times(1)).where(JUROR_POOL.isActive.isTrue());
 
         verify(jpaQuery, times(1)).leftJoin(PANEL);
 
@@ -290,6 +292,9 @@ class MessageTemplateRepositoryImplTest {
         verify(jpaQuery, times(1)).on(JUROR.eq(JUROR_POOL.juror));
         verify(jpaQuery, times(1))
             .where(JUROR_POOL.pool.courtLocation.locCode.eq(TestConstants.VALID_COURT_LOCATION));
+        verify(jpaQuery, times(1)).where(JUROR_POOL.isActive.isTrue());
+        verify(jpaQuery, times(1))
+            .where(JUROR_POOL.pool.owner.ne("400"));
 
         verify(jpaQuery, times(1)).limit(4L);
         verify(jpaQuery, times(1)).offset(0L);
@@ -361,13 +366,16 @@ class MessageTemplateRepositoryImplTest {
         verify(jpaQuery, times(1)).on(JUROR.eq(JUROR_POOL.juror));
         verify(jpaQuery, times(1))
             .where(JUROR_POOL.pool.courtLocation.locCode.eq(TestConstants.VALID_COURT_LOCATION));
+        verify(jpaQuery, times(1)).where(JUROR_POOL.isActive.isTrue());
+        verify(jpaQuery, times(1))
+            .where(JUROR_POOL.pool.owner.ne("400"));
 
         verify(jpaQuery, times(1)).leftJoin(PANEL);
         verify(jpaQuery, times(1)).on(
-            JUROR.eq(PANEL.juror),
-            PANEL.result.in(PanelResult.JUROR),
-            TRIAL.courtLocation.locCode.eq(JUROR_POOL.pool.courtLocation.locCode),
-            JUROR_POOL.status.status.in(IJurorStatus.PANEL, IJurorStatus.JUROR));
+            JUROR.eq(PANEL.juror)
+                .and(PANEL.result.notIn(PanelResult.RETURNED, PanelResult.NOT_USED, PanelResult.CHALLENGED))
+                .and(PANEL.trial.courtLocation.locCode.eq(JUROR_POOL.pool.courtLocation.locCode))
+                .and(JUROR_POOL.status.status.in(IJurorStatus.PANEL, IJurorStatus.JUROR)));
 
 
         verify(jpaQuery, times(1)).leftJoin(PANEL);
@@ -453,13 +461,16 @@ class MessageTemplateRepositoryImplTest {
         verify(jpaQuery, times(1)).on(JUROR.eq(JUROR_POOL.juror));
         verify(jpaQuery, times(1))
             .where(JUROR_POOL.pool.courtLocation.locCode.eq(TestConstants.VALID_COURT_LOCATION));
+        verify(jpaQuery, times(1)).where(JUROR_POOL.isActive.isTrue());
+        verify(jpaQuery, times(1))
+            .where(JUROR_POOL.pool.owner.ne("400"));
 
         verify(jpaQuery, times(1)).leftJoin(PANEL);
         verify(jpaQuery, times(1)).on(
-            JUROR.eq(PANEL.juror),
-            PANEL.result.in(PanelResult.JUROR),
-            TRIAL.courtLocation.locCode.eq(JUROR_POOL.pool.courtLocation.locCode),
-            JUROR_POOL.status.status.in(IJurorStatus.PANEL, IJurorStatus.JUROR));
+            JUROR.eq(PANEL.juror)
+                .and(PANEL.result.notIn(PanelResult.RETURNED, PanelResult.NOT_USED, PanelResult.CHALLENGED))
+                .and(PANEL.trial.courtLocation.locCode.eq(JUROR_POOL.pool.courtLocation.locCode))
+                .and(JUROR_POOL.status.status.in(IJurorStatus.PANEL, IJurorStatus.JUROR)));
 
 
         verify(jpaQuery, times(1)).leftJoin(PANEL);


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7147)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ajuror-api&pullRequest=260)


### Change description ###
Reassign a juror from pool 1 to pool 2
Search by pool 1 in export contact details

Expected:

juror does not appear in search for pool 1

Actual:

juror appears in search for pool 1 with status ‘Reassigned’


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
