### PR TITLE
Modify confirmed appearance still uses pool number as part of appearance search

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/request/jurormanagement/ModifyConfirmedAttendanceDto.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/request/jurormanagement/ModifyConfirmedAttendanceDto.java
@@ -12,8 +12,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import uk.gov.hmcts.juror.api.moj.validation.dto.ConditionalDtoValidation;
+import uk.gov.hmcts.juror.api.validation.CourtLocationCode;
 import uk.gov.hmcts.juror.api.validation.JurorNumber;
-import uk.gov.hmcts.juror.api.validation.PoolNumber;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -36,9 +36,11 @@ public class ModifyConfirmedAttendanceDto {
     @Schema(description = "Juror to update attendance record of")
     private String jurorNumber;
 
-    @Schema(requiredMode = Schema.RequiredMode.REQUIRED, description = "The unique number for a pool request")
-    @NotBlank(message = "Request should contain a valid pool number")
-    private @PoolNumber String poolNumber;
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED, description = "The location code of the court of the "
+        + "appearance to modify")
+    @NotBlank(message = "Request should contain a valid location code")
+    @CourtLocationCode
+    private String locCode;
 
     @NotNull(message = "attendanceDate is mandatory")
     @Schema(description = "Attendance date for jury service")

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/JurorRecordServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/JurorRecordServiceImpl.java
@@ -1169,6 +1169,7 @@ public class JurorRecordServiceImpl implements JurorRecordService {
                                                                        BureauJwtPayload payload) {
         log.info("Juror {} attendance record requested by user {}", jurorNumber, payload.getLogin());
 
+        SecurityUtil.validateCourtLocationPermitted(locCode);
         JurorPool jurorPool = getJurorPoolByLocCode(locCode, jurorNumber);
         JurorPoolUtils.checkReadAccessForCurrentUser(jurorPool, payload.getOwner());
 

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceImpl.java
@@ -369,29 +369,20 @@ public class JurorAppearanceServiceImpl implements JurorAppearanceService {
     @Override
     @Transactional
     public void modifyConfirmedAttendance(ModifyConfirmedAttendanceDto request) {
-
+        SecurityUtil.validateCourtLocationPermitted(request.getLocCode());
         final LocalDate attendanceDate = request.getAttendanceDate();
         final String jurorNumber = request.getJurorNumber();
-        final String poolNumber = request.getPoolNumber();
-
 
         log.debug(
             String.format("User %s is modifying attendance for juror %s", SecurityUtil.getActiveLogin(), jurorNumber));
 
-        JurorPool jurorPool = jurorPoolRepository.findByJurorJurorNumberAndPoolPoolNumber(jurorNumber,
-            poolNumber);
-
-        if (jurorPool == null) {
-            throw new MojException.NotFound("No valid juror pool found for juror " + jurorNumber, null);
-        }
-
-        // validate the court user has access to the juror and pool
-        JurorPoolUtils.checkOwnershipForCurrentUser(jurorPool, SecurityUtil.getActiveOwner());
-
         // get the appearance record if it exists
         Appearance appearance =
-            appearanceRepository.findByJurorNumberAndPoolNumberAndAttendanceDate(jurorNumber, poolNumber,
-                attendanceDate).orElseThrow(() -> new MojException.NotFound("No valid appearance record found", null));
+            appearanceRepository.findByCourtLocationLocCodeAndJurorNumberAndAttendanceDate(
+                request.getLocCode(),
+                jurorNumber,
+                attendanceDate)
+                .orElseThrow(() -> new MojException.NotFound("No valid appearance record found", null));
 
         modifyConfirmedAttendance(appearance,
             request.getModifyAttendanceType(),


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7202)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=%pullRequestNumber%)


### Change description ###
When modifying a confirmed attendance, the BE code is still using pool number to find the relevant appearance record. This can cause problems if a juror has since moved to another pool. 

The unique identifier for appearance records is:

* juror_number
* attendance_date
* loc_code

Please update the {{JurorAppearanceServiceImpl}} class ({{modifyConfirmedAttendance}} method) to use the {{findByCourtLocationLocCodeAndJurorNumberAndAttendanceDate}} repository method instead

API contract change likely so FE and BE effort required.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
