### PR TITLE
Update Trials List API to allow for no cap on return limit

### DIFF
--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/TrialControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/TrialControllerITest.java
@@ -22,6 +22,7 @@ import uk.gov.hmcts.juror.api.moj.controller.request.trial.EndTrialDto;
 import uk.gov.hmcts.juror.api.moj.controller.request.trial.JurorDetailRequestDto;
 import uk.gov.hmcts.juror.api.moj.controller.request.trial.ReturnJuryDto;
 import uk.gov.hmcts.juror.api.moj.controller.request.trial.TrialDto;
+import uk.gov.hmcts.juror.api.moj.controller.request.trial.TrialSearch;
 import uk.gov.hmcts.juror.api.moj.controller.response.trial.CourtroomsDto;
 import uk.gov.hmcts.juror.api.moj.controller.response.trial.JudgeDto;
 import uk.gov.hmcts.juror.api.moj.controller.response.trial.TrialListDto;
@@ -29,6 +30,8 @@ import uk.gov.hmcts.juror.api.moj.controller.response.trial.TrialSummaryDto;
 import uk.gov.hmcts.juror.api.moj.domain.Appearance;
 import uk.gov.hmcts.juror.api.moj.domain.IJurorStatus;
 import uk.gov.hmcts.juror.api.moj.domain.JurorPool;
+import uk.gov.hmcts.juror.api.moj.domain.PaginatedList;
+import uk.gov.hmcts.juror.api.moj.domain.SortMethod;
 import uk.gov.hmcts.juror.api.moj.domain.UserType;
 import uk.gov.hmcts.juror.api.moj.domain.trial.Panel;
 import uk.gov.hmcts.juror.api.moj.domain.trial.Trial;
@@ -42,7 +45,6 @@ import uk.gov.hmcts.juror.api.moj.repository.JurorPoolRepository;
 import uk.gov.hmcts.juror.api.moj.repository.trial.PanelRepository;
 import uk.gov.hmcts.juror.api.moj.repository.trial.TrialRepository;
 import uk.gov.hmcts.juror.api.moj.utils.PanelUtils;
-import uk.gov.hmcts.juror.api.utils.CustomPageImpl;
 
 import java.net.URI;
 import java.time.LocalDate;
@@ -303,20 +305,29 @@ class TrialControllerITest extends AbstractIntegrationTest {
     @Nested
     @SuppressWarnings("PMD.JUnitAssertionsShouldIncludeMessage")
     class TrialList {
-        static final String URL = "/api/v1/moj/trial/list?";
-        static final String URL_TRIAL_LIST = URL + "page_number=0&sort_by=trialNumber&sort_order=desc&is_active=false";
+        static final String URL = "/api/v1/moj/trial/list";
+
+        private TrialSearch getValidPayload() {
+            return TrialSearch.builder()
+                .pageNumber(1)
+                .pageLimit(25)
+                .sortField(TrialSearch.SortField.TRIAL_NUMBER)
+                .sortMethod(SortMethod.DESC)
+                .isActive(false)
+                .build();
+        }
 
         @Test
         void testGetTrialsDescOrder() {
             initialiseHeader(singletonList("415"), "415", COURT_USER);
 
-            ResponseEntity<CustomPageImpl<TrialListDto>> responseEntity = invokeService();
+            ResponseEntity<PaginatedList<TrialListDto>> responseEntity = invokeService();
 
-            CustomPageImpl<TrialListDto> responseBody = responseEntity.getBody();
+            PaginatedList<TrialListDto> responseBody = responseEntity.getBody();
 
             verifyResponseBody(responseBody, 14);
 
-            assertThat(responseBody.getContent())
+            assertThat(responseBody.getData())
                 .as("Expect list of trials to be 14")
                 .extracting(TrialListDto::getTrialNumber)
                 .containsExactly("T100000027", "T100000025",
@@ -338,14 +349,14 @@ class TrialControllerITest extends AbstractIntegrationTest {
         void testGetTrialsDuplicateTrialNumberPrimaryCourt() {
             initialiseHeader(singletonList("415"), "415", COURT_USER);
 
-            ResponseEntity<CustomPageImpl<TrialListDto>> responseEntity = invokeService();
+            ResponseEntity<PaginatedList<TrialListDto>> responseEntity = invokeService();
 
-            CustomPageImpl<TrialListDto> responseBody = responseEntity.getBody();
+            PaginatedList<TrialListDto> responseBody = responseEntity.getBody();
             assertThat(responseBody).isNotNull();
 
             verifyResponseBody(responseBody, 14);
 
-            assertThat(responseBody.getContent())
+            assertThat(responseBody.getData())
                 .as("Expect list of trials to be 14")
                 .extracting(TrialListDto::getTrialNumber, TrialListDto::getDefendants)
                 .containsExactly(
@@ -369,14 +380,14 @@ class TrialControllerITest extends AbstractIntegrationTest {
         void testGetTrialsDuplicateTrialNumberSecondaryCourt() {
             initialiseHeader(singletonList("462"), "415", COURT_USER);
 
-            ResponseEntity<CustomPageImpl<TrialListDto>> responseEntity = invokeService();
+            ResponseEntity<PaginatedList<TrialListDto>> responseEntity = invokeService();
 
-            CustomPageImpl<TrialListDto> responseBody = responseEntity.getBody();
+            PaginatedList<TrialListDto> responseBody = responseEntity.getBody();
             assertThat(responseBody).isNotNull();
 
             verifyResponseBody(responseBody, 15);
 
-            assertThat(responseBody.getContent())
+            assertThat(responseBody.getData())
                 .as("Expect list of trials to be 15")
                 .extracting(TrialListDto::getTrialNumber, TrialListDto::getDefendants)
                 .containsExactly(
@@ -402,24 +413,24 @@ class TrialControllerITest extends AbstractIntegrationTest {
             initialiseHeader(singletonList("400"), "400", BUREAU_USER);
 
             ResponseEntity<TrialListDto> responseEntity = restTemplate.exchange(
-                new RequestEntity<>(httpHeaders, GET, URI.create(URL_TRIAL_LIST)), TrialListDto.class);
+                new RequestEntity<>(getValidPayload(), httpHeaders, POST, URI.create(URL)), TrialListDto.class);
 
             assertThat(responseEntity.getStatusCode())
                 .as("Expect the request to get a list of trials to fail for Bureau users.")
                 .isEqualTo(FORBIDDEN);
         }
 
-        private void verifyResponseBody(CustomPageImpl<TrialListDto> responseBody, int listCount) {
+        private void verifyResponseBody(PaginatedList<TrialListDto> responseBody, int listCount) {
             assertThat(responseBody).isNotNull();
 
-            assertThat(responseBody.stream().count())
+            assertThat((long) responseBody.getData().size())
                 .as("Expect the response to return a list of " + listCount + " trials")
                 .isEqualTo(listCount);
         }
 
-        private ResponseEntity<CustomPageImpl<TrialListDto>> invokeService() {
-            ResponseEntity<CustomPageImpl<TrialListDto>> responseEntity = restTemplate.exchange(
-                new RequestEntity<>(httpHeaders, GET, URI.create(URL_TRIAL_LIST)),
+        private ResponseEntity<PaginatedList<TrialListDto>> invokeService() {
+            ResponseEntity<PaginatedList<TrialListDto>> responseEntity = restTemplate.exchange(
+                new RequestEntity<>(getValidPayload(), httpHeaders, POST, URI.create(URL)),
                 new ParameterizedTypeReference<>() {
                 });
 

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/TrialController.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/TrialController.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Page;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -24,13 +23,13 @@ import uk.gov.hmcts.juror.api.moj.controller.request.trial.EndTrialDto;
 import uk.gov.hmcts.juror.api.moj.controller.request.trial.JurorDetailRequestDto;
 import uk.gov.hmcts.juror.api.moj.controller.request.trial.ReturnJuryDto;
 import uk.gov.hmcts.juror.api.moj.controller.request.trial.TrialDto;
-import uk.gov.hmcts.juror.api.moj.controller.response.PageDto;
+import uk.gov.hmcts.juror.api.moj.controller.request.trial.TrialSearch;
 import uk.gov.hmcts.juror.api.moj.controller.response.trial.TrialListDto;
 import uk.gov.hmcts.juror.api.moj.controller.response.trial.TrialSummaryDto;
+import uk.gov.hmcts.juror.api.moj.domain.PaginatedList;
 import uk.gov.hmcts.juror.api.moj.exception.MojException;
 import uk.gov.hmcts.juror.api.moj.service.trial.TrialService;
 import uk.gov.hmcts.juror.api.moj.utils.SecurityUtil;
-import uk.gov.hmcts.juror.api.validation.TrialNumber;
 
 import java.util.List;
 
@@ -72,20 +71,12 @@ public class TrialController {
         return ResponseEntity.ok().body(trialSummaryDto);
     }
 
-    @GetMapping("/list")
+    @PostMapping("/list")
     @Operation(summary = "Get a list of all trials")
     @PreAuthorize(SecurityUtil.IS_COURT)
-    public ResponseEntity<PageDto<TrialListDto>> getTrials(
-        @Parameter(hidden = true) @AuthenticationPrincipal BureauJwtPayload payload,
-        @RequestParam("page_number") @PathVariable("pageNumber") @Valid int pageNumber,
-        @RequestParam("sort_by") @PathVariable("sortBy") @Valid String sortBy,
-        @RequestParam("sort_order") @PathVariable("sortOrder") @Valid String sortOrder,
-        @RequestParam(value = "trial_number", required = false)
-        @TrialNumber @Valid String trialNumber,
-        @RequestParam("is_active") @PathVariable("isActive") @Valid Boolean isActive) {
-        Page<TrialListDto> trials = trialService
-            .getTrials(payload, pageNumber, sortBy, sortOrder, isActive, trialNumber);
-        return ResponseEntity.ok().body(new PageDto<>(trials));
+    public ResponseEntity<PaginatedList<TrialListDto>> getTrials(
+        @Valid @RequestBody TrialSearch trialSearch) {
+        return ResponseEntity.ok().body(trialService.getTrials(trialSearch));
     }
 
     @GetMapping("/summary")

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/request/trial/TrialSearch.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/request/trial/TrialSearch.java
@@ -1,0 +1,67 @@
+package uk.gov.hmcts.juror.api.moj.controller.request.trial;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.querydsl.core.types.Expression;
+import com.querydsl.jpa.impl.JPAQuery;
+import jakarta.validation.constraints.Min;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import uk.gov.hmcts.juror.api.moj.domain.SortMethod;
+import uk.gov.hmcts.juror.api.moj.domain.trial.QTrial;
+import uk.gov.hmcts.juror.api.moj.domain.trial.Trial;
+import uk.gov.hmcts.juror.api.moj.service.IsPageable;
+
+@Data
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class TrialSearch implements IsPageable {
+
+    private boolean isActive;
+
+    private String trialNumber;
+
+    @Min(1)
+    private long pageNumber;
+
+    @Min(1)
+    private long pageLimit;
+
+    private SortMethod sortMethod;
+
+    private TrialSearch.SortField sortField;
+
+    public void apply(JPAQuery<Trial> query) {
+        if (isActive) {
+            query.where(QTrial.trial.trialEndDate.isNull());
+        }
+
+        if (trialNumber != null) {
+            query.where(QTrial.trial.trialNumber.startsWith(trialNumber));
+        }
+    }
+
+
+    @Getter
+    public enum SortField implements SortMethod.HasComparableExpression {
+        TRIAL_NUMBER(QTrial.trial.trialNumber),
+        NAMES(QTrial.trial.description),
+        TRIAL_TYPE(QTrial.trial.trialType),
+        COURT_NAME(QTrial.trial.courtLocation.name),
+        COURT_CODE(QTrial.trial.courtLocation.locCode),
+        COURTROOM(QTrial.trial.courtroom.description),
+        JUDGE(QTrial.trial.judge.name),
+        START_DATE(QTrial.trial.trialStartDate),
+        END_DATE(QTrial.trial.trialEndDate),
+        JUROR_REQUESTED(QTrial.trial.jurorRequested),
+        JUROR_SENT(QTrial.trial.jurorsSent),
+        ANONYMOUS(QTrial.trial.anonymous);
+
+        private final Expression<? extends Comparable<?>> comparableExpression;
+
+        SortField(Expression<? extends Comparable<?>> comparableExpression) {
+            this.comparableExpression = comparableExpression;
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/trial/ITrialRepository.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/trial/ITrialRepository.java
@@ -1,19 +1,20 @@
 package uk.gov.hmcts.juror.api.moj.repository.trial;
 
 import com.querydsl.core.Tuple;
-import org.springframework.data.domain.Pageable;
+import uk.gov.hmcts.juror.api.moj.controller.request.trial.TrialSearch;
+import uk.gov.hmcts.juror.api.moj.domain.PaginatedList;
 import uk.gov.hmcts.juror.api.moj.domain.trial.Trial;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.function.Function;
 
 public interface ITrialRepository {
-    List<Trial> getListOfTrialsForCourtLocations(List<String> locCode, boolean isActiveFilter,
-                                                 String trialNumber, Pageable pageable);
+
+    <T> PaginatedList<T> getListOfTrials(TrialSearch trialSearch,
+                                         Function<Trial, T> dataMapper);
 
     List<Trial> getListOfActiveTrials(String locCode);
-
-    Long getTotalTrialsForCourtLocations(List<String> locCode, boolean isActiveFilter);
 
     List<Tuple> getActiveTrialsWithJurorCount(String locationCode, LocalDate attendanceDate);
 }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/trial/ITrialRepositoryImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/trial/ITrialRepositoryImpl.java
@@ -1,22 +1,24 @@
 package uk.gov.hmcts.juror.api.moj.repository.trial;
 
 import com.querydsl.core.Tuple;
-import com.querydsl.core.types.dsl.PathBuilderFactory;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.support.Querydsl;
+import uk.gov.hmcts.juror.api.moj.controller.request.trial.TrialSearch;
+import uk.gov.hmcts.juror.api.moj.domain.PaginatedList;
+import uk.gov.hmcts.juror.api.moj.domain.SortMethod;
 import uk.gov.hmcts.juror.api.moj.domain.trial.QPanel;
 import uk.gov.hmcts.juror.api.moj.domain.trial.QTrial;
 import uk.gov.hmcts.juror.api.moj.domain.trial.Trial;
 import uk.gov.hmcts.juror.api.moj.enumeration.trial.PanelResult;
+import uk.gov.hmcts.juror.api.moj.utils.PaginationUtil;
+import uk.gov.hmcts.juror.api.moj.utils.SecurityUtil;
 
 import java.time.LocalDate;
-import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 
 
 public class ITrialRepositoryImpl implements ITrialRepository {
@@ -27,44 +29,30 @@ public class ITrialRepositoryImpl implements ITrialRepository {
     private static final QTrial TRIAL = QTrial.trial;
     private static final QPanel PANEL = QPanel.panel;
 
-    private JPQLQuery<Trial> buildCommonQuery(String trialNumber, List<String> locCode, boolean isActiveFilter) {
-        JPQLQuery<Trial> query = new JPAQuery<>(entityManager);
+    @Override
+    public <T> PaginatedList<T> getListOfTrials(TrialSearch trialSearch,
+                                                Function<Trial, T> dataMapper) {
+        JPAQuery<Trial> query = getQueryFactory()
+            .select(TRIAL)
+            .from(TRIAL)
+            .where(TRIAL.courtLocation.locCode.in(SecurityUtil.getCourts()));
 
-        query.select(TRIAL).from(TRIAL).where(TRIAL.courtLocation.locCode.in(locCode));
-
-        if (isActiveFilter) {
-            query.where(TRIAL.trialEndDate.isNull());
-        }
-
-        if (trialNumber != null) {
-            query.where(TRIAL.trialNumber.startsWith(trialNumber));
-        }
-        return query;
+        return PaginationUtil.toPaginatedList(query, trialSearch,
+            TrialSearch.SortField.TRIAL_NUMBER,
+            SortMethod.DESC,
+            dataMapper, null);
     }
 
-    @Override
-    public List<Trial> getListOfTrialsForCourtLocations(List<String> locCode, boolean isActiveFilter,
-                                                        String trialNumber, Pageable pageable) {
-        Querydsl querydsl = new Querydsl(entityManager, new PathBuilderFactory().create(Trial.class));
-        return querydsl.applyPagination(pageable, buildCommonQuery(trialNumber, locCode, isActiveFilter)).fetch();
+    JPAQueryFactory getQueryFactory() {
+        return new JPAQueryFactory(entityManager);
     }
 
     @Override
     public List<Trial> getListOfActiveTrials(String locCode) {
-        return buildCommonQuery(null, Collections.singletonList(locCode), true).fetch();
-    }
-
-
-    @Override
-    public Long getTotalTrialsForCourtLocations(List<String> locCode, boolean isActiveFilter) {
         JPQLQuery<Trial> query = new JPAQuery<>(entityManager);
-
-        query.select(TRIAL).from(TRIAL).where(TRIAL.courtLocation.locCode.in(locCode));
-
-        if (isActiveFilter) {
-            query.where(TRIAL.trialEndDate.isNull());
-        }
-        return query.fetchCount();
+        query.select(TRIAL).from(TRIAL).where(TRIAL.courtLocation.locCode.eq(locCode));
+        query.where(TRIAL.trialEndDate.isNull());
+        return query.fetch();
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/trial/ITrialRepositoryImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/trial/ITrialRepositoryImpl.java
@@ -36,7 +36,7 @@ public class ITrialRepositoryImpl implements ITrialRepository {
             .select(TRIAL)
             .from(TRIAL)
             .where(TRIAL.courtLocation.locCode.in(SecurityUtil.getCourts()));
-
+        trialSearch.apply(query);
         return PaginationUtil.toPaginatedList(query, trialSearch,
             TrialSearch.SortField.TRIAL_NUMBER,
             SortMethod.DESC,

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/trial/TrialService.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/trial/TrialService.java
@@ -1,21 +1,21 @@
 package uk.gov.hmcts.juror.api.moj.service.trial;
 
-import org.springframework.data.domain.Page;
 import uk.gov.hmcts.juror.api.config.bureau.BureauJwtPayload;
 import uk.gov.hmcts.juror.api.moj.controller.request.trial.EndTrialDto;
 import uk.gov.hmcts.juror.api.moj.controller.request.trial.JurorDetailRequestDto;
 import uk.gov.hmcts.juror.api.moj.controller.request.trial.ReturnJuryDto;
 import uk.gov.hmcts.juror.api.moj.controller.request.trial.TrialDto;
+import uk.gov.hmcts.juror.api.moj.controller.request.trial.TrialSearch;
 import uk.gov.hmcts.juror.api.moj.controller.response.trial.TrialListDto;
 import uk.gov.hmcts.juror.api.moj.controller.response.trial.TrialSummaryDto;
+import uk.gov.hmcts.juror.api.moj.domain.PaginatedList;
 
 import java.util.List;
 
 public interface TrialService {
     TrialSummaryDto createTrial(BureauJwtPayload payload, TrialDto trialDto);
 
-    Page<TrialListDto> getTrials(BureauJwtPayload payload, int pageNumber, String sortBy, String sortOrder,
-                                 boolean isActive, String trialNumber);
+    PaginatedList<TrialListDto> getTrials(TrialSearch trialSearch);
 
     TrialSummaryDto getTrialSummary(BureauJwtPayload payload, String trialNo, String locCode);
 


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7437)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=419)


### Change description ###
Further changes needed to endpoint to get a list of trials, [GET /api/v1/moj/trial/list|http://localhost:8080/swagger-ui/index.html#/Trial%20Management/getTrials].

The trial selection page needs all active trials returned, the current endpoint is capped to 25.


!image-20240530-085711.png|width=50%,alt="image-20240530-085711.png"!



Discussed with [~accountid:712020:c60a5691-915b-44ae-af30-91be5d42156c] to add a query param for showAll=true which will remove the limit of 25 items being returned.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
