### PR TITLE
UAT - Users only show up in Assign replies if they have at least one reply assigned

### DIFF
--- a/src/integration-test/java/uk/gov/hmcts/juror/api/bureau/controller/BureauOfficerAllocatedRepliesControllerTest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/bureau/controller/BureauOfficerAllocatedRepliesControllerTest.java
@@ -105,7 +105,7 @@ public class BureauOfficerAllocatedRepliesControllerTest extends AbstractIntegra
         assertThat(exchange.getBody().getBureauBacklogCount().getNonUrgent()).isEqualTo(4);
         assertThat(exchange.getBody().getBureauBacklogCount().getUrgent()).isEqualTo(3);
 
-        assertThat(exchange.getBody().getData().size()).isEqualTo(2);
+        assertThat(exchange.getBody().getData().size()).isEqualTo(6);
 
         List<BureauOfficerAllocatedData> carneson =
             exchange.getBody().getData().stream().filter(r -> "carneson".equals(r.getLogin()))
@@ -125,6 +125,13 @@ public class BureauOfficerAllocatedRepliesControllerTest extends AbstractIntegra
         assertThat(mruby.get(0).getUrgent()).isEqualTo(2);
         assertThat(mruby.get(0).getNonUrgent()).isEqualTo(2);
 
+        exchange.getBody().getData()
+            .stream()
+            .filter(r -> !("carneson".equals(r.getLogin()) || "mruby".equals(r.getLogin())))
+            .forEach(bureauOfficerAllocatedData -> {
+                assertThat(bureauOfficerAllocatedData.getAllReplies()).isEqualTo(0);
+                assertThat(bureauOfficerAllocatedData.getUrgent()).isEqualTo(0);
+                assertThat(bureauOfficerAllocatedData.getNonUrgent()).isEqualTo(0);
+            });
     }
-
 }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/jurorresponse/JurorDigitalResponseRepositoryModImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/jurorresponse/JurorDigitalResponseRepositoryModImpl.java
@@ -50,9 +50,10 @@ public class JurorDigitalResponseRepositoryModImpl implements IJurorDigitalRespo
                 new CaseBuilder().when(
                     digitalResponse.processingStatus.eq(ProcessingStatus.TODO)
                 ).then(1).otherwise(0).sum().as("allReplies")
-            ).from(digitalResponse)
-            .join(user)
-            .on(user.eq(digitalResponse.staff).and(user.userType.eq(UserType.BUREAU)))
+            ).from(user)
+            .where(user.userType.eq(UserType.BUREAU))
+            .leftJoin(digitalResponse)
+            .on(user.eq(digitalResponse.staff))
             .groupBy(user.username, user.name);
         return query.fetch();
     }


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7386)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=364)


### Change description ###
When you create a new user with no replies assigned the user does not appear in assign replies as a bureau user

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
