### PR TITLE
Sent to court comms does not pick up any valid requests as the logic is incorrect

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/JurorPoolQueries.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/JurorPoolQueries.java
@@ -30,7 +30,7 @@ public class JurorPoolQueries {
 
 
     public static BooleanExpression respondedStatus() {
-        return jurorDetail.jurorPool.status.status.eq(IJurorStatus.RESPONDED);
+        return jurorDetail.status.status.eq(IJurorStatus.RESPONDED);
     }
 
     /**
@@ -55,6 +55,10 @@ public class JurorPoolQueries {
         return jurorDetail.owner.eq(OWNER_IS_BUREAU);
     }
 
+    public static BooleanExpression jurorRecordNotWithBureau() {
+        return jurorDetail.owner.ne(OWNER_IS_BUREAU);
+    }
+
     /**
      * Query to match instance where an email exists.
      */
@@ -67,21 +71,20 @@ public class JurorPoolQueries {
      */
 
     public static BooleanExpression bureauToCourtTransferDate() {
-
-        LocalDate currentDateAtSixPm = LocalDateTime.now().plusHours(18L).toLocalDate();
+        LocalDate currentDate = LocalDate.now();
         log.info("Bureau To Court Transfer Date {}", jurorDetail.juror.bureauTransferDate);
-        log.info("Current Date at 6pm {}", currentDateAtSixPm);
-        return jurorDetail.juror.bureauTransferDate.after(
-            LocalDateTime.now().plusHours(18L).toLocalDate());
+        log.info("Current Date at 6pm {}", currentDate);
+        return jurorDetail.juror.bureauTransferDate.after(currentDate)
+            .or(jurorDetail.juror.bureauTransferDate.eq(currentDate));
     }
 
 
     public static BooleanExpression courtDateWithin4Wks() {
 
         //hearingDate(next_date) between now and now+28 days.
-        return jurorDetail.jurorPool.nextDate.between(
-            LocalDateTime.now().toLocalDate(),
-            LocalDateTime.now().plusDays(28L).toLocalDate());
+        return jurorDetail.nextDate.between(
+            LocalDate.now(),
+            LocalDate.now().plusDays(28L));
     }
 
     /**
@@ -95,9 +98,9 @@ public class JurorPoolQueries {
      * Identify all Pool Records for which a sent To Comms needs to be sent.
      */
     public static BooleanExpression awaitingSentToCourtComms() {
-        return jurorDetail.jurorPool.nextDate.after(LocalDateTime.now().toLocalDate())
+        return QJurorPool.jurorPool.nextDate.after(LocalDate.now())
             .and(respondedStatus())
-            .and(jurorRecordWithBureau())
+            .and(jurorRecordNotWithBureau())
             .and(sentToCourtCommsNotSent())
             .and(bureauToCourtTransferDate());
     }
@@ -129,7 +132,7 @@ public class JurorPoolQueries {
      * Query to match Excused PoolCourt instances.
      */
     public static BooleanExpression excusedStatus() {
-        return jurorDetail.jurorPool.status.status.eq(IJurorStatus.EXCUSED);
+        return jurorDetail.status.status.eq(IJurorStatus.EXCUSED);
     }
 
     /**


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7378)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=411)


### Change description ###
This needs looking at in potentially a couple of areas

* Seems to be looking for a juror_pool owned by bureau but that also has a transfer to court date set
* Also seems to be filtering on transfer time but we don’t actually store a time anymore just a date

Probably needs a full rework as there will be more than this

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
