### PR TITLE
Cannot generate a letter on a weekend (Bureau)

### DIFF
--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/LetterControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/LetterControllerITest.java
@@ -2848,13 +2848,7 @@ class LetterControllerITest extends AbstractIntegrationTest {
                 httpHeaders, POST, uri);
             ResponseEntity<String> response = template.exchange(request, String.class);
 
-            // making sure the test passes on the weekend as letters cannot be sent via weekend
-            Calendar calendar = Calendar.getInstance();
-            if (calendar.get(Calendar.DAY_OF_WEEK) == SATURDAY || calendar.get(Calendar.DAY_OF_WEEK) == SUNDAY) {
-                assertBusinessRuleViolation(response, "Can not generate a letter on a weekend",
-                    MojException.BusinessRuleViolation.ErrorCode.LETTER_CANNOT_GENERATE_ON_WEEKEND);
-                return;
-            }
+
 
             assertThat(response).isNotNull();
             assertThat(response.getStatusCode())
@@ -2875,14 +2869,14 @@ class LetterControllerITest extends AbstractIntegrationTest {
             assertThat(bulkPrintData.get().getFormAttribute().getFormType())
                 .as("Expect form attribute form code to be " + FormCode.ENG_POSTPONE.getCode());
 
-
+            Calendar calendar = Calendar.getInstance();
             switch (calendar.get(Calendar.DAY_OF_WEEK)) {
                 case MONDAY, TUESDAY, WEDNESDAY -> assertThat(bulkPrintData.get().getDetailRec()).contains(
                     LocalDate
                         .now()
                         .plusDays(2)
                         .format(DateTimeFormatter.ofPattern("dd MMMM yyyy")).toUpperCase());
-                case THURSDAY, FRIDAY -> assertThat(bulkPrintData.get().getDetailRec()).contains(
+                case THURSDAY, FRIDAY, SATURDAY, SUNDAY -> assertThat(bulkPrintData.get().getDetailRec()).contains(
                     LocalDate
                         .now()
                         .plusDays(4)
@@ -3256,7 +3250,7 @@ class LetterControllerITest extends AbstractIntegrationTest {
                                 .now()
                                 .plusDays(2)
                                 .format(DateTimeFormatter.ofPattern("dd MMMM yyyy")).toUpperCase());
-                        case THURSDAY, FRIDAY -> assertThat(bulkPrintData.getDetailRec()).contains(
+                        case THURSDAY, FRIDAY, SATURDAY, SUNDAY -> assertThat(bulkPrintData.getDetailRec()).contains(
                             LocalDate
                                 .now()
                                 .plusDays(4)

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/LetterBase.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/LetterBase.java
@@ -26,7 +26,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
-import static uk.gov.hmcts.juror.api.moj.exception.MojException.BusinessRuleViolation.ErrorCode.LETTER_CANNOT_GENERATE_ON_WEEKEND;
 
 @Slf4j
 public class LetterBase {
@@ -99,7 +98,7 @@ public class LetterBase {
         return format("%s %s %s, %s", welshDay, dateParts[1], welshMonth, dateParts[3]);
     }
 
-    protected static String getDateOfLetter() {
+    static String getDateOfLetter() {
         final int processDays = 2;
         final int processDaysOverWeekend = 4;
 
@@ -109,12 +108,11 @@ public class LetterBase {
             case Calendar.MONDAY, Calendar.TUESDAY, Calendar.WEDNESDAY:
                 cal.add(Calendar.DAY_OF_MONTH, processDays);
                 break;
-            case Calendar.THURSDAY, Calendar.FRIDAY:
+            case Calendar.THURSDAY, Calendar.FRIDAY, Calendar.SATURDAY, Calendar.SUNDAY:
                 cal.add(Calendar.DAY_OF_MONTH, processDaysOverWeekend);
                 break;
             default:
-                throw new MojException.BusinessRuleViolation("cannot generate a letter on a weekend",
-                    LETTER_CANNOT_GENERATE_ON_WEEKEND);
+                throw new MojException.InternalServerError("Unknown day of week", null);
         }
 
         SimpleDateFormat formatter = new SimpleDateFormat("dd MMMM yyyy");

--- a/src/test/java/uk/gov/hmcts/juror/api/bureau/service/PrintDataServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/bureau/service/PrintDataServiceImplTest.java
@@ -24,7 +24,6 @@ import uk.gov.hmcts.juror.api.moj.service.PrintDataServiceImpl;
 import uk.gov.hmcts.juror.api.moj.utils.RepositoryUtils;
 import uk.gov.hmcts.juror.api.moj.xerox.LetterBase;
 import uk.gov.hmcts.juror.api.moj.xerox.LetterTestUtils;
-import uk.gov.hmcts.juror.api.testsupport.DisableIfWeekend;
 
 import java.time.LocalDate;
 import java.time.Month;
@@ -92,7 +91,6 @@ class PrintDataServiceImplTest {
     }
 
     @Test
-    @DisableIfWeekend
     void bulkPrintSummonsLetterCallsForEachListMember() {
         final LocalDate date = LocalDate.of(2017, Month.FEBRUARY, 6);
 
@@ -106,7 +104,6 @@ class PrintDataServiceImplTest {
     }
 
     @Test
-    @DisableIfWeekend
     void bulkPrintSummonsLetterSkipsDisqualifiedListMembers() {
         final LocalDate date = LocalDate.of(2017, Month.FEBRUARY, 6);
 
@@ -126,7 +123,6 @@ class PrintDataServiceImplTest {
     }
 
     @Test
-    @DisableIfWeekend
     void printDeferralLetterCallsCommit() {
         final LocalDate date = LocalDate.of(2017, Month.FEBRUARY, 6);
 
@@ -142,7 +138,6 @@ class PrintDataServiceImplTest {
     }
 
     @Test
-    @DisableIfWeekend
     void printDeferralDeniedLetterCallsCommit() {
         final LocalDate date = LocalDate.of(2017, Month.FEBRUARY, 6);
 
@@ -158,7 +153,6 @@ class PrintDataServiceImplTest {
     }
 
     @Test
-    @DisableIfWeekend
     void printExcusalDeniedLetterCallsCommit() {
         final LocalDate date = LocalDate.of(2017, Month.FEBRUARY, 6);
 
@@ -174,7 +168,6 @@ class PrintDataServiceImplTest {
     }
 
     @Test
-    @DisableIfWeekend
     void printConfirmationLetterCallsCommit() {
         final LocalDate date = LocalDate.of(2017, Month.FEBRUARY, 6);
 
@@ -190,7 +183,6 @@ class PrintDataServiceImplTest {
     }
 
     @Test
-    @DisableIfWeekend
     void printPostponeLetterCallsCommit() {
         final LocalDate date = LocalDate.of(2017, Month.FEBRUARY, 6);
 
@@ -205,7 +197,6 @@ class PrintDataServiceImplTest {
     }
 
     @Test
-    @DisableIfWeekend
     void printExcusalLetterCallsCommit() {
         final LocalDate date = LocalDate.of(2017, Month.FEBRUARY, 6);
         doReturn(IJurorStatus.SUMMONED).when(jurorStatus).getStatus();
@@ -220,7 +211,6 @@ class PrintDataServiceImplTest {
     }
 
     @Test
-    @DisableIfWeekend
     void printWithdrawalLetterCallsCommit() {
         final LocalDate date = LocalDate.of(2017, Month.FEBRUARY, 6);
         doReturn(IJurorStatus.SUMMONED).when(jurorStatus).getStatus();

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/AbstractLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/AbstractLetterTest.java
@@ -41,6 +41,8 @@ public abstract class AbstractLetterTest {
                 break;
             case Calendar.THURSDAY:
             case Calendar.FRIDAY:
+            case Calendar.SATURDAY:
+            case Calendar.SUNDAY:
                 cal.add(Calendar.DAY_OF_MONTH, 4);
                 break;
             default:

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/ConfirmLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/ConfirmLetterTest.java
@@ -4,16 +4,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.juror.api.moj.domain.FormCode;
-import uk.gov.hmcts.juror.api.moj.exception.MojException;
 import uk.gov.hmcts.juror.api.moj.xerox.letters.ConfirmLetter;
-import uk.gov.hmcts.juror.api.testsupport.DisableIfWeekend;
 
 import java.time.LocalDate;
 import java.time.Month;
-import java.util.Calendar;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @ExtendWith(SpringExtension.class)
 class ConfirmLetterTest extends AbstractLetterTest {
@@ -85,23 +81,18 @@ class ConfirmLetterTest extends AbstractLetterTest {
         final LocalDate date = LocalDate.of(2017, Month.FEBRUARY, 6);
         setupEnglishExpectedResult();
         ConfirmLetter confirmLetter = new ConfirmLetter(LetterTestUtils.testJurorPool(date),
-                                                        LetterTestUtils.testCourtLocation(),
-                                                        LetterTestUtils.testBureauLocation());
+            LetterTestUtils.testCourtLocation(),
+            LetterTestUtils.testBureauLocation());
 
-        int dayOfTheWeek = Calendar.getInstance().get(Calendar.DAY_OF_WEEK);
-        if (dayOfTheWeek == Calendar.SATURDAY || dayOfTheWeek == Calendar.SUNDAY) {
-            assertThatExceptionOfType(MojException.BusinessRuleViolation.class)
-                .isThrownBy(confirmLetter::getLetterString);
-        } else {
-            assertThat(confirmLetter.getLetterString()).isEqualTo(getExpectedEnglishResult());
-            assertThat(confirmLetter.getFormCode()).isEqualTo(FormCode.ENG_CONFIRMATION.getCode());
-            assertThat(confirmLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testJuror().getJurorNumber());
+        assertThat(confirmLetter.getLetterString()).isEqualTo(getExpectedEnglishResult());
+        assertThat(confirmLetter.getFormCode()).isEqualTo(FormCode.ENG_CONFIRMATION.getCode());
+        assertThat(confirmLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testJuror().getJurorNumber());
 
-            // Fax number is always empty
-            assertThat(confirmLetter.getData().get(12).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
-            // Juror address 6 is always empty
-            assertThat(confirmLetter.getData().get(23).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(35));
-        }
+        // Fax number is always empty
+        assertThat(confirmLetter.getData().get(12).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
+        // Juror address 6 is always empty
+        assertThat(confirmLetter.getData().get(23).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(35));
+
     }
 
     @Test
@@ -110,34 +101,28 @@ class ConfirmLetterTest extends AbstractLetterTest {
         final LocalDate date = LocalDate.of(2017, Month.FEBRUARY, 6);
         setupWelshExpectedResult();
         ConfirmLetter confirmLetter = new ConfirmLetter(LetterTestUtils.testWelshJurorPool(date),
-                                                        LetterTestUtils.testCourtLocation(),
-                                                        LetterTestUtils.testBureauLocation(),
-                                                        LetterTestUtils.testWelshCourtLocation());
+            LetterTestUtils.testCourtLocation(),
+            LetterTestUtils.testBureauLocation(),
+            LetterTestUtils.testWelshCourtLocation());
 
-        int dayOfTheWeek = Calendar.getInstance().get(Calendar.DAY_OF_WEEK);
-        if (dayOfTheWeek == Calendar.SATURDAY || dayOfTheWeek == Calendar.SUNDAY) {
-            assertThatExceptionOfType(MojException.BusinessRuleViolation.class)
-                .isThrownBy(confirmLetter::getLetterString);
-        } else {
-            assertThat(confirmLetter.getLetterString()).isEqualTo(getExpectedWelshResult());
-            assertThat(confirmLetter.getFormCode()).isEqualTo(FormCode.BI_CONFIRMATION.getCode());
-            assertThat(confirmLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testWelshJuror().getJurorNumber());
+        assertThat(confirmLetter.getLetterString()).isEqualTo(getExpectedWelshResult());
+        assertThat(confirmLetter.getFormCode()).isEqualTo(FormCode.BI_CONFIRMATION.getCode());
+        assertThat(confirmLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testWelshJuror().getJurorNumber());
 
-            // Fax number is always empty
-            assertThat(confirmLetter.getData().get(12).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
-            // Juror address 6 is always empty
-            assertThat(confirmLetter.getData().get(23).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(35));
-        }
+        // Fax number is always empty
+        assertThat(confirmLetter.getData().get(12).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
+        // Juror address 6 is always empty
+        assertThat(confirmLetter.getData().get(23).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(35));
+
     }
 
     @Test
-    @DisableIfWeekend
     void confirmWelshWithoutWelshCourtProducesEnglishOutput() {
         final LocalDate date = LocalDate.of(2017, Month.FEBRUARY, 6);
         setupEnglishExpectedResult();
         ConfirmLetter confirmLetter = new ConfirmLetter(LetterTestUtils.testWelshJurorPool(date),
-                                                        LetterTestUtils.testCourtLocation(),
-                                                        LetterTestUtils.testBureauLocation());
+            LetterTestUtils.testCourtLocation(),
+            LetterTestUtils.testBureauLocation());
         assertThat(confirmLetter.getLetterString()).isEqualTo(getExpectedEnglishResult());
     }
 }

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/DeferralDeniedLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/DeferralDeniedLetterTest.java
@@ -4,16 +4,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.juror.api.moj.domain.FormCode;
-import uk.gov.hmcts.juror.api.moj.exception.MojException;
 import uk.gov.hmcts.juror.api.moj.xerox.letters.DeferralDeniedLetter;
-import uk.gov.hmcts.juror.api.testsupport.DisableIfWeekend;
 
 import java.time.LocalDate;
 import java.time.Month;
-import java.util.Calendar;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @ExtendWith(SpringExtension.class)
 class DeferralDeniedLetterTest extends AbstractLetterTest {
@@ -97,22 +93,17 @@ class DeferralDeniedLetterTest extends AbstractLetterTest {
             LetterTestUtils.testCourtLocation(),
             LetterTestUtils.testBureauLocation());
 
-        int dayOfTheWeek = Calendar.getInstance().get(Calendar.DAY_OF_WEEK);
-        if (dayOfTheWeek == Calendar.SATURDAY || dayOfTheWeek == Calendar.SUNDAY) {
-            assertThatExceptionOfType(MojException.BusinessRuleViolation.class)
-                .isThrownBy(deferralDeniedLetter::getLetterString);
-        } else {
-            assertThat(deferralDeniedLetter.getLetterString()).isEqualTo(getExpectedEnglishResult());
-            assertThat(deferralDeniedLetter.getFormCode()).isEqualTo(FormCode.ENG_DEFERRALDENIED.getCode());
-            assertThat(deferralDeniedLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testJuror().getJurorNumber());
+        assertThat(deferralDeniedLetter.getLetterString()).isEqualTo(getExpectedEnglishResult());
+        assertThat(deferralDeniedLetter.getFormCode()).isEqualTo(FormCode.ENG_DEFERRALDENIED.getCode());
+        assertThat(deferralDeniedLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testJuror().getJurorNumber());
 
-            // Fax number is always empty
-            assertThat(deferralDeniedLetter.getData().get(11).getFormattedString())
-                .isEqualTo(LetterTestUtils.emptyField(12));
-            // Juror address 6 is always empty
-            assertThat(deferralDeniedLetter.getData().get(27).getFormattedString())
-                .isEqualTo(LetterTestUtils.emptyField(35));
-        }
+        // Fax number is always empty
+        assertThat(deferralDeniedLetter.getData().get(11).getFormattedString())
+            .isEqualTo(LetterTestUtils.emptyField(12));
+        // Juror address 6 is always empty
+        assertThat(deferralDeniedLetter.getData().get(27).getFormattedString())
+            .isEqualTo(LetterTestUtils.emptyField(35));
+
     }
 
     @Test
@@ -125,27 +116,21 @@ class DeferralDeniedLetterTest extends AbstractLetterTest {
             LetterTestUtils.testBureauLocation(),
             LetterTestUtils.testWelshCourtLocation());
 
-        int dayOfTheWeek = Calendar.getInstance().get(Calendar.DAY_OF_WEEK);
-        if (dayOfTheWeek == Calendar.SATURDAY || dayOfTheWeek == Calendar.SUNDAY) {
-            assertThatExceptionOfType(MojException.BusinessRuleViolation.class)
-                .isThrownBy(deferralDeniedLetter::getLetterString);
-        } else {
-            assertThat(deferralDeniedLetter.getLetterString()).isEqualTo(getExpectedWelshResult());
-            assertThat(deferralDeniedLetter.getFormCode()).isEqualTo(FormCode.BI_DEFERRALDENIED.getCode());
-            assertThat(deferralDeniedLetter.getJurorNumber())
-                .isEqualTo(LetterTestUtils.testWelshJuror().getJurorNumber());
+        assertThat(deferralDeniedLetter.getLetterString()).isEqualTo(getExpectedWelshResult());
+        assertThat(deferralDeniedLetter.getFormCode()).isEqualTo(FormCode.BI_DEFERRALDENIED.getCode());
+        assertThat(deferralDeniedLetter.getJurorNumber())
+            .isEqualTo(LetterTestUtils.testWelshJuror().getJurorNumber());
 
-            // Fax number is always empty
-            assertThat(deferralDeniedLetter.getData().get(11).getFormattedString())
-                .isEqualTo(LetterTestUtils.emptyField(12));
-            // Juror address 6 is always empty
-            assertThat(deferralDeniedLetter.getData().get(27).getFormattedString())
-                .isEqualTo(LetterTestUtils.emptyField(35));
-        }
+        // Fax number is always empty
+        assertThat(deferralDeniedLetter.getData().get(11).getFormattedString())
+            .isEqualTo(LetterTestUtils.emptyField(12));
+        // Juror address 6 is always empty
+        assertThat(deferralDeniedLetter.getData().get(27).getFormattedString())
+            .isEqualTo(LetterTestUtils.emptyField(35));
+
     }
 
     @Test
-    @DisableIfWeekend
     void confirmWelshWithoutWelshCourtProducesEnglishOutput() {
         final LocalDate date = LocalDate.of(2017, Month.FEBRUARY, 6);
         setupEnglishExpectedResult();

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/DeferralLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/DeferralLetterTest.java
@@ -4,16 +4,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.juror.api.moj.domain.FormCode;
-import uk.gov.hmcts.juror.api.moj.exception.MojException;
 import uk.gov.hmcts.juror.api.moj.xerox.letters.DeferralLetter;
-import uk.gov.hmcts.juror.api.testsupport.DisableIfWeekend;
 
 import java.time.LocalDate;
 import java.time.Month;
-import java.util.Calendar;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @ExtendWith(SpringExtension.class)
 class DeferralLetterTest extends AbstractLetterTest {
@@ -85,23 +81,17 @@ class DeferralLetterTest extends AbstractLetterTest {
         final LocalDate date = LocalDate.of(2017, Month.FEBRUARY, 6);
         setupEnglishExpectedResult();
         DeferralLetter deferralLetter = new DeferralLetter(LetterTestUtils.testJurorPool(date),
-                                                        LetterTestUtils.testCourtLocation(),
-                                                        LetterTestUtils.testBureauLocation());
+            LetterTestUtils.testCourtLocation(),
+            LetterTestUtils.testBureauLocation());
 
-        int dayOfTheWeek = Calendar.getInstance().get(Calendar.DAY_OF_WEEK);
-        if (dayOfTheWeek == Calendar.SATURDAY || dayOfTheWeek == Calendar.SUNDAY) {
-            assertThatExceptionOfType(MojException.BusinessRuleViolation.class)
-                .isThrownBy(deferralLetter::getLetterString);
-        } else {
-            assertThat(deferralLetter.getLetterString()).isEqualTo(getExpectedEnglishResult());
-            assertThat(deferralLetter.getFormCode()).isEqualTo(FormCode.ENG_DEFERRAL.getCode());
-            assertThat(deferralLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testJuror().getJurorNumber());
+        assertThat(deferralLetter.getLetterString()).isEqualTo(getExpectedEnglishResult());
+        assertThat(deferralLetter.getFormCode()).isEqualTo(FormCode.ENG_DEFERRAL.getCode());
+        assertThat(deferralLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testJuror().getJurorNumber());
 
-            // Fax number is always empty
-            assertThat(deferralLetter.getData().get(11).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
-            // Juror address 6 is always empty
-            assertThat(deferralLetter.getData().get(22).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(35));
-        }
+        // Fax number is always empty
+        assertThat(deferralLetter.getData().get(11).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
+        // Juror address 6 is always empty
+        assertThat(deferralLetter.getData().get(22).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(35));
     }
 
     @Test
@@ -110,34 +100,27 @@ class DeferralLetterTest extends AbstractLetterTest {
         final LocalDate date = LocalDate.of(2017, Month.FEBRUARY, 6);
         setupWelshExpectedResult();
         DeferralLetter deferralLetter = new DeferralLetter(LetterTestUtils.testWelshJurorPool(date),
-                                                        LetterTestUtils.testCourtLocation(),
-                                                        LetterTestUtils.testBureauLocation(),
-                                                        LetterTestUtils.testWelshCourtLocation());
+            LetterTestUtils.testCourtLocation(),
+            LetterTestUtils.testBureauLocation(),
+            LetterTestUtils.testWelshCourtLocation());
 
-        int dayOfTheWeek = Calendar.getInstance().get(Calendar.DAY_OF_WEEK);
-        if (dayOfTheWeek == Calendar.SATURDAY || dayOfTheWeek == Calendar.SUNDAY) {
-            assertThatExceptionOfType(MojException.BusinessRuleViolation.class)
-                .isThrownBy(deferralLetter::getLetterString);
-        } else {
-            assertThat(deferralLetter.getLetterString()).isEqualTo(getExpectedWelshResult());
-            assertThat(deferralLetter.getFormCode()).isEqualTo(FormCode.BI_DEFERRAL.getCode());
-            assertThat(deferralLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testWelshJuror().getJurorNumber());
+        assertThat(deferralLetter.getLetterString()).isEqualTo(getExpectedWelshResult());
+        assertThat(deferralLetter.getFormCode()).isEqualTo(FormCode.BI_DEFERRAL.getCode());
+        assertThat(deferralLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testWelshJuror().getJurorNumber());
 
-            // Fax number is always empty
-            assertThat(deferralLetter.getData().get(11).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
-            // Juror address 6 is always empty
-            assertThat(deferralLetter.getData().get(22).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(35));
-        }
+        // Fax number is always empty
+        assertThat(deferralLetter.getData().get(11).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
+        // Juror address 6 is always empty
+        assertThat(deferralLetter.getData().get(22).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(35));
     }
 
     @Test
-    @DisableIfWeekend
     void confirmWelshWithoutWelshCourtProducesEnglishOutput() {
         final LocalDate date = LocalDate.of(2017, Month.FEBRUARY, 6);
         setupEnglishExpectedResult();
         DeferralLetter deferralLetter = new DeferralLetter(LetterTestUtils.testWelshJurorPool(date),
-                                                        LetterTestUtils.testCourtLocation(),
-                                                        LetterTestUtils.testBureauLocation());
+            LetterTestUtils.testCourtLocation(),
+            LetterTestUtils.testBureauLocation());
         assertThat(deferralLetter.getLetterString()).isEqualTo(getExpectedEnglishResult());
     }
 }

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/ExcusalDeniedLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/ExcusalDeniedLetterTest.java
@@ -4,16 +4,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.juror.api.moj.domain.FormCode;
-import uk.gov.hmcts.juror.api.moj.exception.MojException;
 import uk.gov.hmcts.juror.api.moj.xerox.letters.ExcusalDeniedLetter;
-import uk.gov.hmcts.juror.api.testsupport.DisableIfWeekend;
 
 import java.time.LocalDate;
 import java.time.Month;
-import java.util.Calendar;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @ExtendWith(SpringExtension.class)
 class ExcusalDeniedLetterTest extends AbstractLetterTest {
@@ -97,22 +93,17 @@ class ExcusalDeniedLetterTest extends AbstractLetterTest {
             LetterTestUtils.testCourtLocation(),
             LetterTestUtils.testBureauLocation());
 
-        int dayOfTheWeek = Calendar.getInstance().get(Calendar.DAY_OF_WEEK);
-        if (dayOfTheWeek == Calendar.SATURDAY || dayOfTheWeek == Calendar.SUNDAY) {
-            assertThatExceptionOfType(MojException.BusinessRuleViolation.class)
-                .isThrownBy(excusalDeniedLetter::getLetterString);
-        } else {
-            assertThat(excusalDeniedLetter.getLetterString()).isEqualTo(getExpectedEnglishResult());
-            assertThat(excusalDeniedLetter.getFormCode()).isEqualTo(FormCode.ENG_EXCUSALDENIED.getCode());
-            assertThat(excusalDeniedLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testJuror().getJurorNumber());
+        assertThat(excusalDeniedLetter.getLetterString()).isEqualTo(getExpectedEnglishResult());
+        assertThat(excusalDeniedLetter.getFormCode()).isEqualTo(FormCode.ENG_EXCUSALDENIED.getCode());
+        assertThat(excusalDeniedLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testJuror().getJurorNumber());
 
-            // Fax number is always empty
-            assertThat(excusalDeniedLetter.getData().get(11).getFormattedString())
-                .isEqualTo(LetterTestUtils.emptyField(12));
-            // Juror address 6 is always empty
-            assertThat(excusalDeniedLetter.getData().get(27).getFormattedString())
-                .isEqualTo(LetterTestUtils.emptyField(35));
-        }
+        // Fax number is always empty
+        assertThat(excusalDeniedLetter.getData().get(11).getFormattedString())
+            .isEqualTo(LetterTestUtils.emptyField(12));
+        // Juror address 6 is always empty
+        assertThat(excusalDeniedLetter.getData().get(27).getFormattedString())
+            .isEqualTo(LetterTestUtils.emptyField(35));
+
     }
 
     @Test
@@ -125,27 +116,20 @@ class ExcusalDeniedLetterTest extends AbstractLetterTest {
             LetterTestUtils.testBureauLocation(),
             LetterTestUtils.testWelshCourtLocation());
 
-        int dayOfTheWeek = Calendar.getInstance().get(Calendar.DAY_OF_WEEK);
-        if (dayOfTheWeek == Calendar.SATURDAY || dayOfTheWeek == Calendar.SUNDAY) {
-            assertThatExceptionOfType(MojException.BusinessRuleViolation.class)
-                .isThrownBy(excusalDeniedLetter::getLetterString);
-        } else {
-            assertThat(excusalDeniedLetter.getLetterString()).isEqualTo(getExpectedWelshResult());
-            assertThat(excusalDeniedLetter.getFormCode()).isEqualTo(FormCode.BI_EXCUSALDENIED.getCode());
-            assertThat(excusalDeniedLetter.getJurorNumber())
-                .isEqualTo(LetterTestUtils.testWelshJuror().getJurorNumber());
+        assertThat(excusalDeniedLetter.getLetterString()).isEqualTo(getExpectedWelshResult());
+        assertThat(excusalDeniedLetter.getFormCode()).isEqualTo(FormCode.BI_EXCUSALDENIED.getCode());
+        assertThat(excusalDeniedLetter.getJurorNumber())
+            .isEqualTo(LetterTestUtils.testWelshJuror().getJurorNumber());
 
-            // Fax number is always empty
-            assertThat(excusalDeniedLetter.getData().get(11).getFormattedString())
-                .isEqualTo(LetterTestUtils.emptyField(12));
-            // Juror address 6 is always empty
-            assertThat(excusalDeniedLetter.getData().get(27).getFormattedString())
-                .isEqualTo(LetterTestUtils.emptyField(35));
-        }
+        // Fax number is always empty
+        assertThat(excusalDeniedLetter.getData().get(11).getFormattedString())
+            .isEqualTo(LetterTestUtils.emptyField(12));
+        // Juror address 6 is always empty
+        assertThat(excusalDeniedLetter.getData().get(27).getFormattedString())
+            .isEqualTo(LetterTestUtils.emptyField(35));
     }
 
     @Test
-    @DisableIfWeekend
     void confirmWelshWithoutWelshCourtProducesEnglishOutput() {
         final LocalDate date = LocalDate.of(2017, Month.FEBRUARY, 6);
         setupEnglishExpectedResult();

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/ExcusalLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/ExcusalLetterTest.java
@@ -4,15 +4,12 @@ import org.junit.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.juror.api.moj.domain.FormCode;
-import uk.gov.hmcts.juror.api.moj.exception.MojException;
 import uk.gov.hmcts.juror.api.moj.xerox.letters.ExcusalLetter;
 
 import java.time.LocalDate;
 import java.time.Month;
-import java.util.Calendar;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @ExtendWith(SpringExtension.class)
 public class ExcusalLetterTest extends AbstractLetterTest {
@@ -83,22 +80,17 @@ public class ExcusalLetterTest extends AbstractLetterTest {
             LetterTestUtils.testCourtLocation(),
             LetterTestUtils.testBureauLocation());
 
-        int dayOfTheWeek = Calendar.getInstance().get(Calendar.DAY_OF_WEEK);
-        if (dayOfTheWeek == Calendar.SATURDAY || dayOfTheWeek == Calendar.SUNDAY) {
-            assertThatExceptionOfType(MojException.BusinessRuleViolation.class)
-                .isThrownBy(excusalLetter::getLetterString);
-        } else {
-            assertThat(excusalLetter.getLetterString()).isEqualTo(getExpectedEnglishResult());
-            assertThat(excusalLetter.getFormCode()).isEqualTo(FormCode.ENG_EXCUSAL.getCode());
-            assertThat(excusalLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testJuror().getJurorNumber());
+        assertThat(excusalLetter.getLetterString()).isEqualTo(getExpectedEnglishResult());
+        assertThat(excusalLetter.getFormCode()).isEqualTo(FormCode.ENG_EXCUSAL.getCode());
+        assertThat(excusalLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testJuror().getJurorNumber());
 
-            // Fax number is always empty
-            assertThat(excusalLetter.getData().get(11).getFormattedString())
-                .isEqualTo(LetterTestUtils.emptyField(12));
-            // Juror address 6 is always empty
-            assertThat(excusalLetter.getData().get(20).getFormattedString())
-                .isEqualTo(LetterTestUtils.emptyField(35));
-        }
+        // Fax number is always empty
+        assertThat(excusalLetter.getData().get(11).getFormattedString())
+            .isEqualTo(LetterTestUtils.emptyField(12));
+        // Juror address 6 is always empty
+        assertThat(excusalLetter.getData().get(20).getFormattedString())
+            .isEqualTo(LetterTestUtils.emptyField(35));
+
     }
 
     @Test
@@ -111,23 +103,19 @@ public class ExcusalLetterTest extends AbstractLetterTest {
             LetterTestUtils.testBureauLocation(),
             LetterTestUtils.testWelshCourtLocation());
 
-        int dayOfTheWeek = Calendar.getInstance().get(Calendar.DAY_OF_WEEK);
-        if (dayOfTheWeek == Calendar.SATURDAY || dayOfTheWeek == Calendar.SUNDAY) {
-            assertThatExceptionOfType(MojException.BusinessRuleViolation.class)
-                .isThrownBy(excusalLetter::getLetterString);
-        } else {
-            assertThat(excusalLetter.getLetterString()).isEqualTo(getExpectedWelshResult());
-            assertThat(excusalLetter.getFormCode()).isEqualTo(FormCode.BI_EXCUSAL.getCode());
-            assertThat(excusalLetter.getJurorNumber())
-                .isEqualTo(LetterTestUtils.testWelshJuror().getJurorNumber());
 
-            // Fax number is always empty
-            assertThat(excusalLetter.getData().get(11).getFormattedString())
-                .isEqualTo(LetterTestUtils.emptyField(12));
-            // Juror address 6 is always empty
-            assertThat(excusalLetter.getData().get(20).getFormattedString())
-                .isEqualTo(LetterTestUtils.emptyField(35));
-        }
+        assertThat(excusalLetter.getLetterString()).isEqualTo(getExpectedWelshResult());
+        assertThat(excusalLetter.getFormCode()).isEqualTo(FormCode.BI_EXCUSAL.getCode());
+        assertThat(excusalLetter.getJurorNumber())
+            .isEqualTo(LetterTestUtils.testWelshJuror().getJurorNumber());
+
+        // Fax number is always empty
+        assertThat(excusalLetter.getData().get(11).getFormattedString())
+            .isEqualTo(LetterTestUtils.emptyField(12));
+        // Juror address 6 is always empty
+        assertThat(excusalLetter.getData().get(20).getFormattedString())
+            .isEqualTo(LetterTestUtils.emptyField(35));
+
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/LetterBaseTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/LetterBaseTest.java
@@ -4,10 +4,11 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import uk.gov.hmcts.juror.api.moj.exception.MojException;
 
 import java.time.LocalDate;
 import java.time.Month;
@@ -15,11 +16,12 @@ import java.util.Calendar;
 import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(SpringExtension.class)
 class LetterBaseTest {
@@ -30,7 +32,7 @@ class LetterBaseTest {
     @BeforeEach
     void mockCalendar() {
         mockStaticCalendar = mockStatic(Calendar.class);
-        mockStaticCalendar.when(() -> Calendar.getInstance((Locale)any())).thenReturn(mockCalendar);
+        mockStaticCalendar.when(() -> Calendar.getInstance((Locale) any())).thenReturn(mockCalendar);
         mockStaticCalendar.when(Calendar::getInstance).thenReturn(mockCalendar);
         // Mock for business logic
         doReturn(Calendar.MONDAY).when(mockCalendar).get(Calendar.DAY_OF_WEEK);
@@ -76,21 +78,33 @@ class LetterBaseTest {
         ));
     }
 
-    @Test
-    void dateOfLetterThrowsAtWeekend() {
-        doReturn(Calendar.SUNDAY).when(mockCalendar).get(Calendar.DAY_OF_WEEK);
+    @ParameterizedTest
+    @ValueSource(ints = {
+        Calendar.THURSDAY,
+        Calendar.FRIDAY,
+        Calendar.SATURDAY,
+        Calendar.SUNDAY
+    })
+    void dateOfLetterPlus4Days(int day) {
+        doReturn(day).when(mockCalendar).get(Calendar.DAY_OF_WEEK);
+        LetterBase.getDateOfLetter();
+        verify(mockCalendar, times(1))
+            .add(Calendar.DAY_OF_MONTH, 4);
+    }
 
-        LetterBase testLetter = new LetterBase(testContextBuilder().build());
-        testLetter.addData(LetterBase.LetterDataType.DATE_OF_LETTER, 18);
-        assertThatExceptionOfType(MojException.BusinessRuleViolation.class)
-            .isThrownBy(testLetter::getLetterString);
+    @Test
+    void dateOfLetterPlus4AtWeekendSunday() {
+        doReturn(Calendar.SUNDAY).when(mockCalendar).get(Calendar.DAY_OF_WEEK);
+        LetterBase.getDateOfLetter();
+        verify(mockCalendar, times(1))
+            .add(Calendar.DAY_OF_MONTH, 4);
     }
 
     @Test
     void courtLocationCodeIsCorrect() {
         LetterBase testLetter = new LetterBase(testContextBuilder()
-                                                   .courtLocation(LetterTestUtils.testCourtLocation())
-                                                   .build());
+            .courtLocation(LetterTestUtils.testCourtLocation())
+            .build());
         testLetter.addData(LetterBase.LetterDataType.COURT_LOCATION_CODE, 3);
         assertThat(testLetter.getLetterString()).isEqualTo(LetterTestUtils.pad(
             "457", 3
@@ -100,8 +114,8 @@ class LetterBaseTest {
     @Test
     void courtNameIsCorrect() {
         LetterBase testLetter = new LetterBase(testContextBuilder()
-                                                   .courtLocation(LetterTestUtils.testCourtLocation())
-                                                   .build());
+            .courtLocation(LetterTestUtils.testCourtLocation())
+            .build());
         testLetter.addData(LetterBase.LetterDataType.COURT_NAME, 15);
         assertThat(testLetter.getLetterString()).isEqualTo(LetterTestUtils.pad(
             "SWANSEA CROWN COURT", 15
@@ -111,8 +125,8 @@ class LetterBaseTest {
     @Test
     void courtAddress1IsCorrect() {
         LetterBase testLetter = new LetterBase(testContextBuilder()
-                                                   .courtLocation(LetterTestUtils.testCourtLocation())
-                                                   .build());
+            .courtLocation(LetterTestUtils.testCourtLocation())
+            .build());
         testLetter.addData(LetterBase.LetterDataType.COURT_ADDRESS1, 15);
         assertThat(testLetter.getLetterString()).isEqualTo(LetterTestUtils.pad(
             "THE LAW COURTS", 15
@@ -122,8 +136,8 @@ class LetterBaseTest {
     @Test
     void courAddress2IsCorrect() {
         LetterBase testLetter = new LetterBase(testContextBuilder()
-                                                   .courtLocation(LetterTestUtils.testCourtLocation())
-                                                   .build());
+            .courtLocation(LetterTestUtils.testCourtLocation())
+            .build());
         testLetter.addData(LetterBase.LetterDataType.COURT_ADDRESS2, 15);
         assertThat(testLetter.getLetterString()).isEqualTo(LetterTestUtils.pad(
             "ST HELENS ROAD", 15
@@ -133,8 +147,8 @@ class LetterBaseTest {
     @Test
     void courtAddress3IsCorrect() {
         LetterBase testLetter = new LetterBase(testContextBuilder()
-                                                   .courtLocation(LetterTestUtils.testCourtLocation())
-                                                   .build());
+            .courtLocation(LetterTestUtils.testCourtLocation())
+            .build());
         testLetter.addData(LetterBase.LetterDataType.COURT_ADDRESS3, 15);
         assertThat(testLetter.getLetterString()).isEqualTo(LetterTestUtils.pad(
             "SWANSEA", 15
@@ -144,8 +158,8 @@ class LetterBaseTest {
     @Test
     void courtAddress4IsCorrect() {
         LetterBase testLetter = new LetterBase(testContextBuilder()
-                                                   .courtLocation(LetterTestUtils.testCourtLocation())
-                                                   .build());
+            .courtLocation(LetterTestUtils.testCourtLocation())
+            .build());
         testLetter.addData(LetterBase.LetterDataType.COURT_ADDRESS4, 15);
         assertThat(testLetter.getLetterString()).isEqualTo(LetterTestUtils.pad(
             "SHREWSBURY", 15
@@ -155,8 +169,8 @@ class LetterBaseTest {
     @Test
     void courtAddress5IsCorrect() {
         LetterBase testLetter = new LetterBase(testContextBuilder()
-                                                   .courtLocation(LetterTestUtils.testCourtLocation())
-                                                   .build());
+            .courtLocation(LetterTestUtils.testCourtLocation())
+            .build());
         testLetter.addData(LetterBase.LetterDataType.COURT_ADDRESS5, 15);
         assertThat(testLetter.getLetterString()).isEqualTo(LetterTestUtils.pad(
             "COURT_ADDRESS_5", 15
@@ -166,8 +180,8 @@ class LetterBaseTest {
     @Test
     void courtAddress6IsCorrect() {
         LetterBase testLetter = new LetterBase(testContextBuilder()
-                                                   .courtLocation(LetterTestUtils.testCourtLocation())
-                                                   .build());
+            .courtLocation(LetterTestUtils.testCourtLocation())
+            .build());
         testLetter.addData(LetterBase.LetterDataType.COURT_ADDRESS6, 15);
         assertThat(testLetter.getLetterString()).isEqualTo(LetterTestUtils.pad(
             "COURT_ADDRESS_6", 15
@@ -177,8 +191,8 @@ class LetterBaseTest {
     @Test
     void courtPostcodeIsCorrect() {
         LetterBase testLetter = new LetterBase(testContextBuilder()
-                                                   .courtLocation(LetterTestUtils.testCourtLocation())
-                                                   .build());
+            .courtLocation(LetterTestUtils.testCourtLocation())
+            .build());
         testLetter.addData(LetterBase.LetterDataType.COURT_POSTCODE, 15);
         assertThat(testLetter.getLetterString()).isEqualTo(LetterTestUtils.pad(
             "SY2 6LU", 15
@@ -188,8 +202,8 @@ class LetterBaseTest {
     @Test
     void courtPhoneIsCorrect() {
         LetterBase testLetter = new LetterBase(testContextBuilder()
-                                                   .courtLocation(LetterTestUtils.testCourtLocation())
-                                                   .build());
+            .courtLocation(LetterTestUtils.testCourtLocation())
+            .build());
         testLetter.addData(LetterBase.LetterDataType.COURT_PHONE, 15);
         assertThat(testLetter.getLetterString()).isEqualTo(LetterTestUtils.pad(
             "01792637000", 15
@@ -199,8 +213,8 @@ class LetterBaseTest {
     @Test
     void courtFaxIsEmpty() {
         LetterBase testLetter = new LetterBase(testContextBuilder()
-                                                   .courtLocation(LetterTestUtils.testCourtLocation())
-                                                   .build());
+            .courtLocation(LetterTestUtils.testCourtLocation())
+            .build());
         testLetter.addData(LetterBase.LetterDataType.COURT_FAX, 15);
         assertThat(testLetter.getLetterString()).isEqualTo(LetterTestUtils.pad(
             "", 15
@@ -210,8 +224,8 @@ class LetterBaseTest {
     @Test
     void courtInsertIsCorrect() {
         LetterBase testLetter = new LetterBase(testContextBuilder()
-                                                   .courtLocation(LetterTestUtils.testCourtLocation())
-                                                   .build());
+            .courtLocation(LetterTestUtils.testCourtLocation())
+            .build());
         testLetter.addData(LetterBase.LetterDataType.INSERT_INDICATORS, 15);
         assertThat(testLetter.getLetterString()).isEqualTo(LetterTestUtils.pad(
             "TWO WEEKS", 15
@@ -221,8 +235,8 @@ class LetterBaseTest {
     @Test
     void courtSignatoryIsCorrect() {
         LetterBase testLetter = new LetterBase(testContextBuilder()
-                                                   .courtLocation(LetterTestUtils.testCourtLocation())
-                                                   .build());
+            .courtLocation(LetterTestUtils.testCourtLocation())
+            .build());
         testLetter.addData(LetterBase.LetterDataType.COURT_SIGNATORY, 15);
         assertThat(testLetter.getLetterString()).isEqualTo(LetterTestUtils.pad(
             "JURY MANAGER", 15
@@ -232,8 +246,8 @@ class LetterBaseTest {
     @Test
     void bureauNameIsCorrect() {
         LetterBase testLetter = new LetterBase(testContextBuilder()
-                                                   .bureauLocation(LetterTestUtils.testBureauLocation())
-                                                   .build());
+            .bureauLocation(LetterTestUtils.testBureauLocation())
+            .build());
 
         testLetter.addData(LetterBase.LetterDataType.BUREAU_NAME, 40);
         assertThat(testLetter.getLetterString()).isEqualTo(LetterTestUtils.pad("JURY CENTRAL SUMMONING BUREAU", 40));
@@ -242,8 +256,8 @@ class LetterBaseTest {
     @Test
     void bureauAddress1IsCorrect() {
         LetterBase testLetter = new LetterBase(testContextBuilder()
-                                                   .bureauLocation(LetterTestUtils.testBureauLocation())
-                                                   .build());
+            .bureauLocation(LetterTestUtils.testBureauLocation())
+            .build());
 
         testLetter.addData(LetterBase.LetterDataType.BUREAU_ADDRESS1, 40);
         assertThat(testLetter.getLetterString()).isEqualTo(LetterTestUtils.pad("THE COURT SERVICE", 40));
@@ -252,8 +266,8 @@ class LetterBaseTest {
     @Test
     void bureauAddress2IsCorrect() {
         LetterBase testLetter = new LetterBase(testContextBuilder()
-                                                   .bureauLocation(LetterTestUtils.testBureauLocation())
-                                                   .build());
+            .bureauLocation(LetterTestUtils.testBureauLocation())
+            .build());
 
         testLetter.addData(LetterBase.LetterDataType.BUREAU_ADDRESS2, 40);
         assertThat(testLetter.getLetterString()).isEqualTo(LetterTestUtils.pad("FREEPOST LON 19669", 40));
@@ -262,8 +276,8 @@ class LetterBaseTest {
     @Test
     void bureauAddress3IsCorrect() {
         LetterBase testLetter = new LetterBase(testContextBuilder()
-                                                   .bureauLocation(LetterTestUtils.testBureauLocation())
-                                                   .build());
+            .bureauLocation(LetterTestUtils.testBureauLocation())
+            .build());
 
         testLetter.addData(LetterBase.LetterDataType.BUREAU_ADDRESS3, 40);
         assertThat(testLetter.getLetterString()).isEqualTo(LetterTestUtils.pad("POCOCK STREET", 40));
@@ -272,8 +286,8 @@ class LetterBaseTest {
     @Test
     void bureauAddress4IsCorrect() {
         LetterBase testLetter = new LetterBase(testContextBuilder()
-                                                   .bureauLocation(LetterTestUtils.testBureauLocation())
-                                                   .build());
+            .bureauLocation(LetterTestUtils.testBureauLocation())
+            .build());
 
         testLetter.addData(LetterBase.LetterDataType.BUREAU_ADDRESS4, 40);
         assertThat(testLetter.getLetterString()).isEqualTo(LetterTestUtils.pad("LONDON", 40));
@@ -282,8 +296,8 @@ class LetterBaseTest {
     @Test
     void bureauAddress5IsCorrect() {
         LetterBase testLetter = new LetterBase(testContextBuilder()
-                                                   .bureauLocation(LetterTestUtils.testBureauLocation())
-                                                   .build());
+            .bureauLocation(LetterTestUtils.testBureauLocation())
+            .build());
 
         testLetter.addData(LetterBase.LetterDataType.BUREAU_ADDRESS5, 40);
         assertThat(testLetter.getLetterString()).isEqualTo(LetterTestUtils.pad("BUREAU_ADDRESS_5", 40));
@@ -292,8 +306,8 @@ class LetterBaseTest {
     @Test
     void bureauAddress6IsCorrect() {
         LetterBase testLetter = new LetterBase(testContextBuilder()
-                                                   .bureauLocation(LetterTestUtils.testBureauLocation())
-                                                   .build());
+            .bureauLocation(LetterTestUtils.testBureauLocation())
+            .build());
 
         testLetter.addData(LetterBase.LetterDataType.BUREAU_ADDRESS6, 40);
         assertThat(testLetter.getLetterString()).isEqualTo(LetterTestUtils.pad("BUREAU_ADDRESS_6", 40));
@@ -302,8 +316,8 @@ class LetterBaseTest {
     @Test
     void bureauPostcodeIsCorrect() {
         LetterBase testLetter = new LetterBase(testContextBuilder()
-                                                   .bureauLocation(LetterTestUtils.testBureauLocation())
-                                                   .build());
+            .bureauLocation(LetterTestUtils.testBureauLocation())
+            .build());
 
         testLetter.addData(LetterBase.LetterDataType.BUREAU_POSTCODE, 40);
         assertThat(testLetter.getLetterString()).isEqualTo(LetterTestUtils.pad("SE1 0YG", 40));
@@ -312,8 +326,8 @@ class LetterBaseTest {
     @Test
     void bureauPhoneIsCorrect() {
         LetterBase testLetter = new LetterBase(testContextBuilder()
-                                                   .bureauLocation(LetterTestUtils.testBureauLocation())
-                                                   .build());
+            .bureauLocation(LetterTestUtils.testBureauLocation())
+            .build());
 
         testLetter.addData(LetterBase.LetterDataType.BUREAU_PHONE, 40);
         assertThat(testLetter.getLetterString()).isEqualTo(LetterTestUtils.pad("0845 3555567", 40));
@@ -322,8 +336,8 @@ class LetterBaseTest {
     @Test
     void bureauFaxIsBlank() {
         LetterBase testLetter = new LetterBase(testContextBuilder()
-                                                   .bureauLocation(LetterTestUtils.testBureauLocation())
-                                                   .build());
+            .bureauLocation(LetterTestUtils.testBureauLocation())
+            .build());
 
         testLetter.addData(LetterBase.LetterDataType.BUREAU_FAX, 40);
         // Fax is deprecated and always empty
@@ -333,8 +347,8 @@ class LetterBaseTest {
     @Test
     void bureauSignatoryIsCorrect() {
         LetterBase testLetter = new LetterBase(testContextBuilder()
-                                                   .bureauLocation(LetterTestUtils.testBureauLocation())
-                                                   .build());
+            .bureauLocation(LetterTestUtils.testBureauLocation())
+            .build());
 
         testLetter.addData(LetterBase.LetterDataType.BUREAU_SIGNATORY, 40);
         assertThat(testLetter.getLetterString()).isEqualTo(LetterTestUtils.pad("JURY MANAGER", 40));
@@ -375,8 +389,8 @@ class LetterBaseTest {
     @Test
     void timeOfAttendanceIsCorrect() {
         LetterBase testLetter = new LetterBase(testContextBuilder()
-                                                   .courtLocation(LetterTestUtils.testCourtLocation())
-                                                   .build());
+            .courtLocation(LetterTestUtils.testCourtLocation())
+            .build());
 
         testLetter.addData(LetterBase.LetterDataType.TIME_OF_ATTENDANCE, 40);
         assertThat(testLetter.getLetterString()).isEqualTo(LetterTestUtils.pad("10:00", 40));
@@ -385,8 +399,8 @@ class LetterBaseTest {
     @Test
     void deferralTimeIsCorrect() {
         LetterBase testLetter = new LetterBase(testContextBuilder()
-                                                   .courtLocation(LetterTestUtils.testCourtLocation())
-                                                   .build());
+            .courtLocation(LetterTestUtils.testCourtLocation())
+            .build());
 
         testLetter.addData(LetterBase.LetterDataType.DEFERRAL_TIME, 40);
         assertThat(testLetter.getLetterString()).isEqualTo(LetterTestUtils.pad("10:00", 40));
@@ -494,7 +508,7 @@ class LetterBaseTest {
         final String additionalInformation =
             "This is the additional information for the request additional information letter";
         LetterBase testLetter = new LetterBase(testContextBuilder()
-                                                   .additionalInformation(additionalInformation).build());
+            .additionalInformation(additionalInformation).build());
 
         testLetter.addData(LetterBase.LetterDataType.ADDITIONAL_INFORMATION, 210);
         assertThat(testLetter.getLetterString())
@@ -504,8 +518,8 @@ class LetterBaseTest {
     @Test
     void welshCourtNameIsCorrect() {
         LetterBase testLetter = new LetterBase(testContextBuilder()
-                                                   .welshCourtLocation(LetterTestUtils.testWelshCourtLocation())
-                                                   .build());
+            .welshCourtLocation(LetterTestUtils.testWelshCourtLocation())
+            .build());
 
         testLetter.addData(LetterBase.LetterDataType.WELSH_COURT_NAME, 40);
         assertThat(testLetter.getLetterString()).isEqualTo(LetterTestUtils.pad("ABERTAWE", 40));
@@ -514,8 +528,8 @@ class LetterBaseTest {
     @Test
     void welshCourtAddress1IsCorrect() {
         LetterBase testLetter = new LetterBase(testContextBuilder()
-                                                   .welshCourtLocation(LetterTestUtils.testWelshCourtLocation())
-                                                   .build());
+            .welshCourtLocation(LetterTestUtils.testWelshCourtLocation())
+            .build());
 
         testLetter.addData(LetterBase.LetterDataType.WELSH_COURT_ADDRESS1, 40);
         assertThat(testLetter.getLetterString()).isEqualTo(LetterTestUtils.pad("Y LLYSOEDD BARN", 40));
@@ -524,8 +538,8 @@ class LetterBaseTest {
     @Test
     void welshCourtAddress2IsCorrect() {
         LetterBase testLetter = new LetterBase(testContextBuilder()
-                                                   .welshCourtLocation(LetterTestUtils.testWelshCourtLocation())
-                                                   .build());
+            .welshCourtLocation(LetterTestUtils.testWelshCourtLocation())
+            .build());
 
         testLetter.addData(LetterBase.LetterDataType.WELSH_COURT_ADDRESS2, 40);
         assertThat(testLetter.getLetterString()).isEqualTo(LetterTestUtils.pad("LON SAN HELEN", 40));
@@ -534,8 +548,8 @@ class LetterBaseTest {
     @Test
     void welshCourtAddress3IsCorrect() {
         LetterBase testLetter = new LetterBase(testContextBuilder()
-                                                   .welshCourtLocation(LetterTestUtils.testWelshCourtLocation())
-                                                   .build());
+            .welshCourtLocation(LetterTestUtils.testWelshCourtLocation())
+            .build());
 
         testLetter.addData(LetterBase.LetterDataType.WELSH_COURT_ADDRESS3, 40);
         assertThat(testLetter.getLetterString()).isEqualTo(LetterTestUtils.pad("ABERTAWE", 40));
@@ -544,8 +558,8 @@ class LetterBaseTest {
     @Test
     void welshCourtAddress4IsCorrect() {
         LetterBase testLetter = new LetterBase(testContextBuilder()
-                                                   .welshCourtLocation(LetterTestUtils.testWelshCourtLocation())
-                                                   .build());
+            .welshCourtLocation(LetterTestUtils.testWelshCourtLocation())
+            .build());
 
         testLetter.addData(LetterBase.LetterDataType.WELSH_COURT_ADDRESS4, 40);
         assertThat(testLetter.getLetterString()).isEqualTo(LetterTestUtils.pad("WELSH_COURT_ADDRESS_4", 40));
@@ -554,8 +568,8 @@ class LetterBaseTest {
     @Test
     void welshCourtAddress5IsCorrect() {
         LetterBase testLetter = new LetterBase(testContextBuilder()
-                                                   .welshCourtLocation(LetterTestUtils.testWelshCourtLocation())
-                                                   .build());
+            .welshCourtLocation(LetterTestUtils.testWelshCourtLocation())
+            .build());
 
         testLetter.addData(LetterBase.LetterDataType.WELSH_COURT_ADDRESS5, 40);
         assertThat(testLetter.getLetterString()).isEqualTo(LetterTestUtils.pad("WELSH_COURT_ADDRESS_5", 40));
@@ -564,8 +578,8 @@ class LetterBaseTest {
     @Test
     void welshCourtAddress6IsCorrect() {
         LetterBase testLetter = new LetterBase(testContextBuilder()
-                                                   .welshCourtLocation(LetterTestUtils.testWelshCourtLocation())
-                                                   .build());
+            .welshCourtLocation(LetterTestUtils.testWelshCourtLocation())
+            .build());
 
         testLetter.addData(LetterBase.LetterDataType.WELSH_COURT_ADDRESS6, 40);
         assertThat(testLetter.getLetterString()).isEqualTo(LetterTestUtils.pad("WELSH_COURT_ADDRESS_6", 40));

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/PostponeLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/PostponeLetterTest.java
@@ -4,16 +4,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.juror.api.moj.domain.FormCode;
-import uk.gov.hmcts.juror.api.moj.exception.MojException;
 import uk.gov.hmcts.juror.api.moj.xerox.letters.PostponeLetter;
-import uk.gov.hmcts.juror.api.testsupport.DisableIfWeekend;
 
 import java.time.LocalDate;
 import java.time.Month;
-import java.util.Calendar;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @ExtendWith(SpringExtension.class)
 public class PostponeLetterTest extends AbstractLetterTest {
@@ -84,23 +80,18 @@ public class PostponeLetterTest extends AbstractLetterTest {
         final LocalDate date = LocalDate.of(2017, Month.FEBRUARY, 6);
         setupEnglishExpectedResult();
         PostponeLetter postponeLetter = new PostponeLetter(LetterTestUtils.testJurorPool(date),
-                                                        LetterTestUtils.testCourtLocation(),
-                                                        LetterTestUtils.testBureauLocation());
+            LetterTestUtils.testCourtLocation(),
+            LetterTestUtils.testBureauLocation());
 
-        int dayOfTheWeek = Calendar.getInstance().get(Calendar.DAY_OF_WEEK);
-        if (dayOfTheWeek == Calendar.SATURDAY || dayOfTheWeek == Calendar.SUNDAY) {
-            assertThatExceptionOfType(MojException.BusinessRuleViolation.class)
-                .isThrownBy(postponeLetter::getLetterString);
-        } else {
-            assertThat(postponeLetter.getLetterString()).isEqualTo(getExpectedEnglishResult());
-            assertThat(postponeLetter.getFormCode()).isEqualTo(FormCode.ENG_POSTPONE.getCode());
-            assertThat(postponeLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testJuror().getJurorNumber());
 
-            // Fax number is always empty
-            assertThat(postponeLetter.getData().get(11).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
-            // Juror address 6 is always empty
-            assertThat(postponeLetter.getData().get(20).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(35));
-        }
+        assertThat(postponeLetter.getLetterString()).isEqualTo(getExpectedEnglishResult());
+        assertThat(postponeLetter.getFormCode()).isEqualTo(FormCode.ENG_POSTPONE.getCode());
+        assertThat(postponeLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testJuror().getJurorNumber());
+
+        // Fax number is always empty
+        assertThat(postponeLetter.getData().get(11).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
+        // Juror address 6 is always empty
+        assertThat(postponeLetter.getData().get(20).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(35));
     }
 
     @Test
@@ -109,34 +100,29 @@ public class PostponeLetterTest extends AbstractLetterTest {
         final LocalDate date = LocalDate.of(2017, Month.FEBRUARY, 6);
         setupWelshExpectedResult();
         PostponeLetter postponeLetter = new PostponeLetter(LetterTestUtils.testWelshJurorPool(date),
-                                                        LetterTestUtils.testCourtLocation(),
-                                                        LetterTestUtils.testBureauLocation(),
-                                                        LetterTestUtils.testWelshCourtLocation());
+            LetterTestUtils.testCourtLocation(),
+            LetterTestUtils.testBureauLocation(),
+            LetterTestUtils.testWelshCourtLocation());
 
-        int dayOfTheWeek = Calendar.getInstance().get(Calendar.DAY_OF_WEEK);
-        if (dayOfTheWeek == Calendar.SATURDAY || dayOfTheWeek == Calendar.SUNDAY) {
-            assertThatExceptionOfType(MojException.BusinessRuleViolation.class)
-                .isThrownBy(postponeLetter::getLetterString);
-        } else {
-            assertThat(postponeLetter.getLetterString()).isEqualTo(getExpectedWelshResult());
-            assertThat(postponeLetter.getFormCode()).isEqualTo(FormCode.BI_POSTPONE.getCode());
-            assertThat(postponeLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testWelshJuror().getJurorNumber());
 
-            // Fax number is always empty
-            assertThat(postponeLetter.getData().get(11).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
-            // Juror address 6 is always empty
-            assertThat(postponeLetter.getData().get(20).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(35));
-        }
+        assertThat(postponeLetter.getLetterString()).isEqualTo(getExpectedWelshResult());
+        assertThat(postponeLetter.getFormCode()).isEqualTo(FormCode.BI_POSTPONE.getCode());
+        assertThat(postponeLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testWelshJuror().getJurorNumber());
+
+        // Fax number is always empty
+        assertThat(postponeLetter.getData().get(11).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
+        // Juror address 6 is always empty
+        assertThat(postponeLetter.getData().get(20).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(35));
+
     }
 
     @Test
-    @DisableIfWeekend
     void confirmWelshWithoutWelshCourtProducesEnglishOutput() {
         final LocalDate date = LocalDate.of(2017, Month.FEBRUARY, 6);
         setupEnglishExpectedResult();
         PostponeLetter postponeLetter = new PostponeLetter(LetterTestUtils.testWelshJurorPool(date),
-                                                        LetterTestUtils.testCourtLocation(),
-                                                        LetterTestUtils.testBureauLocation());
+            LetterTestUtils.testCourtLocation(),
+            LetterTestUtils.testBureauLocation());
         assertThat(postponeLetter.getLetterString()).isEqualTo(getExpectedEnglishResult());
     }
 }

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/RequestInfoLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/RequestInfoLetterTest.java
@@ -4,16 +4,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.juror.api.moj.domain.FormCode;
-import uk.gov.hmcts.juror.api.moj.exception.MojException;
 import uk.gov.hmcts.juror.api.moj.xerox.letters.RequestInfoLetter;
-import uk.gov.hmcts.juror.api.testsupport.DisableIfWeekend;
 
 import java.time.LocalDate;
 import java.time.Month;
-import java.util.Calendar;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @ExtendWith(SpringExtension.class)
 class RequestInfoLetterTest extends AbstractLetterTest {
@@ -85,26 +81,21 @@ class RequestInfoLetterTest extends AbstractLetterTest {
         final LocalDate date = LocalDate.of(2017, Month.FEBRUARY, 6);
         setupEnglishExpectedResult();
         RequestInfoLetter requestInfoLetter = new RequestInfoLetter(LetterTestUtils.testJurorPool(date),
-                                                        additionalInformation,
-                                                        LetterTestUtils.testCourtLocation(),
-                                                        LetterTestUtils.testBureauLocation());
+            additionalInformation,
+            LetterTestUtils.testCourtLocation(),
+            LetterTestUtils.testBureauLocation());
 
-        int dayOfTheWeek = Calendar.getInstance().get(Calendar.DAY_OF_WEEK);
-        if (dayOfTheWeek == Calendar.SATURDAY || dayOfTheWeek == Calendar.SUNDAY) {
-            assertThatExceptionOfType(MojException.BusinessRuleViolation.class)
-                .isThrownBy(requestInfoLetter::getLetterString);
-        } else {
-            assertThat(requestInfoLetter.getLetterString()).isEqualTo(getExpectedEnglishResult());
-            assertThat(requestInfoLetter.getFormCode()).isEqualTo(FormCode.ENG_REQUESTINFO.getCode());
-            assertThat(requestInfoLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testJuror().getJurorNumber());
 
-            // Fax number is always empty
-            assertThat(requestInfoLetter.getData().get(11).getFormattedString())
-                .isEqualTo(LetterTestUtils.emptyField(12));
-            // Juror address 6 is always empty
-            assertThat(requestInfoLetter.getData().get(21).getFormattedString())
-                .isEqualTo(LetterTestUtils.emptyField(35));
-        }
+        assertThat(requestInfoLetter.getLetterString()).isEqualTo(getExpectedEnglishResult());
+        assertThat(requestInfoLetter.getFormCode()).isEqualTo(FormCode.ENG_REQUESTINFO.getCode());
+        assertThat(requestInfoLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testJuror().getJurorNumber());
+
+        // Fax number is always empty
+        assertThat(requestInfoLetter.getData().get(11).getFormattedString())
+            .isEqualTo(LetterTestUtils.emptyField(12));
+        // Juror address 6 is always empty
+        assertThat(requestInfoLetter.getData().get(21).getFormattedString())
+            .isEqualTo(LetterTestUtils.emptyField(35));
     }
 
     @Test
@@ -113,38 +104,31 @@ class RequestInfoLetterTest extends AbstractLetterTest {
         final LocalDate date = LocalDate.of(2017, Month.FEBRUARY, 6);
         setupWelshExpectedResult();
         RequestInfoLetter requestInfoLetter = new RequestInfoLetter(LetterTestUtils.testWelshJurorPool(date),
-                                                        additionalInformation,
-                                                        LetterTestUtils.testCourtLocation(),
-                                                        LetterTestUtils.testBureauLocation(),
-                                                        LetterTestUtils.testWelshCourtLocation());
+            additionalInformation,
+            LetterTestUtils.testCourtLocation(),
+            LetterTestUtils.testBureauLocation(),
+            LetterTestUtils.testWelshCourtLocation());
 
-        int dayOfTheWeek = Calendar.getInstance().get(Calendar.DAY_OF_WEEK);
-        if (dayOfTheWeek == Calendar.SATURDAY || dayOfTheWeek == Calendar.SUNDAY) {
-            assertThatExceptionOfType(MojException.BusinessRuleViolation.class)
-                .isThrownBy(requestInfoLetter::getLetterString);
-        } else {
-            assertThat(requestInfoLetter.getLetterString()).isEqualTo(getExpectedWelshResult());
-            assertThat(requestInfoLetter.getFormCode()).isEqualTo(FormCode.BI_REQUESTINFO.getCode());
-            assertThat(requestInfoLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testWelshJuror().getJurorNumber());
+        assertThat(requestInfoLetter.getLetterString()).isEqualTo(getExpectedWelshResult());
+        assertThat(requestInfoLetter.getFormCode()).isEqualTo(FormCode.BI_REQUESTINFO.getCode());
+        assertThat(requestInfoLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testWelshJuror().getJurorNumber());
 
-            // Fax number is always empty
-            assertThat(requestInfoLetter.getData().get(11).getFormattedString())
-                .isEqualTo(LetterTestUtils.emptyField(12));
-            // Juror address 6 is always empty
-            assertThat(requestInfoLetter.getData().get(21).getFormattedString())
-                .isEqualTo(LetterTestUtils.emptyField(35));
-        }
+        // Fax number is always empty
+        assertThat(requestInfoLetter.getData().get(11).getFormattedString())
+            .isEqualTo(LetterTestUtils.emptyField(12));
+        // Juror address 6 is always empty
+        assertThat(requestInfoLetter.getData().get(21).getFormattedString())
+            .isEqualTo(LetterTestUtils.emptyField(35));
     }
 
     @Test
-    @DisableIfWeekend
     void confirmWelshWithoutWelshCourtProducesEnglishOutput() {
         final LocalDate date = LocalDate.of(2017, Month.FEBRUARY, 6);
         setupEnglishExpectedResult();
         RequestInfoLetter requestInfoLetter = new RequestInfoLetter(LetterTestUtils.testWelshJurorPool(date),
-                                                        additionalInformation,
-                                                        LetterTestUtils.testCourtLocation(),
-                                                        LetterTestUtils.testBureauLocation());
+            additionalInformation,
+            LetterTestUtils.testCourtLocation(),
+            LetterTestUtils.testBureauLocation());
         assertThat(requestInfoLetter.getLetterString()).isEqualTo(getExpectedEnglishResult());
     }
 }

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/SummonsLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/SummonsLetterTest.java
@@ -4,16 +4,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.juror.api.moj.domain.FormCode;
-import uk.gov.hmcts.juror.api.moj.exception.MojException;
 import uk.gov.hmcts.juror.api.moj.xerox.letters.SummonsLetter;
-import uk.gov.hmcts.juror.api.testsupport.DisableIfWeekend;
 
 import java.time.LocalDate;
 import java.time.Month;
-import java.util.Calendar;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @ExtendWith(SpringExtension.class)
 class SummonsLetterTest extends AbstractLetterTest {
@@ -122,21 +118,17 @@ class SummonsLetterTest extends AbstractLetterTest {
             LetterTestUtils.testCourtLocation(),
             LetterTestUtils.testBureauLocation());
 
-        int dayOfTheWeek = Calendar.getInstance().get(Calendar.DAY_OF_WEEK);
-        if (dayOfTheWeek == Calendar.SATURDAY || dayOfTheWeek == Calendar.SUNDAY) {
-            assertThatExceptionOfType(MojException.BusinessRuleViolation.class)
-                .isThrownBy(summonsLetter::getLetterString);
-        } else {
-            assertThat(summonsLetter.getLetterString()).isEqualTo(getExpectedEnglishResult());
-            assertThat(summonsLetter.getFormCode()).isEqualTo(FormCode.ENG_SUMMONS.getCode());
-            assertThat(summonsLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testJuror().getJurorNumber());
 
-            // Juror address 6 is always empty
-            assertThat(summonsLetter.getData().get(9).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(35));
-            // Fax number is always empty
-            assertThat(summonsLetter.getData().get(27).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
-            assertThat(summonsLetter.getData().get(38).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
-        }
+        assertThat(summonsLetter.getLetterString()).isEqualTo(getExpectedEnglishResult());
+        assertThat(summonsLetter.getFormCode()).isEqualTo(FormCode.ENG_SUMMONS.getCode());
+        assertThat(summonsLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testJuror().getJurorNumber());
+
+        // Juror address 6 is always empty
+        assertThat(summonsLetter.getData().get(9).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(35));
+        // Fax number is always empty
+        assertThat(summonsLetter.getData().get(27).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
+        assertThat(summonsLetter.getData().get(38).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
+
     }
 
     @Test
@@ -149,25 +141,19 @@ class SummonsLetterTest extends AbstractLetterTest {
             LetterTestUtils.testBureauLocation(),
             LetterTestUtils.testWelshCourtLocation());
 
-        int dayOfTheWeek = Calendar.getInstance().get(Calendar.DAY_OF_WEEK);
-        if (dayOfTheWeek == Calendar.SATURDAY || dayOfTheWeek == Calendar.SUNDAY) {
-            assertThatExceptionOfType(MojException.BusinessRuleViolation.class)
-                .isThrownBy(summonsLetter::getLetterString);
-        } else {
-            assertThat(summonsLetter.getLetterString()).isEqualTo(getExpectedWelshResult());
-            assertThat(summonsLetter.getFormCode()).isEqualTo(FormCode.BI_SUMMONS.getCode());
-            assertThat(summonsLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testWelshJuror().getJurorNumber());
+        assertThat(summonsLetter.getLetterString()).isEqualTo(getExpectedWelshResult());
+        assertThat(summonsLetter.getFormCode()).isEqualTo(FormCode.BI_SUMMONS.getCode());
+        assertThat(summonsLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testWelshJuror().getJurorNumber());
 
-            // Juror address 6 is always empty
-            assertThat(summonsLetter.getData().get(9).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(35));
-            // Fax number is always empty
-            assertThat(summonsLetter.getData().get(27).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
-            assertThat(summonsLetter.getData().get(38).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
-        }
+        // Juror address 6 is always empty
+        assertThat(summonsLetter.getData().get(9).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(35));
+        // Fax number is always empty
+        assertThat(summonsLetter.getData().get(27).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
+        assertThat(summonsLetter.getData().get(38).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
+
     }
 
     @Test
-    @DisableIfWeekend
     void confirmWelshWithoutWelshCourtProducesEnglishOutput() {
         final LocalDate date = LocalDate.of(2017, Month.FEBRUARY, 6);
         setupEnglishExpectedResult();

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/SummonsReminderLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/SummonsReminderLetterTest.java
@@ -5,16 +5,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.juror.api.moj.domain.FormCode;
-import uk.gov.hmcts.juror.api.moj.exception.MojException;
 import uk.gov.hmcts.juror.api.moj.xerox.letters.SummonsReminderLetter;
-import uk.gov.hmcts.juror.api.testsupport.DisableIfWeekend;
 
 import java.time.LocalDate;
 import java.time.Month;
-import java.util.Calendar;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @ExtendWith(SpringExtension.class)
 class SummonsReminderLetterTest extends AbstractLetterTest {
@@ -85,22 +81,16 @@ class SummonsReminderLetterTest extends AbstractLetterTest {
             LetterTestUtils.testCourtLocation(),
             LetterTestUtils.testBureauLocation());
 
-        int dayOfTheWeek = Calendar.getInstance().get(Calendar.DAY_OF_WEEK);
-        if (dayOfTheWeek == Calendar.SATURDAY || dayOfTheWeek == Calendar.SUNDAY) {
-            assertThatExceptionOfType(MojException.BusinessRuleViolation.class)
-                .isThrownBy(summonsReminderLetter::getLetterString);
-        } else {
-            assertThat(summonsReminderLetter.getLetterString()).isEqualTo(getExpectedEnglishResult());
-            assertThat(summonsReminderLetter.getFormCode()).isEqualTo(FormCode.ENG_SUMMONS_REMINDER.getCode());
-            assertThat(summonsReminderLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testJuror().getJurorNumber());
+        assertThat(summonsReminderLetter.getLetterString()).isEqualTo(getExpectedEnglishResult());
+        assertThat(summonsReminderLetter.getFormCode()).isEqualTo(FormCode.ENG_SUMMONS_REMINDER.getCode());
+        assertThat(summonsReminderLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testJuror().getJurorNumber());
 
-            // Juror address 6 is always empty
-            assertThat(summonsReminderLetter.getData().get(11).getFormattedString())
-                .isEqualTo(LetterTestUtils.emptyField(12));
-            // Fax number is always empty
-            assertThat(summonsReminderLetter.getData().get(20).getFormattedString())
-                .isEqualTo(LetterTestUtils.emptyField(35));
-        }
+        // Juror address 6 is always empty
+        assertThat(summonsReminderLetter.getData().get(11).getFormattedString())
+            .isEqualTo(LetterTestUtils.emptyField(12));
+        // Fax number is always empty
+        assertThat(summonsReminderLetter.getData().get(20).getFormattedString())
+            .isEqualTo(LetterTestUtils.emptyField(35));
     }
 
     @Test
@@ -114,27 +104,20 @@ class SummonsReminderLetterTest extends AbstractLetterTest {
                 LetterTestUtils.testBureauLocation(),
                 LetterTestUtils.testWelshCourtLocation());
 
-        int dayOfTheWeek = Calendar.getInstance().get(Calendar.DAY_OF_WEEK);
-        if (dayOfTheWeek == Calendar.SATURDAY || dayOfTheWeek == Calendar.SUNDAY) {
-            assertThatExceptionOfType(MojException.BusinessRuleViolation.class)
-                .isThrownBy(summonsReminderLetter::getLetterString);
-        } else {
-            assertThat(summonsReminderLetter.getLetterString()).isEqualTo(getExpectedWelshResult());
-            assertThat(summonsReminderLetter.getFormCode()).isEqualTo(FormCode.BI_SUMMONS_REMINDER.getCode());
-            assertThat(summonsReminderLetter.getJurorNumber()).isEqualTo(
-                LetterTestUtils.testWelshJuror().getJurorNumber());
+        assertThat(summonsReminderLetter.getLetterString()).isEqualTo(getExpectedWelshResult());
+        assertThat(summonsReminderLetter.getFormCode()).isEqualTo(FormCode.BI_SUMMONS_REMINDER.getCode());
+        assertThat(summonsReminderLetter.getJurorNumber()).isEqualTo(
+            LetterTestUtils.testWelshJuror().getJurorNumber());
 
-            // Juror address 6 is always empty
-            assertThat(summonsReminderLetter.getData().get(12).getFormattedString()).isEqualTo(
-                LetterTestUtils.emptyField(12));
-            // Fax number is always empty
-            assertThat(summonsReminderLetter.getData().get(21).getFormattedString()).isEqualTo(
-                LetterTestUtils.emptyField(35));
-        }
+        // Juror address 6 is always empty
+        assertThat(summonsReminderLetter.getData().get(12).getFormattedString()).isEqualTo(
+            LetterTestUtils.emptyField(12));
+        // Fax number is always empty
+        assertThat(summonsReminderLetter.getData().get(21).getFormattedString()).isEqualTo(
+            LetterTestUtils.emptyField(35));
     }
 
     @Test
-    @DisableIfWeekend
     void confirmWelshWithoutWelshCourtProducesEnglishOutput() {
         final LocalDate date = LocalDate.of(2017, Month.FEBRUARY, 6);
         setupEnglishExpectedResult();

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/WithdrawalLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/WithdrawalLetterTest.java
@@ -4,15 +4,12 @@ import org.junit.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.juror.api.moj.domain.FormCode;
-import uk.gov.hmcts.juror.api.moj.exception.MojException;
 import uk.gov.hmcts.juror.api.moj.xerox.letters.WithdrawalLetter;
 
 import java.time.LocalDate;
 import java.time.Month;
-import java.util.Calendar;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @ExtendWith(SpringExtension.class)
 public class WithdrawalLetterTest extends AbstractLetterTest {
@@ -83,22 +80,17 @@ public class WithdrawalLetterTest extends AbstractLetterTest {
             LetterTestUtils.testCourtLocation(),
             LetterTestUtils.testBureauLocation());
 
-        int dayOfTheWeek = Calendar.getInstance().get(Calendar.DAY_OF_WEEK);
-        if (dayOfTheWeek == Calendar.SATURDAY || dayOfTheWeek == Calendar.SUNDAY) {
-            assertThatExceptionOfType(MojException.BusinessRuleViolation.class)
-                .isThrownBy(withdrawalLetter::getLetterString);
-        } else {
-            assertThat(withdrawalLetter.getLetterString()).isEqualTo(getExpectedEnglishResult());
-            assertThat(withdrawalLetter.getFormCode()).isEqualTo(FormCode.ENG_WITHDRAWAL.getCode());
-            assertThat(withdrawalLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testJuror().getJurorNumber());
+        assertThat(withdrawalLetter.getLetterString()).isEqualTo(getExpectedEnglishResult());
+        assertThat(withdrawalLetter.getFormCode()).isEqualTo(FormCode.ENG_WITHDRAWAL.getCode());
+        assertThat(withdrawalLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testJuror().getJurorNumber());
 
-            // Fax number is always empty
-            assertThat(withdrawalLetter.getData().get(11).getFormattedString())
-                .isEqualTo(LetterTestUtils.emptyField(12));
-            // Juror address 6 is always empty
-            assertThat(withdrawalLetter.getData().get(20).getFormattedString())
-                .isEqualTo(LetterTestUtils.emptyField(35));
-        }
+        // Fax number is always empty
+        assertThat(withdrawalLetter.getData().get(11).getFormattedString())
+            .isEqualTo(LetterTestUtils.emptyField(12));
+        // Juror address 6 is always empty
+        assertThat(withdrawalLetter.getData().get(20).getFormattedString())
+            .isEqualTo(LetterTestUtils.emptyField(35));
+
     }
 
     @Test
@@ -111,23 +103,18 @@ public class WithdrawalLetterTest extends AbstractLetterTest {
             LetterTestUtils.testBureauLocation(),
             LetterTestUtils.testWelshCourtLocation());
 
-        int dayOfTheWeek = Calendar.getInstance().get(Calendar.DAY_OF_WEEK);
-        if (dayOfTheWeek == Calendar.SATURDAY || dayOfTheWeek == Calendar.SUNDAY) {
-            assertThatExceptionOfType(MojException.BusinessRuleViolation.class)
-                .isThrownBy(withdrawalLetter::getLetterString);
-        } else {
-            assertThat(withdrawalLetter.getLetterString()).isEqualTo(getExpectedWelshResult());
-            assertThat(withdrawalLetter.getFormCode()).isEqualTo(FormCode.BI_WITHDRAWAL.getCode());
-            assertThat(withdrawalLetter.getJurorNumber())
-                .isEqualTo(LetterTestUtils.testWelshJuror().getJurorNumber());
+        assertThat(withdrawalLetter.getLetterString()).isEqualTo(getExpectedWelshResult());
+        assertThat(withdrawalLetter.getFormCode()).isEqualTo(FormCode.BI_WITHDRAWAL.getCode());
+        assertThat(withdrawalLetter.getJurorNumber())
+            .isEqualTo(LetterTestUtils.testWelshJuror().getJurorNumber());
 
-            // Fax number is always empty
-            assertThat(withdrawalLetter.getData().get(11).getFormattedString())
-                .isEqualTo(LetterTestUtils.emptyField(12));
-            // Juror address 6 is always empty
-            assertThat(withdrawalLetter.getData().get(20).getFormattedString())
-                .isEqualTo(LetterTestUtils.emptyField(35));
-        }
+        // Fax number is always empty
+        assertThat(withdrawalLetter.getData().get(11).getFormattedString())
+            .isEqualTo(LetterTestUtils.emptyField(12));
+        // Juror address 6 is always empty
+        assertThat(withdrawalLetter.getData().get(20).getFormattedString())
+            .isEqualTo(LetterTestUtils.emptyField(35));
+
     }
 
 }


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-6312)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=393)


### Change description ###
I ran the tests over the weekend and noticed this test failed, citing “can not generate a letter on a weekend”. [~accountid:62306f3e50cceb0070797d12] is that correct? Should the bureau be prevented from generating letters at the weekend?

!image-20240226-102702.png|width=843,height=411!

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
