### PR TITLE
Last Login Date incorrectly displayed on System Admin > Users screen

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/moj/domain/authentication/UserDetailsDto.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/domain/authentication/UserDetailsDto.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.juror.api.moj.domain.authentication;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import jakarta.validation.constraints.NotNull;
@@ -12,6 +13,7 @@ import lombok.experimental.SuperBuilder;
 import uk.gov.hmcts.juror.api.moj.domain.Role;
 import uk.gov.hmcts.juror.api.moj.domain.User;
 import uk.gov.hmcts.juror.api.moj.domain.UserType;
+import uk.gov.hmcts.juror.api.validation.ValidationConstants;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -27,6 +29,7 @@ import java.util.Set;
 public class UserDetailsDto extends UserDetailsSimpleDto {
     @NotNull
     private Boolean isActive;
+    @JsonFormat(pattern = ValidationConstants.DATE_FORMAT)
     private LocalDateTime lastSignIn;
     private UserType userType;
 

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/domain/authentication/UserDetailsDto.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/domain/authentication/UserDetailsDto.java
@@ -29,7 +29,7 @@ import java.util.Set;
 public class UserDetailsDto extends UserDetailsSimpleDto {
     @NotNull
     private Boolean isActive;
-    @JsonFormat(pattern = ValidationConstants.DATE_FORMAT)
+    @JsonFormat(pattern = ValidationConstants.DATETIME_FORMAT)
     private LocalDateTime lastSignIn;
     private UserType userType;
 


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7187)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=287)


### Change description ###
Insert a last login date/time in the database for existing user(s)

Log in as a system admin user

Navigate to the Users screen

Verify the last login date is displayed correctly:



!image-20240501-091504.png|width=1422,height=740,alt="image-20240501-091504.png"!

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
