### PR TITLE
As a system admin, court locations appear that are already assigned

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/juror/domain/CourtLocation.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/juror/domain/CourtLocation.java
@@ -200,6 +200,6 @@ public class CourtLocation implements Serializable {
     }
 
     public boolean isPrimaryCourt() {
-        return owner.equals(locCode);
+        return CourtType.MAIN.equals(getType());
     }
 }

--- a/src/main/java/uk/gov/hmcts/juror/api/juror/domain/CourtLocation.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/juror/domain/CourtLocation.java
@@ -198,4 +198,8 @@ public class CourtLocation implements Serializable {
     public CourtType getType() {
         return owner.equals(locCode) ? CourtType.MAIN : CourtType.SATELLITE;
     }
+
+    public boolean isPrimaryCourt() {
+        return owner.equals(locCode);
+    }
 }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/UserServiceModImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/UserServiceModImpl.java
@@ -146,7 +146,10 @@ public class UserServiceModImpl implements UserService {
     @Transactional
     public void addCourt(String username, List<String> courts) {
         User user = findUserByUsername(username);
-        courts.forEach(string -> user.addCourt(getCourtLocation(string)));
+        courts.stream()
+            .map(this::getCourtLocation)
+            .filter(CourtLocation::isPrimaryCourt)
+            .forEach(user::addCourt);
         //TEMP until AD move
         if (!courts.isEmpty()) {
             user.setOwner(courts.get(0));

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/UserServiceModImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/UserServiceModImpl.java
@@ -149,6 +149,7 @@ public class UserServiceModImpl implements UserService {
         courts.stream()
             .map(this::getCourtLocation)
             .filter(CourtLocation::isPrimaryCourt)
+            .filter(courtLocation -> !user.hasCourtByOwner(courtLocation.getOwner()))
             .forEach(user::addCourt);
         //TEMP until AD move
         if (!courts.isEmpty()) {


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7201)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=292)


### Change description ###
Log in as a system admin

select a court user with assigned courts

click assign courts

you should not see court locations that are already assigned



!image-20240502-093829.png|width=1011,height=837,alt="image-20240502-093829.png"!



!image-20240502-093856.png|width=1011,height=837,alt="image-20240502-093856.png"!

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
