### PR TITLE
Granting or refusing deferral requests as a Bureau user is failing

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/bureau/controller/ResponseDeferralController.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/bureau/controller/ResponseDeferralController.java
@@ -79,8 +79,8 @@ public class ResponseDeferralController {
         private Boolean acceptDeferral;
 
         @NotEmpty
-        @Size(min = 1, max = 1)
-        @Schema(description = "Excusal code reason. Single character.", requiredMode = Schema.RequiredMode.REQUIRED)
+        @Size(min = 1, max = 2)
+        @Schema(description = "Excusal code reason.", requiredMode = Schema.RequiredMode.REQUIRED)
         private String deferralReason;//is an EXC_CODE char
 
         @Future

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/request/DeferralRequestDto.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/request/DeferralRequestDto.java
@@ -38,9 +38,9 @@ public class DeferralRequestDto {
 
     @NotNull
     @JsonProperty("deferralReason")
-    @Size(min = 1, max = 1)
-    @Schema(description = "Excusal code reason. Single character.", requiredMode = Schema.RequiredMode.REQUIRED)
-    private String deferralReason; //is an EXC_CODE char
+    @Size(min = 1, max = 2)
+    @Schema(description = "Excusal code reason.", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String deferralReason; //is an EXC_CODE
 
     @JsonProperty("deferralDecision")
     @Schema(description = "Deferral Decision, either GRANT or REFUSE", requiredMode = Schema.RequiredMode.REQUIRED)


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7251)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=311)


### Change description ###
When updating jurors record to accept/reject a referral request it will fail with the error {{“Date cannot be earlier than orginal summons"}} - Even when the date is not earlier than original summons

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
