### PR TITLE
add activeUserType to old authentication mechanism

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/bureau/controller/BureauAuthenticationController.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/bureau/controller/BureauAuthenticationController.java
@@ -99,7 +99,7 @@ public class BureauAuthenticationController {
         private Boolean passwordWarning;
 
         private UserType userType;
-
+        private UserType activeUserType;
 
         private Set<Role> roles;
 

--- a/src/main/java/uk/gov/hmcts/juror/api/bureau/service/BureauAuthenticationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/bureau/service/BureauAuthenticationServiceImpl.java
@@ -52,6 +52,7 @@ public class BureauAuthenticationServiceImpl implements BureauAuthenticationServ
                     999,
                     false,
                     user.getUserType(),
+                    user.getUserType(),
                     user.getRoles(),
                     BureauAuthenticationController.UserDto.from(courtLocationRepository, entityManager, user)
                 );


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
- Add activeUserType from the new authentication by email, to the old authentication mechanism for compatibility purposes.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
