### PR TITLE
As a developer I want to remove REAPPROEVED_EDIT as a financial audit type

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/request/expense/ExpenseType.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/request/expense/ExpenseType.java
@@ -29,8 +29,7 @@ public enum ExpenseType {
 
     public FinancialAuditDetails.Type toEditType() {
         return switch (this) {
-            case FOR_APPROVAL -> FinancialAuditDetails.Type.FOR_APPROVAL_EDIT;
-            case FOR_REAPPROVAL -> FinancialAuditDetails.Type.REAPPROVED_EDIT;
+            case FOR_APPROVAL, FOR_REAPPROVAL -> FinancialAuditDetails.Type.FOR_APPROVAL_EDIT;
             case APPROVED -> FinancialAuditDetails.Type.APPROVED_EDIT;
             case DRAFT -> throw new IllegalArgumentException("Cannot convert DRAFT to edit type");
         };

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/domain/FinancialAuditDetails.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/domain/FinancialAuditDetails.java
@@ -94,8 +94,7 @@ public class FinancialAuditDetails implements Serializable {
         REAPPROVED_CASH(GenericType.APPROVED),
         REAPPROVED_BACS(GenericType.APPROVED),
         FOR_APPROVAL_EDIT(GenericType.EDIT),
-        APPROVED_EDIT(GenericType.EDIT),
-        REAPPROVED_EDIT(GenericType.EDIT);
+        APPROVED_EDIT(GenericType.EDIT);
 
         private final GenericType genericType;
 

--- a/src/main/resources/db/migration/V1_77__removed_reapproval_edit_expense_type.sql
+++ b/src/main/resources/db/migration/V1_77__removed_reapproval_edit_expense_type.sql
@@ -1,0 +1,13 @@
+update juror_mod.financial_audit_details set type = 'APPROVED_EDIT'
+where type ='REAPPROVED_EDIT';
+
+ALTER TABLE juror_mod.financial_audit_details
+    DROP CONSTRAINT financial_audit_details_type_check,
+    ADD CONSTRAINT financial_audit_details_type_check CHECK (((type)::text = ANY
+                                                              (ARRAY [('FOR_APPROVAL'::character varying)::text,
+                                                                  ('APPROVED_BACS'::character varying)::text,
+                                                                  ('APPROVED_CASH'::character varying)::text,
+                                                                  ('REAPPROVED_CASH'::character varying)::text,
+                                                                  ('REAPPROVED_BACS'::character varying)::text,
+                                                                  ('FOR_APPROVAL_EDIT'::character varying)::text,
+                                                                  ('APPROVED_EDIT'::character varying)::text])));


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7290)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=337)


### Change description ###
The {{FinancialAuditDetails}} entity has a type property which maps to an enum

{{REAPPROVED_EDIT}} is not needed and didn’t exist in Heritage so can be removed

the database constraint will also need updating via flyway to remove this value

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
