### PR TITLE
Mark as absent doesn't work from record attendance

### DIFF
--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorManagementControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorManagementControllerITest.java
@@ -35,6 +35,7 @@ import uk.gov.hmcts.juror.api.moj.domain.IJurorStatus;
 import uk.gov.hmcts.juror.api.moj.domain.PoliceCheck;
 import uk.gov.hmcts.juror.api.moj.domain.UserType;
 import uk.gov.hmcts.juror.api.moj.enumeration.AppearanceStage;
+import uk.gov.hmcts.juror.api.moj.enumeration.AttendanceType;
 import uk.gov.hmcts.juror.api.moj.enumeration.HistoryCodeMod;
 import uk.gov.hmcts.juror.api.moj.enumeration.jurormanagement.JurorStatusGroup;
 import uk.gov.hmcts.juror.api.moj.enumeration.jurormanagement.RetrieveAttendanceDetailsTag;
@@ -223,7 +224,6 @@ class JurorManagementControllerITest extends AbstractIntegrationTest {
         assertThat(appearance.getTimeIn()).isEqualTo(requestDto.getCheckInTime());
         assertThat(appearance.getTimeOut()).isEqualTo(requestDto.getCheckOutTime());
     }
-
 
 
     @Test
@@ -1510,10 +1510,13 @@ class JurorManagementControllerITest extends AbstractIntegrationTest {
             assertThat(summary.getDeleted()).isEqualTo(1L);
             assertThat(summary.getAdditionalInformation()).isBlank();
 
-            // verify attendance record no longer exists
-            List<Tuple> tuples =
-                appearanceRepository.retrieveAttendanceDetails(buildRetrieveAttendanceDetailsDto(jurors));
-            assertThat(tuples).size().isEqualTo(0);
+            // verify attendance record has been updated to absent longer exists
+            List<Appearance> appearances = appearanceRepository.findAllByCourtLocationLocCodeAndJurorNumber(
+                "415", JUROR7);
+
+            assertThat(appearances).size().isEqualTo(1);
+            assertThat(appearances.get(0).getAttendanceType()).isEqualTo(AttendanceType.ABSENT);
+
         }
 
         @Test

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceImpl.java
@@ -348,9 +348,11 @@ public class JurorAppearanceServiceImpl implements JurorAppearanceService {
         AppearanceId appearanceId = new AppearanceId(jurorNumber, commonData.getAttendanceDate(), courtLocation);
 
         AttendanceDetailsResponse.Summary summary;
-        Optional<Appearance> appearance = appearanceRepository.findById(appearanceId);
-        if (appearance.isPresent()) {
-            appearanceRepository.deleteById(appearanceId);
+        Optional<Appearance> appearanceOptional = appearanceRepository.findById(appearanceId);
+        if (appearanceOptional.isPresent()) {
+            Appearance appearance = appearanceOptional.get();
+            appearance.setAttendanceType(AttendanceType.ABSENT);
+            appearanceRepository.save(appearance);
             summary = AttendanceDetailsResponse.Summary.builder().deleted(1).build();
         } else {
             summary = AttendanceDetailsResponse.Summary.builder()


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-6969)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=403)


### Change description ###
Steps to reproduce (also commented)

* Check in juror to mark them down as listed as attending
* Click change link
* Click ‘delete attendance and mark as absent’
* Click yes on confirmation screen
* Go to juror record and check attendance table, 0 absences.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
