### PR TITLE
PNC batch job does not count meta_data correctly

### DIFF
--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorRecordControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorRecordControllerITest.java
@@ -3482,16 +3482,18 @@ class JurorRecordControllerITest extends AbstractIntegrationTest {
             "111111122"})
         @Sql({"/db/mod/truncate.sql", "/db/JurorRecordController_policeCheck.sql"})
         void updatePncCheckStatusEligible(String jurorNumber) {
-            ResponseEntity<Void> response =
+            ResponseEntity<PoliceCheckStatusDto> response =
                 restTemplate.exchange(new RequestEntity<>(new PoliceCheckStatusDto(PoliceCheck.ELIGIBLE),
                         httpHeaders, HttpMethod.PATCH,
                         URI.create("/api/v1/moj/juror-record/pnc/" + jurorNumber)),
-                    Void.class);
+                    PoliceCheckStatusDto.class);
 
             assertThat(response.getStatusCode())
                 .as("Expect the HTTP GET request to be accepted")
                 .isEqualTo(HttpStatus.ACCEPTED);
 
+            assertThat(response.getBody())
+                .isEqualTo(new PoliceCheckStatusDto(PoliceCheck.ELIGIBLE));
 
             Juror juror = jurorRepository.findById(jurorNumber).get();
             final JurorPool jurorPool = jurorPoolRepository.findByJurorJurorNumberAndIsActive(jurorNumber, true).get(0);
@@ -3532,16 +3534,18 @@ class JurorRecordControllerITest extends AbstractIntegrationTest {
             "111111122"})
         @Sql({"/db/mod/truncate.sql", "/db/JurorRecordController_policeCheck.sql"})
         void updatePncCheckStatusIneligible(String jurorNumber) {
-            ResponseEntity<Void> response =
+            ResponseEntity<PoliceCheckStatusDto> response =
                 restTemplate.exchange(new RequestEntity<>(new PoliceCheckStatusDto(PoliceCheck.INELIGIBLE),
                         httpHeaders, HttpMethod.PATCH,
                         URI.create("/api/v1/moj/juror-record/pnc/" + jurorNumber)),
-                    Void.class);
+                    PoliceCheckStatusDto.class);
 
             assertThat(response.getStatusCode())
                 .as("Expect the HTTP GET request to be accepted")
                 .isEqualTo(HttpStatus.ACCEPTED);
 
+            assertThat(response.getBody())
+                .isEqualTo(new PoliceCheckStatusDto(PoliceCheck.INELIGIBLE));
 
             Juror juror = jurorRepository.findById(jurorNumber).get();
             final JurorPool jurorPool = jurorPoolRepository.findByJurorJurorNumberAndIsActive(jurorNumber, true).get(0);
@@ -3580,16 +3584,19 @@ class JurorRecordControllerITest extends AbstractIntegrationTest {
         })
         @Sql({"/db/mod/truncate.sql", "/db/JurorRecordController_policeCheck.sql"})
         void updatePncCheckStatusInError(String jurorNumber) {
-            ResponseEntity<Void> response =
+            ResponseEntity<PoliceCheckStatusDto> response =
                 restTemplate.exchange(
                     new RequestEntity<>(new PoliceCheckStatusDto(PoliceCheck.ERROR_RETRY_CONNECTION_ERROR),
                         httpHeaders, HttpMethod.PATCH,
                         URI.create("/api/v1/moj/juror-record/pnc/" + jurorNumber)),
-                    Void.class);
+                    PoliceCheckStatusDto.class);
 
             assertThat(response.getStatusCode())
                 .as("Expect the HTTP GET request to be accepted")
                 .isEqualTo(HttpStatus.ACCEPTED);
+
+            assertThat(response.getBody())
+                .isEqualTo(new PoliceCheckStatusDto(PoliceCheck.ERROR_RETRY_CONNECTION_ERROR));
 
 
             Juror juror = jurorRepository.findById(jurorNumber).get();
@@ -3618,17 +3625,19 @@ class JurorRecordControllerITest extends AbstractIntegrationTest {
         })
         @Sql({"/db/mod/truncate.sql", "/db/JurorRecordController_policeCheck.sql"})
         void updatePncCheckStatusMaxRetiesError(String jurorNumber) {
-            ResponseEntity<Void> response =
+            ResponseEntity<PoliceCheckStatusDto> response =
                 restTemplate.exchange(
                     new RequestEntity<>(new PoliceCheckStatusDto(PoliceCheck.ERROR_RETRY_CONNECTION_ERROR),
                         httpHeaders, HttpMethod.PATCH,
                         URI.create("/api/v1/moj/juror-record/pnc/" + jurorNumber)),
-                    Void.class);
+                    PoliceCheckStatusDto.class);
 
             assertThat(response.getStatusCode())
                 .as("Expect the HTTP GET request to be accepted")
                 .isEqualTo(HttpStatus.ACCEPTED);
 
+            assertThat(response.getBody())
+                .isEqualTo(new PoliceCheckStatusDto(PoliceCheck.UNCHECKED_MAX_RETRIES_EXCEEDED));
 
             Juror juror = jurorRepository.findById(jurorNumber).get();
             final JurorPool jurorPool = jurorPoolRepository.findByJurorJurorNumberAndIsActive(jurorNumber, true).get(0);

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/JurorRecordController.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/JurorRecordController.java
@@ -377,7 +377,7 @@ public class JurorRecordController {
     @PatchMapping("/pnc/{jurorNumber}")
     @Operation(summary = "Updates the juror police national computer check status",
         description = "Updates the juror police national computer check status")
-    public ResponseEntity<Void> updatePncCheckStatus(
+    public ResponseEntity<PoliceCheckStatusDto> updatePncCheckStatus(
         @Parameter(description = "Valid juror number",
             required = true)
         @JurorNumber
@@ -386,8 +386,7 @@ public class JurorRecordController {
         @Valid String jurorNumber,
         @Valid @RequestBody PoliceCheckStatusDto request
     ) {
-        jurorRecordService.updatePncStatus(jurorNumber, request.getStatus());
-        return new ResponseEntity<>(HttpStatus.ACCEPTED);
+        return ResponseEntity.accepted().body(jurorRecordService.updatePncStatus(jurorNumber, request.getStatus()));
     }
 
     @PatchMapping("/failed-to-attend")

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/request/PoliceCheckStatusDto.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/request/PoliceCheckStatusDto.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.juror.api.moj.controller.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -10,6 +11,7 @@ import uk.gov.hmcts.juror.api.moj.domain.PoliceCheck;
 
 @AllArgsConstructor
 @NoArgsConstructor
+@EqualsAndHashCode
 @Getter
 @Setter
 @Schema(description = "Police Check Status request")

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/JurorRecordService.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/JurorRecordService.java
@@ -11,6 +11,7 @@ import uk.gov.hmcts.juror.api.moj.controller.request.JurorCreateRequestDto;
 import uk.gov.hmcts.juror.api.moj.controller.request.JurorNameDetailsDto;
 import uk.gov.hmcts.juror.api.moj.controller.request.JurorOpticRefRequestDto;
 import uk.gov.hmcts.juror.api.moj.controller.request.JurorRecordFilterRequestQuery;
+import uk.gov.hmcts.juror.api.moj.controller.request.PoliceCheckStatusDto;
 import uk.gov.hmcts.juror.api.moj.controller.request.ProcessNameChangeRequestDto;
 import uk.gov.hmcts.juror.api.moj.controller.request.ProcessPendingJurorRequestDto;
 import uk.gov.hmcts.juror.api.moj.controller.request.RequestBankDetailsDto;
@@ -72,7 +73,7 @@ public interface JurorRecordService {
 
     void editJurorDetails(BureauJwtPayload payload, EditJurorRecordRequestDto requestDto, String jurorNumber);
 
-    void updatePncStatus(String jurorNumber, PoliceCheck policeCheck);
+    PoliceCheckStatusDto updatePncStatus(String jurorNumber, PoliceCheck policeCheck);
 
     void createJurorRecord(BureauJwtPayload payload, JurorCreateRequestDto jurorCreateRequestDto);
 

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/JurorRecordServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/JurorRecordServiceImpl.java
@@ -27,6 +27,7 @@ import uk.gov.hmcts.juror.api.moj.controller.request.JurorCreateRequestDto;
 import uk.gov.hmcts.juror.api.moj.controller.request.JurorNameDetailsDto;
 import uk.gov.hmcts.juror.api.moj.controller.request.JurorOpticRefRequestDto;
 import uk.gov.hmcts.juror.api.moj.controller.request.JurorRecordFilterRequestQuery;
+import uk.gov.hmcts.juror.api.moj.controller.request.PoliceCheckStatusDto;
 import uk.gov.hmcts.juror.api.moj.controller.request.ProcessNameChangeRequestDto;
 import uk.gov.hmcts.juror.api.moj.controller.request.ProcessPendingJurorRequestDto;
 import uk.gov.hmcts.juror.api.moj.controller.request.RequestBankDetailsDto;
@@ -1072,7 +1073,7 @@ public class JurorRecordServiceImpl implements JurorRecordService {
 
     @Override
     @Transactional
-    public void updatePncStatus(final String jurorNumber, final PoliceCheck policeCheck) {
+    public PoliceCheckStatusDto updatePncStatus(final String jurorNumber, final PoliceCheck policeCheck) {
         log.info("Attempting to update PNC check status for juror {} to be {}", jurorNumber, policeCheck);
         final JurorPool jurorPool = JurorPoolUtils.getLatestActiveJurorPoolRecord(jurorPoolRepository, jurorNumber);
         final Juror juror = jurorPool.getJuror();
@@ -1081,7 +1082,7 @@ public class JurorRecordServiceImpl implements JurorRecordService {
         final PoliceCheck newPoliceCheckValue = PoliceCheck.getEffectiveValue(oldPoliceCheckValue, policeCheck);
         if (oldPoliceCheckValue == newPoliceCheckValue) {
             log.debug("Skipping PNC check update for juror {} as new value equals existing value", jurorNumber);
-            return;//If both are the same no point continuing
+            return new PoliceCheckStatusDto(policeCheck);//If both are the same no point continuing
         }
         juror.setPoliceCheck(newPoliceCheckValue);
 
@@ -1119,6 +1120,7 @@ public class JurorRecordServiceImpl implements JurorRecordService {
         }
         jurorPoolRepository.save(jurorPool);
         jurorRepository.save(juror);
+        return new PoliceCheckStatusDto(newPoliceCheckValue);
     }
 
     @Override


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7297)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=333)


### Change description ###
PNC scheduler batch job reports MAX_RETRIES_EXCEEDED count as 0 even when there are jurors updated to that status. It counts them in the {{TOTAL_WITH_STATUS_ERROR_RETRY_OTHER_ERROR_CODE}}

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
