### PR TITLE
WeeklyComms does not pick up any jurors who should receive the comms

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/JurorPoolQueries.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/JurorPoolQueries.java
@@ -122,7 +122,6 @@ public class JurorPoolQueries {
         return courtDateWithin4Wks()
             .and(respondedStatus())
             .and(jurorRecordWithBureau())
-            .and(jurorRecordNotWithBureau())
             .and(infoCommsNotSent())
             .and(emailIsPresent())
             .and(isPoliceChecked());


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7388)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=366)


### Change description ###
This appears to be because it looks for jurors that are both owned and not owned by the bureau

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
