### PR TITLE
Cronbatch excusal completed court comms does not pick up completed jurors

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/bureau/service/BureauBacklogAllocateServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/bureau/service/BureauBacklogAllocateServiceImpl.java
@@ -185,7 +185,7 @@ public class BureauBacklogAllocateServiceImpl implements BureauBacklogAllocateSe
         final List<DigitalResponse> allocation = new LinkedList<>();
 
         final Iterator<DigitalResponse> backlogItems = backlogData.iterator();
-        final LocalDate now = LocalDateTime.now().toLocalDate();
+        final LocalDate now = LocalDate.now();
 
         for (int j = 0;
              j < urgencyAllocateCount && backlogItems.hasNext();

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/JurorPoolQueries.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/JurorPoolQueries.java
@@ -30,7 +30,10 @@ public class JurorPoolQueries {
 
 
     public static BooleanExpression respondedStatus() {
-        return jurorDetail.jurorPool.status.status.eq(IJurorStatus.RESPONDED);
+        return jurorDetail.status.status.eq(IJurorStatus.RESPONDED);
+    }
+    public static BooleanExpression completedStatus() {
+        return jurorDetail.status.status.eq(IJurorStatus.COMPLETED);
     }
 
     /**
@@ -79,8 +82,8 @@ public class JurorPoolQueries {
     public static BooleanExpression courtDateWithin4Wks() {
 
         //hearingDate(next_date) between now and now+28 days.
-        return jurorDetail.jurorPool.nextDate.between(
-            LocalDateTime.now().toLocalDate(),
+        return jurorDetail.nextDate.between(
+            LocalDate.now(),
             LocalDateTime.now().plusDays(28L).toLocalDate());
     }
 
@@ -95,7 +98,7 @@ public class JurorPoolQueries {
      * Identify all Pool Records for which a sent To Comms needs to be sent.
      */
     public static BooleanExpression awaitingSentToCourtComms() {
-        return jurorDetail.jurorPool.nextDate.after(LocalDateTime.now().toLocalDate())
+        return jurorDetail.nextDate.after(LocalDate.now())
             .and(respondedStatus())
             .and(jurorRecordWithBureau())
             .and(sentToCourtCommsNotSent())
@@ -129,7 +132,7 @@ public class JurorPoolQueries {
      * Query to match Excused PoolCourt instances.
      */
     public static BooleanExpression excusedStatus() {
-        return jurorDetail.jurorPool.status.status.eq(IJurorStatus.EXCUSED);
+        return jurorDetail.status.status.eq(IJurorStatus.EXCUSED);
     }
 
     /**
@@ -147,15 +150,15 @@ public class JurorPoolQueries {
 
         return jurorDetail.juror.excusalDate.between(
             LocalDateTime.now().minusDays(3L).toLocalDate(),
-            LocalDateTime.now().toLocalDate());
+            LocalDate.now());
     }
 
     /**
      * Query COMPLETION_DATE between now and now minus SERVICE COMPLETION PARAMETER.
      */
     public static BooleanExpression completionDateBetweenSysdateCompletionParameter() {
-        return jurorDetail.juror.completionDate.between(LocalDateTime.now().minusDays(2L).toLocalDate(),
-            LocalDateTime.now().toLocalDate());
+        return jurorDetail.juror.completionDate.between(LocalDate.now().minusDays(2L),
+            LocalDate.now());
     }
 
     /**
@@ -182,7 +185,7 @@ public class JurorPoolQueries {
 
     public static BooleanExpression recordsForServiceCompletedComms() {
         return completionDateBetweenSysdateCompletionParameter()
-            .and(respondedStatus())
+            .and(completedStatus())
             .and(serviceCompCommsStatus())
             .and(completionDateNotNull());
 

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/JurorPoolQueries.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/JurorPoolQueries.java
@@ -32,6 +32,7 @@ public class JurorPoolQueries {
     public static BooleanExpression respondedStatus() {
         return jurorDetail.status.status.eq(IJurorStatus.RESPONDED);
     }
+
     public static BooleanExpression completedStatus() {
         return jurorDetail.status.status.eq(IJurorStatus.COMPLETED);
     }

--- a/src/test/java/uk/gov/hmcts/juror/api/bureau/service/JurorCommsRequestInformationLetterServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/bureau/service/JurorCommsRequestInformationLetterServiceImplTest.java
@@ -45,7 +45,7 @@ public class JurorCommsRequestInformationLetterServiceImplTest {
     List<BulkPrintDataNotifyComms> jurorCommsPrintFilesList = new LinkedList<>();
     List<BulkPrintData> printFileList = new LinkedList<>();
 
-    LocalDate currentDate = LocalDateTime.now().toLocalDate();
+    LocalDate currentDate = LocalDate.now();
 
     @Mock
     private BulkPrintDataNotifyCommsRepository jurorCommsPrintFilesRepository;

--- a/src/test/java/uk/gov/hmcts/juror/api/bureau/service/JurorCommsRequestInformationLetterServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/bureau/service/JurorCommsRequestInformationLetterServiceImplTest.java
@@ -19,7 +19,6 @@ import uk.gov.hmcts.juror.api.moj.repository.BulkPrintDataRepository;
 import uk.gov.hmcts.juror.api.moj.repository.JurorPoolRepository;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.LinkedList;
 import java.util.List;
 

--- a/src/test/java/uk/gov/hmcts/juror/api/juror/service/JurorServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/juror/service/JurorServiceImplTest.java
@@ -161,7 +161,7 @@ public class JurorServiceImplTest {
     @Test
     public void convertJurorResponseDtoToEntityTest() throws Exception {
         final String jurorNumber = "546547731";
-        final LocalDate dob = LocalDateTime.now().toLocalDate();
+        final LocalDate dob = LocalDate.now();
         final String title = "Dr";
         final String firstName = "Namey";
         final String lastName = "McName";


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7380)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=415)


### Change description ###
Believe this may be because the code looks for a completion date in the last 2 days but also a status of responded, I don’t think it’s possible for both of these to be true.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
