### PR TITLE
task/JM-6600: Log changes to users table (users_audit)

### DIFF
--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/UserControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/UserControllerITest.java
@@ -60,6 +60,7 @@ public class UserControllerITest extends AbstractIntegrationTest {
 
     public static final String BASE_URL = "/api/v1/moj/users";
     private static final String EMAIL_SUFFIX = "@email.gov.uk";
+    private static final String SYSTEM_USER = "test_system";
 
     private final TestRestTemplate template;
     private HttpHeaders httpHeaders;
@@ -1350,6 +1351,7 @@ public class UserControllerITest extends AbstractIntegrationTest {
                     .triggerValid()
                     .assertValidNoBody();
                 assertUserHasCourts("test_court_multi", "415", "421");
+                assertUserIsUpdatedBy("test_court_multi", SYSTEM_USER);
             }
         }
 
@@ -1462,7 +1464,7 @@ public class UserControllerITest extends AbstractIntegrationTest {
                     .triggerValid()
                     .assertValidNoBody();
                 assertUserHasCourts("test_court_multi", "415", "421");
-                assertUserIsUpdatedBy("test_court_multi", "test_system");
+                assertUserIsUpdatedBy("test_court_multi", SYSTEM_USER);
             }
         }
 
@@ -1573,7 +1575,7 @@ public class UserControllerITest extends AbstractIntegrationTest {
                     .url(toUrl("test_court_manager", UserType.COURT))
                     .triggerValid()
                     .assertValidNoBody();
-                assertUser("test_court_manager", UserType.COURT, Set.of(Role.MANAGER), "test_system", "415");
+                assertUser("test_court_manager", UserType.COURT, Set.of(Role.MANAGER), SYSTEM_USER, "415");
             }
 
             @Test

--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/UserControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/UserControllerITest.java
@@ -90,6 +90,14 @@ public class UserControllerITest extends AbstractIntegrationTest {
         });
     }
 
+    private void assertUserIsUpdatedBy(String username, String updateBy) {
+        transactionTemplate.execute(status -> {
+            User user = getUserFromUsername(username);
+            assertThat(user.getUpdatedBy()).isEqualTo(updateBy);
+            return null;
+        });
+    }
+
     private User getUserFromUsername(String username) {
         return transactionTemplate.execute(status -> {
             User user = userRepository.findByUsername(username);
@@ -699,7 +707,7 @@ public class UserControllerITest extends AbstractIntegrationTest {
                                 .isActive(true)
                                 .lastSignIn(null)
                                 .userType(UserType.COURT)
-                                .roles(Set.of(Role.MANAGER,Role.SENIOR_JUROR_OFFICER))
+                                .roles(Set.of(Role.MANAGER, Role.SENIOR_JUROR_OFFICER))
                                 .courts(List.of(UserCourtDto.builder()
                                     .primaryCourt(CourtDto.builder()
                                         .name("CHESTER")
@@ -790,6 +798,7 @@ public class UserControllerITest extends AbstractIntegrationTest {
             void assertUserCreated(
                 CreateUserDto userDto,
                 String expectedUsername,
+                String createdBy,
                 String... courtLocCodes
             ) {
                 transactionTemplate.execute(status -> {
@@ -800,6 +809,8 @@ public class UserControllerITest extends AbstractIntegrationTest {
                     assertThat(user.getRoles()).isEqualTo(Optional.ofNullable(userDto.getRoles()).orElse(Set.of()));
                     assertThat(user.isActive()).isTrue();
                     assertThat(user.getUsername()).isEqualTo(expectedUsername);
+                    assertThat(user.getCreatedBy()).isEqualTo(createdBy);
+                    assertThat(user.getUpdatedBy()).isEqualTo(createdBy);
                     assertThat(user.getApprovalLimit()).isEqualTo(
                         Optional.ofNullable(userDto.getApprovalLimit()).orElse(new BigDecimal("0.00")));
                     assertThat(user.getCourts()).hasSize(courtLocCodes.length);
@@ -818,7 +829,7 @@ public class UserControllerITest extends AbstractIntegrationTest {
                     .payload(userDto)
                     .triggerValid()
                     .assertEquals(new UsernameDto("test_new_user"));
-                assertUserCreated(userDto, "test_new_user");
+                assertUserCreated(userDto, "test_new_user", "test_admin_standard");
             }
 
             @Test
@@ -829,7 +840,7 @@ public class UserControllerITest extends AbstractIntegrationTest {
                     .payload(userDto)
                     .triggerValid()
                     .assertEquals(new UsernameDto("test_new_user"));
-                assertUserCreated(userDto, "test_new_user", "400");
+                assertUserCreated(userDto, "test_new_user", "test_admin_standard", "400");
             }
 
             @Test
@@ -840,7 +851,7 @@ public class UserControllerITest extends AbstractIntegrationTest {
                     .payload(userDto)
                     .triggerValid()
                     .assertEquals(new UsernameDto("test_new_user"));
-                assertUserCreated(userDto, "test_new_user", "400");
+                assertUserCreated(userDto, "test_new_user", "test_admin_standard", "400");
             }
 
             @Test
@@ -853,7 +864,7 @@ public class UserControllerITest extends AbstractIntegrationTest {
                     .payload(userDto)
                     .triggerValid()
                     .assertEquals(new UsernameDto("test_court_sjo1"));
-                assertUserCreated(userDto, "test_court_sjo1");
+                assertUserCreated(userDto, "test_court_sjo1", "test_admin_standard");
             }
         }
 
@@ -1142,7 +1153,8 @@ public class UserControllerITest extends AbstractIntegrationTest {
                 User oldUser,
                 UpdateUserDto userDto,
                 boolean isAdmin,
-                String username
+                String username,
+                String updatedBy
             ) {
                 transactionTemplate.execute(status -> {
                     User user = getUserFromUsername(username);
@@ -1159,6 +1171,7 @@ public class UserControllerITest extends AbstractIntegrationTest {
                         assertThat(user.getApprovalLimit()).isEqualTo(oldUser.getApprovalLimit());
                     }
                     assertThat(user.getRoles()).isEqualTo(Optional.ofNullable(userDto.getRoles()).orElse(Set.of()));
+                    assertThat(user.getUpdatedBy()).isEqualTo(updatedBy);
                     return null;
                 });
             }
@@ -1174,7 +1187,7 @@ public class UserControllerITest extends AbstractIntegrationTest {
                     .payload(payload)
                     .triggerValid()
                     .assertValidNoBody();
-                assertUserUpdated(userBeforeUpdate, payload, false, username);
+                assertUserUpdated(userBeforeUpdate, payload, false, username, "test_court_manager");
             }
 
             @Test
@@ -1188,7 +1201,7 @@ public class UserControllerITest extends AbstractIntegrationTest {
                     .payload(payload)
                     .triggerValid()
                     .assertValidNoBody();
-                assertUserUpdated(userBeforeUpdate, payload, false, username);
+                assertUserUpdated(userBeforeUpdate, payload, false, username, "test_bureau_lead");
             }
 
             @Test
@@ -1202,7 +1215,7 @@ public class UserControllerITest extends AbstractIntegrationTest {
                     .payload(payload)
                     .triggerValid()
                     .assertValidNoBody();
-                assertUserUpdated(userBeforeUpdate, payload, true, username);
+                assertUserUpdated(userBeforeUpdate, payload, true, username, "test_admin_standard");
             }
 
             @Test
@@ -1216,7 +1229,7 @@ public class UserControllerITest extends AbstractIntegrationTest {
                     .payload(payload)
                     .triggerValid()
                     .assertValidNoBody();
-                assertUserUpdated(userBeforeUpdate, payload, true, username);
+                assertUserUpdated(userBeforeUpdate, payload, true, username, "test_admin_standard");
             }
         }
 
@@ -1326,6 +1339,7 @@ public class UserControllerITest extends AbstractIntegrationTest {
                     .triggerValid()
                     .assertValidNoBody();
                 assertUserHasCourts("test_court_multi", "415", "421", "466");
+                assertUserIsUpdatedBy("test_court_multi", "test_admin_standard");
             }
 
             @Test
@@ -1436,6 +1450,7 @@ public class UserControllerITest extends AbstractIntegrationTest {
                     .triggerValid()
                     .assertValidNoBody();
                 assertUserHasCourts("test_court_multi", "421");
+                assertUserIsUpdatedBy("test_court_multi", "test_admin_standard");
             }
 
 
@@ -1447,6 +1462,7 @@ public class UserControllerITest extends AbstractIntegrationTest {
                     .triggerValid()
                     .assertValidNoBody();
                 assertUserHasCourts("test_court_multi", "415", "421");
+                assertUserIsUpdatedBy("test_court_multi", "test_system");
             }
         }
 
@@ -1536,7 +1552,8 @@ public class UserControllerITest extends AbstractIntegrationTest {
         @DisplayName("Positive")
         @Nested
         class Positive {
-            private void assertUser(String username, UserType userType, Set<Role> roles, String... locCodes) {
+            private void assertUser(String username, UserType userType, Set<Role> roles,
+                                    String updatedBy, String... locCodes) {
                 transactionTemplate.execute(status -> {
                     User user = getUserFromUsername(username);
                     assertThat(user.getUserType()).isEqualTo(userType);
@@ -1544,6 +1561,7 @@ public class UserControllerITest extends AbstractIntegrationTest {
                     assertThat(user.getCourts()
                         .stream().map(CourtLocation::getLocCode).toList())
                         .containsExactlyInAnyOrder(locCodes);
+                    assertThat(user.getUpdatedBy()).isEqualTo(updatedBy);
                     assertThat(user.getRoles()).isEqualTo(roles);
                     return null;
                 });
@@ -1555,7 +1573,7 @@ public class UserControllerITest extends AbstractIntegrationTest {
                     .url(toUrl("test_court_manager", UserType.COURT))
                     .triggerValid()
                     .assertValidNoBody();
-                assertUser("test_court_manager", UserType.COURT, Set.of(Role.MANAGER), "415");
+                assertUser("test_court_manager", UserType.COURT, Set.of(Role.MANAGER), "test_system", "415");
             }
 
             @Test
@@ -1564,7 +1582,7 @@ public class UserControllerITest extends AbstractIntegrationTest {
                     .url(toUrl("test_admin_standard", UserType.COURT))
                     .triggerValid()
                     .assertValidNoBody();
-                assertUser("test_admin_standard", UserType.COURT, Set.of());
+                assertUser("test_admin_standard", UserType.COURT, Set.of(), "test_admin_standard");
             }
 
 
@@ -1574,7 +1592,7 @@ public class UserControllerITest extends AbstractIntegrationTest {
                     .url(toUrl("test_admin_standard", UserType.BUREAU))
                     .triggerValid()
                     .assertValidNoBody();
-                assertUser("test_admin_standard", UserType.BUREAU, Set.of(), "400");
+                assertUser("test_admin_standard", UserType.BUREAU, Set.of(), "test_admin_standard", "400");
             }
 
             @Test
@@ -1583,7 +1601,7 @@ public class UserControllerITest extends AbstractIntegrationTest {
                     .url(toUrl("test_bureau_standard", UserType.COURT))
                     .triggerValid()
                     .assertValidNoBody();
-                assertUser("test_bureau_standard", UserType.COURT, Set.of());
+                assertUser("test_bureau_standard", UserType.COURT, Set.of(), "test_admin_standard");
             }
         }
 

--- a/src/integration-test/resources/db/administration/createUsers.sql
+++ b/src/integration-test/resources/db/administration/createUsers.sql
@@ -1,7 +1,7 @@
-INSERT INTO juror_mod.users (user_type, username, email, name, active, version)
-VALUES ('BUREAU', 'test_bureau_inactive', 'test_bureau_inactive@email.gov.uk', 'Bureau Inactive', false, 1),
-       ('BUREAU', 'test_bureau_standard', 'test_bureau_standard@email.gov.uk', 'Bureau Standard', true, 1),
-       ('BUREAU', 'test_bureau_lead', 'test_bureau_lead@email.gov.uk', 'Bureau Team Lead', true, 1);
+INSERT INTO juror_mod.users (user_type, username, email, name, active, version, created_by, updated_by)
+VALUES ('BUREAU', 'test_bureau_inactive', 'test_bureau_inactive@email.gov.uk', 'Bureau Inactive', false, 1, 'test_system', 'test_system'),
+       ('BUREAU', 'test_bureau_standard', 'test_bureau_standard@email.gov.uk', 'Bureau Standard', true, 1, 'test_system', 'test_system'),
+       ('BUREAU', 'test_bureau_lead', 'test_bureau_lead@email.gov.uk', 'Bureau Team Lead', true, 1, 'test_system', 'test_system');
 
 INSERT INTO juror_mod.user_roles (username, role)
 VALUES ('test_bureau_lead', 'MANAGER');
@@ -12,15 +12,15 @@ VALUES ('test_bureau_inactive', '400'),
        ('test_bureau_lead', '400');
 
 
-INSERT INTO juror_mod.users (user_type, username, email, name, active, version)
-VALUES ('COURT', 'test_court_no_courts', 'test_court_no_courts@email.gov.uk', 'Court No Courts', false, 1),
-       ('COURT', 'test_court_inactive', 'test_court_inactive@email.gov.uk', 'Court Inactive', false, 1),
-       ('COURT', 'test_court_standard', 'test_court_standard@email.gov.uk', 'Court Standard', true, 1),
-       ('COURT', 'test_court_manager', 'test_court_manager@email.gov.uk', 'Court Manager', true, 1),
-       ('COURT', 'test_court_sjo', 'test_court_sjo@email.gov.uk', 'Court SJO', true, 1),
-       ('COURT', 'test_court_sjo_mangr', 'test_court_sjo_mangr@email.gov.uk', 'Court SJO & Manager', true, 1),
-       ('COURT', 'test_court_primary', 'test_court_primary@email.gov.uk', 'Court Primary Only', true, 1),
-       ('COURT', 'test_court_multi', 'test_court_multi@email.gov.uk', 'Court Multiple Linked', true, 1)
+INSERT INTO juror_mod.users (user_type, username, email, name, active, version, created_by, updated_by)
+VALUES ('COURT', 'test_court_no_courts', 'test_court_no_courts@email.gov.uk', 'Court No Courts', false, 1, 'test_system', 'test_system'),
+       ('COURT', 'test_court_inactive', 'test_court_inactive@email.gov.uk', 'Court Inactive', false, 1, 'test_system', 'test_system'),
+       ('COURT', 'test_court_standard', 'test_court_standard@email.gov.uk', 'Court Standard', true, 1, 'test_system', 'test_system'),
+       ('COURT', 'test_court_manager', 'test_court_manager@email.gov.uk', 'Court Manager', true, 1, 'test_system', 'test_system'),
+       ('COURT', 'test_court_sjo', 'test_court_sjo@email.gov.uk', 'Court SJO', true, 1, 'test_system', 'test_system'),
+       ('COURT', 'test_court_sjo_mangr', 'test_court_sjo_mangr@email.gov.uk', 'Court SJO & Manager', true, 1, 'test_system', 'test_system'),
+       ('COURT', 'test_court_primary', 'test_court_primary@email.gov.uk', 'Court Primary Only', true, 1, 'test_system', 'test_system'),
+       ('COURT', 'test_court_multi', 'test_court_multi@email.gov.uk', 'Court Multiple Linked', true, 1, 'test_system', 'test_system')
 ;
 
 INSERT INTO juror_mod.user_roles (username, role)
@@ -39,14 +39,14 @@ VALUES ('test_court_inactive', '415'),
        ('test_court_multi', '415'),
        ('test_court_multi', '421');
 
-INSERT INTO juror_mod.users (user_type, username, email, name, active, version)
-VALUES ('ADMINISTRATOR', 'test_admin_inactive', 'test_admin_inactive@email.gov.uk', 'Admin Inactive', false, 1),
-       ('ADMINISTRATOR', 'test_admin_standard', 'test_admin_standard@email.gov.uk', 'Admin Standard', true, 1);
+INSERT INTO juror_mod.users (user_type, username, email, name, active, version, created_by, updated_by)
+VALUES ('ADMINISTRATOR', 'test_admin_inactive', 'test_admin_inactive@email.gov.uk', 'Admin Inactive', false, 1, 'test_system', 'test_system'),
+       ('ADMINISTRATOR', 'test_admin_standard', 'test_admin_standard@email.gov.uk', 'Admin Standard', true, 1, 'test_system', 'test_system');
 
 
 INSERT INTO juror_mod.user_courts (username, loc_code)
 VALUES ('test_admin_inactive', '400'),
        ('test_admin_standard', '400');
 
-INSERT INTO juror_mod.users (user_type, username, email, name, active, version)
-VALUES ('SYSTEM', 'test_system', 'test_system@email.gov.uk', 'System User', false, 1);
+INSERT INTO juror_mod.users (user_type, username, email, name, active, version, created_by, updated_by)
+VALUES ('SYSTEM', 'test_system', 'test_system@email.gov.uk', 'System User', false, 1, 'test_system', 'test_system');

--- a/src/integration-test/resources/db/administration/createUsers.sql
+++ b/src/integration-test/resources/db/administration/createUsers.sql
@@ -12,15 +12,15 @@ VALUES ('test_bureau_inactive', '400'),
        ('test_bureau_lead', '400');
 
 
-INSERT INTO juror_mod.users (user_type, username, email, name, active, version, created_by, updated_by)
-VALUES ('COURT', 'test_court_no_courts', 'test_court_no_courts@email.gov.uk', 'Court No Courts', false, 1, 'test_system', 'test_system'),
-       ('COURT', 'test_court_inactive', 'test_court_inactive@email.gov.uk', 'Court Inactive', false, 1, 'test_system', 'test_system'),
-       ('COURT', 'test_court_standard', 'test_court_standard@email.gov.uk', 'Court Standard', true, 1, 'test_system', 'test_system'),
-       ('COURT', 'test_court_manager', 'test_court_manager@email.gov.uk', 'Court Manager', true, 1, 'test_system', 'test_system'),
-       ('COURT', 'test_court_sjo', 'test_court_sjo@email.gov.uk', 'Court SJO', true, 1, 'test_system', 'test_system'),
-       ('COURT', 'test_court_sjo_mangr', 'test_court_sjo_mangr@email.gov.uk', 'Court SJO & Manager', true, 1, 'test_system', 'test_system'),
-       ('COURT', 'test_court_primary', 'test_court_primary@email.gov.uk', 'Court Primary Only', true, 1, 'test_system', 'test_system'),
-       ('COURT', 'test_court_multi', 'test_court_multi@email.gov.uk', 'Court Multiple Linked', true, 1, 'test_system', 'test_system')
+INSERT INTO juror_mod.users (owner, user_type, username, email, name, active, version, created_by, updated_by)
+VALUES (null, 'COURT', 'test_court_no_courts', 'test_court_no_courts@email.gov.uk', 'Court No Courts', false, 1, 'test_system', 'test_system'),
+       ('415', 'COURT', 'test_court_inactive', 'test_court_inactive@email.gov.uk', 'Court Inactive', false, 1, 'test_system', 'test_system'),
+       ('415', 'COURT', 'test_court_standard', 'test_court_standard@email.gov.uk', 'Court Standard', true, 1, 'test_system', 'test_system'),
+       ('415', 'COURT', 'test_court_manager', 'test_court_manager@email.gov.uk', 'Court Manager', true, 1, 'test_system', 'test_system'),
+       ('415', 'COURT', 'test_court_sjo', 'test_court_sjo@email.gov.uk', 'Court SJO', true, 1, 'test_system', 'test_system'),
+       ('415', 'COURT', 'test_court_sjo_mangr', 'test_court_sjo_mangr@email.gov.uk', 'Court SJO & Manager', true, 1, 'test_system', 'test_system'),
+       ('408', 'COURT', 'test_court_primary', 'test_court_primary@email.gov.uk', 'Court Primary Only', true, 1, 'test_system', 'test_system'),
+       ('415', 'COURT', 'test_court_multi', 'test_court_multi@email.gov.uk', 'Court Multiple Linked', true, 1, 'test_system', 'test_system')
 ;
 
 INSERT INTO juror_mod.user_roles (username, role)

--- a/src/integration-test/resources/db/administration/teardownUsers.sql
+++ b/src/integration-test/resources/db/administration/teardownUsers.sql
@@ -1,6 +1,19 @@
 DELETE
+FROM juror_mod.user_roles_audit
+WHERE username LIKE 'test_%';
+
+DELETE
+FROM juror_mod.user_courts_audit
+WHERE username LIKE 'test_%';
+
+DELETE
+FROM juror_mod.users_audit
+WHERE username LIKE 'test_%';
+
+DELETE
 FROM juror_mod.user_roles
 WHERE username LIKE 'test_%';
+
 DELETE
 FROM juror_mod.user_courts
 WHERE username LIKE 'test_%';

--- a/src/integration-test/resources/db/mod/truncate.sql
+++ b/src/integration-test/resources/db/mod/truncate.sql
@@ -29,20 +29,19 @@ DELETE FROM juror_mod.juror_response;
 --
 DELETE FROM juror_mod.juror;
 
---DELETE FROM juror_mod.message;
 --DELETE FROM juror_mod.notify_template_field;
 --DELETE FROM juror_mod.notify_template_mapping;
---DELETE FROM juror_mod.password;
---DELETE FROM juror_mod.payment_data;
-
 --DELETE FROM juror_mod.region_notify_template;
+
+DELETE FROM juror_mod.user_roles_audit;
+DELETE FROM juror_mod.user_courts_audit;
+DELETE FROM juror_mod.users_audit;
 
 DELETE FROM juror_mod.user_roles;
 DELETE FROM juror_mod.user_courts;
 DELETE FROM juror_mod.users;
 
 DELETE FROM juror_mod.rev_info;
---DELETE FROM JUROR_DIGITAL.STAFF_AUDIT;
 
 --DELETE FROM juror_mod.utilisation_stats;
 

--- a/src/main/java/uk/gov/hmcts/juror/api/config/JpaEnversConfig.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/config/JpaEnversConfig.java
@@ -1,0 +1,9 @@
+package uk.gov.hmcts.juror.api.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaEnversConfig {
+}

--- a/src/main/java/uk/gov/hmcts/juror/api/config/SecurityConfig.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import org.springframework.boot.web.servlet.error.DefaultErrorAttributes;
 import org.springframework.boot.web.servlet.error.ErrorAttributes;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -21,6 +22,7 @@ import uk.gov.hmcts.juror.api.config.public1.PublicJwtAuthenticationProvider;
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity(securedEnabled = true)
+@EnableJpaAuditing
 @AllArgsConstructor(onConstructor = @__(@Autowired))
 public class SecurityConfig {
     private final PublicJwtAuthenticationProvider publicJwtAuthenticationProvider;

--- a/src/main/java/uk/gov/hmcts/juror/api/config/SecurityConfig.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/config/SecurityConfig.java
@@ -6,7 +6,6 @@ import org.springframework.boot.web.servlet.error.DefaultErrorAttributes;
 import org.springframework.boot.web.servlet.error.ErrorAttributes;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -22,7 +21,6 @@ import uk.gov.hmcts.juror.api.config.public1.PublicJwtAuthenticationProvider;
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity(securedEnabled = true)
-@EnableJpaAuditing
 @AllArgsConstructor(onConstructor = @__(@Autowired))
 public class SecurityConfig {
     private final PublicJwtAuthenticationProvider publicJwtAuthenticationProvider;

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/audit/AuditorResolver.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/audit/AuditorResolver.java
@@ -1,0 +1,19 @@
+package uk.gov.hmcts.juror.api.moj.audit;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.juror.api.moj.utils.SecurityUtil;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class AuditorResolver implements AuditorAware<String> {
+
+    @Override
+    public Optional<String> getCurrentAuditor() {
+        return Optional.of(SecurityUtil.getUsername());
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/domain/User.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/domain/User.java
@@ -107,7 +107,7 @@ public class User implements Serializable {
     @ManyToMany
     private Set<CourtLocation> courts;
 
-    @Column(name = "created_by")
+    @Column(name = "created_by", updatable = false)
     @CreatedBy
     @NotEmpty
     private String createdBy;
@@ -189,4 +189,5 @@ public class User implements Serializable {
     public void clearRoles() {
         this.getRoles().clear();
     }
+
 }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/domain/User.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/domain/User.java
@@ -5,6 +5,7 @@ import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
@@ -21,6 +22,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import org.hibernate.envers.Audited;
+import org.hibernate.envers.NotAudited;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import uk.gov.hmcts.juror.api.bureau.domain.Team;
 import uk.gov.hmcts.juror.api.juror.domain.CourtLocation;
 
@@ -31,10 +37,12 @@ import java.util.HashSet;
 import java.util.Set;
 
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "users", schema = "juror_mod")
 @Data
 @Builder
 @AllArgsConstructor
+@Audited
 @EqualsAndHashCode(exclude = {"team", "courts"})
 public class User implements Serializable {
 
@@ -63,13 +71,16 @@ public class User implements Serializable {
     @Builder.Default
     private boolean active = true;
 
+    @NotAudited
     @JsonProperty("last_logged_in")
     private LocalDateTime lastLoggedIn;
 
+    @NotAudited
     @ManyToOne
     @Deprecated(forRemoval = true)//TODO confirm
     private Team team;
 
+    @NotAudited
     @Version
     private Integer version;
 
@@ -95,6 +106,15 @@ public class User implements Serializable {
     )
     @ManyToMany
     private Set<CourtLocation> courts;
+
+    @Column(name = "created_by")
+    @CreatedBy
+    @NotEmpty
+    private String createdBy;
+
+    @Column(name = "updated_by")
+    @LastModifiedBy
+    private String updatedBy;
 
 
     public User() {

--- a/src/main/resources/db/migration/V1_65__create_users_audit_table.sql
+++ b/src/main/resources/db/migration/V1_65__create_users_audit_table.sql
@@ -1,0 +1,34 @@
+-- add new auditing user properties to users table
+alter table juror_mod.users
+add column  created_by varchar(20) null,
+add column  updated_by varchar(20) null;
+
+create table juror_mod.users_audit (
+	revision int8 not null,
+	rev_type int4 null,
+	"owner" varchar(3) null,
+	username varchar(20) not null,
+	"name" varchar(50) not null,
+	active bool default true not null,
+	approval_limit numeric(8, 2) default 0 not null,
+	user_type varchar(30) null,
+	email varchar(200) not null,
+	created_by varchar(20) null,
+	updated_by varchar(20) null,
+	constraint users_audit_pkey primary key (revision, username),
+	constraint fk_revision_number foreign key (revision) references juror_mod.rev_info(revision_number)
+);
+
+create table juror_mod.user_roles_audit (
+	revision int8 not null,
+	rev_type int4 null,
+	username varchar(20) not null,
+	role varchar(30) not null
+);
+
+create table juror_mod.user_courts_audit (
+	revision int8 not null,
+	rev_type int4 null,
+	username varchar(20) not null,
+	loc_code varchar(3) not null
+);


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://centralgovernmentcgi.atlassian.net/browse/JM-6600


### Change description ###
- Enable JPA auditing in the SecurityConfig class
- Implement AuditorAware interface to resolve auditing user properties (created_by and updated_by) using the username form the current SecurityContext
- Update User entity to enable envers auditing and add new properties for created_by and updated_by
- add flyway script to create new audit tables and update existing users table


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
