### PR TITLE
Improve the performance of the "Summons reply search"

### DIFF
--- a/src/main/resources/db/migration/V1_82__summons_search_optimisations.sql
+++ b/src/main/resources/db/migration/V1_82__summons_search_optimisations.sql
@@ -1,0 +1,1 @@
+CREATE INDEX juror_response_last_name_idx ON juror_mod.juror_response (lower(last_name));


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7312)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=346)


### Change description ###
The “Summons Reply Search” flow is failing PVT as page load times takes longer then 1.5 seconds 95% of the time.

Biggest offender seems to be when searching by last name.
Need to look at better index’s for the Juror Response table maybe fixed by updates to JM-7311


!image-20240516-165445.png|width=1322,height=468,alt="image-20240516-165445.png"!

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
