### PR TITLE
Number of search results not limited by setting SEARCH_RESULT_LIMIT_* in app_setting

### DIFF
--- a/src/integration-test/resources/db/jurorresponse/RetrieveJurorResponses.sql
+++ b/src/integration-test/resources/db/jurorresponse/RetrieveJurorResponses.sql
@@ -8,6 +8,12 @@ delete from juror_mod.juror;
 delete from juror_mod.pool;
 delete from juror_mod.users;
 
+
+
+INSERT INTO juror_mod.app_setting (SETTING,VALUE) VALUES
+('SEARCH_RESULT_LIMIT_BUREAU_OFFICER','100'),
+('SEARCH_RESULT_LIMIT_TEAM_LEADER','250');
+
 INSERT INTO juror_mod.users (owner, username,email, name, active, team_id,version,user_type)
 VALUES ('400','bureauOfficer','bureauOfficer@email.gov.uk','Bureau Officer',true,1,0,'BUREAU'),
        ('400','teamLeader','teamLeader@email.gov.uk','Team Leader',true,2,0,'BUREAU');

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/summonsmanagement/JurorResponseRetrieveServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/summonsmanagement/JurorResponseRetrieveServiceImpl.java
@@ -102,8 +102,8 @@ public class JurorResponseRetrieveServiceImpl implements JurorResponseRetrieveSe
     }
 
     private int getResultsLimit(boolean isTeamLeader) {
-        return isTeamLeader ?
-            appSettingService.getTeamLeaderSearchResultLimit() :
-            appSettingService.getBureauOfficerSearchResultLimit();
+        return isTeamLeader
+            ? appSettingService.getTeamLeaderSearchResultLimit()
+            : appSettingService.getBureauOfficerSearchResultLimit();
     }
 }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/summonsmanagement/JurorResponseRetrieveServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/summonsmanagement/JurorResponseRetrieveServiceImpl.java
@@ -11,6 +11,7 @@ import uk.gov.hmcts.juror.api.moj.controller.request.summonsmanagement.JurorResp
 import uk.gov.hmcts.juror.api.moj.controller.response.summonsmanagement.JurorResponseRetrieveResponseDto;
 import uk.gov.hmcts.juror.api.moj.exception.MojException;
 import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorResponseCommonRepositoryMod;
+import uk.gov.hmcts.juror.api.moj.service.AppSettingService;
 import uk.gov.hmcts.juror.api.moj.utils.SecurityUtil;
 
 import java.time.LocalDateTime;
@@ -25,11 +26,12 @@ import static uk.gov.hmcts.juror.api.moj.utils.converters.ConversionUtils.toProp
 @Service
 @RequiredArgsConstructor(onConstructor_ = {@Autowired})
 public class JurorResponseRetrieveServiceImpl implements JurorResponseRetrieveService {
-    private static final int SEARCH_RESULT_LIMIT_BUREAU_OFFICER = 100;
-    private static final int SEARCH_RESULT_LIMIT_TEAM_LEADER = 250;
 
     @Autowired
     private JurorResponseCommonRepositoryMod jurorResponseRepository;
+
+    @Autowired
+    private AppSettingService appSettingService;
 
     @Override
     @Transactional(readOnly = true)
@@ -100,6 +102,8 @@ public class JurorResponseRetrieveServiceImpl implements JurorResponseRetrieveSe
     }
 
     private int getResultsLimit(boolean isTeamLeader) {
-        return isTeamLeader ? SEARCH_RESULT_LIMIT_TEAM_LEADER : SEARCH_RESULT_LIMIT_BUREAU_OFFICER;
+        return isTeamLeader ?
+            appSettingService.getTeamLeaderSearchResultLimit() :
+            appSettingService.getBureauOfficerSearchResultLimit();
     }
 }

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/summonsmanagement/JurorResponseRetrieveServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/summonsmanagement/JurorResponseRetrieveServiceImplTest.java
@@ -17,6 +17,7 @@ import uk.gov.hmcts.juror.api.moj.domain.Role;
 import uk.gov.hmcts.juror.api.moj.domain.UserType;
 import uk.gov.hmcts.juror.api.moj.exception.MojException;
 import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorResponseCommonRepositoryMod;
+import uk.gov.hmcts.juror.api.moj.service.AppSettingService;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -59,6 +60,9 @@ class JurorResponseRetrieveServiceImplTest {
     @Mock
     private JurorResponseCommonRepositoryMod jurorResponseCommonRepository;
 
+    @Mock
+    private AppSettingService appSettingService;
+
     @InjectMocks
     private JurorResponseRetrieveServiceImpl jurorResponseRetrieveService;
 
@@ -77,6 +81,7 @@ class JurorResponseRetrieveServiceImplTest {
             List<Tuple> tupleList = new ArrayList<>();
             tupleList.add(tuple);
 
+            doReturn(100).when(appSettingService).getBureauOfficerSearchResultLimit();
             doReturn(tupleList).when(jurorResponseCommonRepository).retrieveJurorResponseDetails(
                 request, false, 100);
 
@@ -127,7 +132,7 @@ class JurorResponseRetrieveServiceImplTest {
             Tuple tuple = createMockedDbResponse(1, ProcessingStatus.TODO);
             List<Tuple> tupleList = new ArrayList<>();
             tupleList.add(tuple);
-
+            doReturn(100).when(appSettingService).getBureauOfficerSearchResultLimit();
             doReturn(tupleList).when(jurorResponseCommonRepository).retrieveJurorResponseDetails(
                 request, false, 100);
 


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7264)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=313)


### Change description ###
I have set SEARCH_RESULT_LIMIT_BUREAU_OFFICER and SEARCH_RESULT_LIMIT_TEAM_LEADER both to have value 100

This has not affected the search results that are returned

!image-20240509-141955.png|width=1270,height=735,alt="image-20240509-141955.png"!

!image-20240509-142021.png|width=342,height=43,alt="image-20240509-142021.png"!

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
