### PR TITLE
As a jury officer I need to be able to generate a unpaid attendance summary report (BE)

### DIFF
--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/report/grouped/UnpaidAttendanceSummaryReportITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/report/grouped/UnpaidAttendanceSummaryReportITest.java
@@ -24,6 +24,7 @@ import java.util.List;
     "/db/administration/createUsers.sql",
     "/db/mod/reports/UnpaidAttendanceSummaryReportITest_typical.sql"
 })
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 class UnpaidAttendanceSummaryReportITest extends AbstractGroupedReportControllerITest {
     @Autowired
     public UnpaidAttendanceSummaryReportITest(TestRestTemplate template) {
@@ -44,7 +45,6 @@ class UnpaidAttendanceSummaryReportITest extends AbstractGroupedReportController
     }
 
     @Test
-    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
     void positiveTypical() {
         testBuilder()
             .triggerValid()
@@ -53,7 +53,6 @@ class UnpaidAttendanceSummaryReportITest extends AbstractGroupedReportController
     }
 
     @Test
-    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
     void positiveTypicalWiderDateRange() {
         StandardReportRequest request = getValidPayload();
         request.setFromDate(LocalDate.of(2024, 1, 1));
@@ -66,7 +65,6 @@ class UnpaidAttendanceSummaryReportITest extends AbstractGroupedReportController
     }
 
     @Test
-    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
     void positiveTypicalNoData() {
         StandardReportRequest request = getValidPayload();
         request.setFromDate(LocalDate.of(2024, 12, 9));
@@ -79,7 +77,6 @@ class UnpaidAttendanceSummaryReportITest extends AbstractGroupedReportController
     }
 
     @Test
-    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
     void negativeUnauthorised() {
         testBuilder()
             .jwt(getBureauJwt())
@@ -88,7 +85,6 @@ class UnpaidAttendanceSummaryReportITest extends AbstractGroupedReportController
     }
 
     @Test
-    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
     void negativeInvalidPayloadMissingDate() {
         StandardReportRequest request = getValidPayload();
         request.setToDate(null);

--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/report/grouped/UnpaidAttendanceSummaryReportITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/report/grouped/UnpaidAttendanceSummaryReportITest.java
@@ -55,8 +55,8 @@ class UnpaidAttendanceSummaryReportITest extends AbstractGroupedReportController
     @Test
     void positiveTypicalWiderDateRange() {
         StandardReportRequest request = getValidPayload();
-        request.setFromDate(LocalDate.of(2024, 1, 1));
-        request.setToDate(LocalDate.of(2024, 12, 31));
+        request.setFromDate(LocalDate.of(2024, 10, 9));
+        request.setToDate(LocalDate.of(2024, 11, 12));
         testBuilder()
             .payload(request)
             .triggerValid()
@@ -183,12 +183,12 @@ class UnpaidAttendanceSummaryReportITest extends AbstractGroupedReportController
                 .add("date_to", StandardReportResponse.DataTypeValue.builder()
                     .displayName("Date To")
                     .dataType("LocalDate")
-                    .value("2024-12-31")
+                    .value("2024-11-12")
                     .build())
                 .add("date_from", StandardReportResponse.DataTypeValue.builder()
                     .displayName("Date From")
                     .dataType("LocalDate")
-                    .value("2024-01-01")
+                    .value("2024-10-09")
                     .build())
                 .add("court_name", StandardReportResponse.DataTypeValue.builder()
                     .displayName("Court Name")

--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/report/grouped/UnpaidAttendanceSummaryReportITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/report/grouped/UnpaidAttendanceSummaryReportITest.java
@@ -24,9 +24,6 @@ import java.util.List;
     "/db/administration/createUsers.sql",
     "/db/mod/reports/UnpaidAttendanceSummaryReportITest_typical.sql"
 })
-@SuppressWarnings({
-    "PMD.JUnitTestsShouldIncludeAssert", "PMD.LawOfDemeter"
-})
 class UnpaidAttendanceSummaryReportITest extends AbstractGroupedReportControllerITest {
     @Autowired
     public UnpaidAttendanceSummaryReportITest(TestRestTemplate template) {
@@ -47,6 +44,7 @@ class UnpaidAttendanceSummaryReportITest extends AbstractGroupedReportController
     }
 
     @Test
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
     void positiveTypical() {
         testBuilder()
             .triggerValid()
@@ -55,18 +53,20 @@ class UnpaidAttendanceSummaryReportITest extends AbstractGroupedReportController
     }
 
     @Test
-    void positiveTypicalDifferentDates() {
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+    void positiveTypicalWiderDateRange() {
         StandardReportRequest request = getValidPayload();
-        request.setFromDate(LocalDate.of(2024, 11, 9));
-        request.setToDate(LocalDate.of(2024, 11, 16));
+        request.setFromDate(LocalDate.of(2024, 1, 1));
+        request.setToDate(LocalDate.of(2024, 12, 31));
         testBuilder()
             .payload(request)
             .triggerValid()
             .responseConsumer(this::verifyAndRemoveReportCreated)
-            .assertEquals(getTypicalResponseChangedDates());
+            .assertEquals(getTypicalResponseWiderDateRange());
     }
 
     @Test
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
     void positiveTypicalNoData() {
         StandardReportRequest request = getValidPayload();
         request.setFromDate(LocalDate.of(2024, 12, 9));
@@ -79,6 +79,7 @@ class UnpaidAttendanceSummaryReportITest extends AbstractGroupedReportController
     }
 
     @Test
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
     void negativeUnauthorised() {
         testBuilder()
             .jwt(getBureauJwt())
@@ -87,6 +88,7 @@ class UnpaidAttendanceSummaryReportITest extends AbstractGroupedReportController
     }
 
     @Test
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
     void negativeInvalidPayloadMissingDate() {
         StandardReportRequest request = getValidPayload();
         request.setToDate(null);
@@ -98,7 +100,7 @@ class UnpaidAttendanceSummaryReportITest extends AbstractGroupedReportController
 
     private GroupedReportResponse getTypicalResponse() {
         return GroupedReportResponse.builder()
-            .groupBy(GroupByResponse.builder().name(DataType.POOL_NUMBER_BY_APPEARANCE.name()).build())
+            .groupBy(GroupByResponse.builder().name(DataType.ATTENDANCE_DATE.name()).build())
             .headings(new ReportHashMap<String, StandardReportResponse.DataTypeValue>()
                 .add("total_unpaid_attendances", StandardReportResponse.DataTypeValue.builder()
                     .displayName("Total Unpaid Attendances")
@@ -142,11 +144,7 @@ class UnpaidAttendanceSummaryReportITest extends AbstractGroupedReportController
                             .headings(null)
                             .build()))
                     .data(new GroupedTableData()
-                        .add("415230103", List.of(
-                            new ReportLinkedMap<String, Object>()
-                                .add("juror_number", "641500023")
-                                .add("first_name", "John3")
-                                .add("last_name", "Smith3"),
+                        .add("2024-10-10", List.of(
                             new ReportLinkedMap<String, Object>()
                                 .add("juror_number", "641500023")
                                 .add("first_name", "John3")
@@ -156,40 +154,45 @@ class UnpaidAttendanceSummaryReportITest extends AbstractGroupedReportController
                                 .add("first_name", "John4")
                                 .add("last_name", "Smith4"),
                             new ReportLinkedMap<String, Object>()
+                                .add("juror_number", "641500026")
+                                .add("first_name", "John6")
+                                .add("last_name", "Smith6")))
+                        .add("2024-10-11", List.of(
+                            new ReportLinkedMap<String, Object>()
+                                .add("juror_number", "641500023")
+                                .add("first_name", "John3")
+                                .add("last_name", "Smith3"),
+                            new ReportLinkedMap<String, Object>()
                                 .add("juror_number", "641500024")
                                 .add("first_name", "John4")
-                                .add("last_name", "Smith4")))
-                        .add("415230104", List.of(
+                                .add("last_name", "Smith4"),
                             new ReportLinkedMap<String, Object>()
                                 .add("juror_number", "641500026")
                                 .add("first_name", "John6")
-                                .add("last_name", "Smith6"),
-                            new ReportLinkedMap<String, Object>()
-                                .add("juror_number", "641500026")
-                                .add("first_name", "John6")
-                                .add("last_name", "Smith6"))))
+                                .add("last_name", "Smith6")
+                            )))
                     .build())
             .build();
     }
 
-    private GroupedReportResponse getTypicalResponseChangedDates() {
+    private GroupedReportResponse getTypicalResponseWiderDateRange() {
         return GroupedReportResponse.builder()
-            .groupBy(GroupByResponse.builder().name(DataType.POOL_NUMBER_BY_APPEARANCE.name()).build())
+            .groupBy(GroupByResponse.builder().name(DataType.ATTENDANCE_DATE.name()).build())
             .headings(new ReportHashMap<String, StandardReportResponse.DataTypeValue>()
                 .add("total_unpaid_attendances", StandardReportResponse.DataTypeValue.builder()
                     .displayName("Total Unpaid Attendances")
                     .dataType("Long")
-                    .value(6)
+                    .value(12)
                     .build())
                 .add("date_to", StandardReportResponse.DataTypeValue.builder()
                     .displayName("Date To")
                     .dataType("LocalDate")
-                    .value("2024-11-16")
+                    .value("2024-12-31")
                     .build())
                 .add("date_from", StandardReportResponse.DataTypeValue.builder()
                     .displayName("Date From")
                     .dataType("LocalDate")
-                    .value("2024-11-09")
+                    .value("2024-01-01")
                     .build())
                 .add("court_name", StandardReportResponse.DataTypeValue.builder()
                     .displayName("Court Name")
@@ -218,11 +221,7 @@ class UnpaidAttendanceSummaryReportITest extends AbstractGroupedReportController
                             .headings(null)
                             .build()))
                     .data(new GroupedTableData()
-                        .add("415230103", List.of(
-                            new ReportLinkedMap<String, Object>()
-                                .add("juror_number", "641500023")
-                                .add("first_name", "John3")
-                                .add("last_name", "Smith3"),
+                        .add("2024-10-10", List.of(
                             new ReportLinkedMap<String, Object>()
                                 .add("juror_number", "641500023")
                                 .add("first_name", "John3")
@@ -232,14 +231,44 @@ class UnpaidAttendanceSummaryReportITest extends AbstractGroupedReportController
                                 .add("first_name", "John4")
                                 .add("last_name", "Smith4"),
                             new ReportLinkedMap<String, Object>()
+                                .add("juror_number", "641500026")
+                                .add("first_name", "John6")
+                                .add("last_name", "Smith6")))
+                        .add("2024-10-11", List.of(
+                            new ReportLinkedMap<String, Object>()
+                                .add("juror_number", "641500023")
+                                .add("first_name", "John3")
+                                .add("last_name", "Smith3"),
+                            new ReportLinkedMap<String, Object>()
                                 .add("juror_number", "641500024")
                                 .add("first_name", "John4")
-                                .add("last_name", "Smith4")))
-                        .add("415230104", List.of(
+                                .add("last_name", "Smith4"),
                             new ReportLinkedMap<String, Object>()
                                 .add("juror_number", "641500026")
                                 .add("first_name", "John6")
-                                .add("last_name", "Smith6"),
+                                .add("last_name", "Smith6")))
+                        .add("2024-11-10", List.of(
+                            new ReportLinkedMap<String, Object>()
+                                .add("juror_number", "641500023")
+                                .add("first_name", "John3")
+                                .add("last_name", "Smith3"),
+                            new ReportLinkedMap<String, Object>()
+                                .add("juror_number", "641500024")
+                                .add("first_name", "John4")
+                                .add("last_name", "Smith4"),
+                            new ReportLinkedMap<String, Object>()
+                                .add("juror_number", "641500026")
+                                .add("first_name", "John6")
+                                .add("last_name", "Smith6")))
+                        .add("2024-11-11", List.of(
+                            new ReportLinkedMap<String, Object>()
+                                .add("juror_number", "641500023")
+                                .add("first_name", "John3")
+                                .add("last_name", "Smith3"),
+                            new ReportLinkedMap<String, Object>()
+                                .add("juror_number", "641500024")
+                                .add("first_name", "John4")
+                                .add("last_name", "Smith4"),
                             new ReportLinkedMap<String, Object>()
                                 .add("juror_number", "641500026")
                                 .add("first_name", "John6")
@@ -250,7 +279,7 @@ class UnpaidAttendanceSummaryReportITest extends AbstractGroupedReportController
 
     private GroupedReportResponse getTypicalResponseNoData() {
         return GroupedReportResponse.builder()
-            .groupBy(GroupByResponse.builder().name(DataType.POOL_NUMBER_BY_APPEARANCE.name()).build())
+            .groupBy(GroupByResponse.builder().name(DataType.ATTENDANCE_DATE.name()).build())
             .headings(new ReportHashMap<String, StandardReportResponse.DataTypeValue>()
                 .add("total_unpaid_attendances", StandardReportResponse.DataTypeValue.builder()
                     .displayName("Total Unpaid Attendances")

--- a/src/integration-test/resources/db/mod/reports/UnpaidAttendanceSummaryReportITest_typical.sql
+++ b/src/integration-test/resources/db/mod/reports/UnpaidAttendanceSummaryReportITest_typical.sql
@@ -8,45 +8,45 @@ values ('415', '415230103', '2023-01-05', 5, 5, 'CRO', '415', 'N', '2023-01-05 0
 insert into juror_mod.juror (juror_number, last_name, first_name, dob, no_def_pos, m_phone, w_phone, h_phone, h_email,
                              police_check, address_line_1, responded, postcode)
 values ('641500020', 'Smith0', 'John0', '1980-01-01', 0, '000000001', '000000002', '000000003',
-        '641500020@email.gov.uk', 'ELIGIBLE', 'addressLine1', true,'AB1 0CD'),
+        '641500020@email.gov.uk', 'ELIGIBLE', 'addressLine1', true, 'AB1 0CD'),
        ('641500021', 'Smith1', 'John1', '1980-01-01', 0, '100000001', '100000002', '100000003',
-        '641500021@email.gov.uk', 'ELIGIBLE', 'addressLine1', true,'AB1 1CD'),
+        '641500021@email.gov.uk', 'ELIGIBLE', 'addressLine1', true, 'AB1 1CD'),
        ('641500022', 'Smith2', 'John2', '1980-01-01', 0, '200000001', '200000002', '200000003',
-        '641500022@email.gov.uk', 'ELIGIBLE', 'addressLine1', true,'AB1 2CD'),
+        '641500022@email.gov.uk', 'ELIGIBLE', 'addressLine1', true, 'AB1 2CD'),
        ('641500023', 'Smith3', 'John3', '1980-01-01', 0, '300000001', '300000002', '300000003',
-        '641500023@email.gov.uk', 'ELIGIBLE', 'addressLine1', true,'AB1 3CD'),
+        '641500023@email.gov.uk', 'ELIGIBLE', 'addressLine1', true, 'AB1 3CD'),
        ('641500024', 'Smith4', 'John4', '1980-01-01', 0, '400000001', '400000002', '400000003',
-        '641500024@email.gov.uk', 'NOT_CHECKED', 'addressLine1', true,'AB1 4CD'),
+        '641500024@email.gov.uk', 'NOT_CHECKED', 'addressLine1', true, 'AB1 4CD'),
        ('641500025', 'Smith5', 'John5', '1980-01-01', 0, '500000001', '500000002', '500000003',
-        '641500025@email.gov.uk', 'INELIGIBLE', 'addressLine1', true,'AB1 5CD'),
+        '641500025@email.gov.uk', 'INELIGIBLE', 'addressLine1', true, 'AB1 5CD'),
        ('641500026', 'Smith6', 'John6', '1980-01-01', 0, '600000001', '600000002', '600000003',
-        '641500026@email.gov.uk', 'NOT_CHECKED', 'addressLine1', true,'AB1 6CD')
+        '641500026@email.gov.uk', 'NOT_CHECKED', 'addressLine1', true, 'AB1 6CD')
 ;
 
 -- create juror_pool associative records
-insert into juror_mod.juror_pool (owner, juror_number, pool_number, status, is_active, def_date,deferral_code)
-values ('415', '641500023', '415230103', 7, true, '2023-01-01 09:30:00.000','P'),
-       ('415', '641500024', '415230103', 7, true, '2023-01-02 09:30:00.000','P'),
-       ('415', '641500025', '415230104', 7, true, '2023-01-01 09:30:00.000','P'),
-       ('415', '641500026', '415230104', 7, true, '2023-01-02 09:30:00.000','P');
+insert into juror_mod.juror_pool (owner, juror_number, pool_number, status, is_active, def_date, deferral_code)
+values ('415', '641500023', '415230103', 7, true, '2023-01-01 09:30:00.000', 'P'),
+       ('415', '641500024', '415230103', 7, true, '2023-01-02 09:30:00.000', 'P'),
+       ('415', '641500025', '415230104', 7, true, '2023-01-01 09:30:00.000', 'P'),
+       ('415', '641500026', '415230104', 7, true, '2023-01-02 09:30:00.000', 'P');
 
 -- create appearance records
-insert into juror_mod.appearance (attendance_date,juror_number,pool_number,loc_code, time_in, misc_total_paid,
-appearance_stage, non_attendance, is_draft_expense) values
-('2024-10-10', '641500023', '415230103', '415','08:00',0,'EXPENSE_ENTERED',false, false),
-('2024-10-11', '641500023', '415230103', '415', '08:00',0,'EXPENSE_ENTERED',false, false),
-('2024-10-12', '641500024', '415230103', '415', '08:00',0,'EXPENSE_ENTERED',false, false),
-('2024-10-13', '641500024', '415230103', '415', '08:00',0,'EXPENSE_ENTERED',false, false),
-('2024-10-14', '641500026', '415230104', '415', '08:00',0,'EXPENSE_ENTERED',false, false),
-('2024-10-15', '641500026', '415230104', '415', '08:00',0,'EXPENSE_ENTERED',false, false);
+insert into juror_mod.appearance (attendance_date, juror_number, pool_number, loc_code, time_in, misc_total_paid,
+                                  appearance_stage, non_attendance, is_draft_expense)
+values ('2024-10-10', '641500023', '415230103', '415', '08:00', 0, 'EXPENSE_ENTERED', false, false),
+       ('2024-10-11', '641500023', '415230103', '415', '08:00', 0, 'EXPENSE_ENTERED', false, false),
+       ('2024-10-10', '641500024', '415230103', '415', '08:00', 0, 'EXPENSE_ENTERED', false, false),
+       ('2024-10-11', '641500024', '415230103', '415', '08:00', 0, 'EXPENSE_ENTERED', false, false),
+       ('2024-10-10', '641500026', '415230104', '415', '08:00', 0, 'EXPENSE_ENTERED', false, false),
+       ('2024-10-11', '641500026', '415230104', '415', '08:00', 0, 'EXPENSE_ENTERED', false, false);
 
 
 -- create appearance records alternate date
-insert into juror_mod.appearance (attendance_date,juror_number,pool_number,loc_code, time_in, misc_total_paid,
-appearance_stage, non_attendance, is_draft_expense) values
-('2024-11-10', '641500023', '415230103', '415','08:00',0,'EXPENSE_ENTERED',false, false),
-('2024-11-11', '641500023', '415230103', '415', '08:00',0,'EXPENSE_ENTERED',false, false),
-('2024-11-12', '641500024', '415230103', '415', '08:00',0,'EXPENSE_ENTERED',false, false),
-('2024-11-13', '641500024', '415230103', '415', '08:00',0,'EXPENSE_ENTERED',false, false),
-('2024-11-14', '641500026', '415230104', '415', '08:00',0,'EXPENSE_ENTERED',false, false),
-('2024-11-15', '641500026', '415230104', '415', '08:00',0,'EXPENSE_ENTERED',false, false);
+insert into juror_mod.appearance (attendance_date, juror_number, pool_number, loc_code, time_in, misc_total_paid,
+                                  appearance_stage, non_attendance, is_draft_expense)
+values ('2024-11-10', '641500023', '415230103', '415', '08:00', 0, 'EXPENSE_ENTERED', false, false),
+       ('2024-11-11', '641500023', '415230103', '415', '08:00', 0, 'EXPENSE_ENTERED', false, false),
+       ('2024-11-10', '641500024', '415230103', '415', '08:00', 0, 'EXPENSE_ENTERED', false, false),
+       ('2024-11-11', '641500024', '415230103', '415', '08:00', 0, 'EXPENSE_ENTERED', false, false),
+       ('2024-11-10', '641500026', '415230104', '415', '08:00', 0, 'EXPENSE_ENTERED', false, false),
+       ('2024-11-11', '641500026', '415230104', '415', '08:00', 0, 'EXPENSE_ENTERED', false, false);

--- a/src/integration-test/resources/db/mod/reports/UnpaidAttendanceSummaryReportITest_typical.sql
+++ b/src/integration-test/resources/db/mod/reports/UnpaidAttendanceSummaryReportITest_typical.sql
@@ -50,3 +50,14 @@ values ('2024-11-10', '641500023', '415230103', '415', '08:00', 0, 'EXPENSE_ENTE
        ('2024-11-11', '641500024', '415230103', '415', '08:00', 0, 'EXPENSE_ENTERED', false, false),
        ('2024-11-10', '641500026', '415230104', '415', '08:00', 0, 'EXPENSE_ENTERED', false, false),
        ('2024-11-11', '641500026', '415230104', '415', '08:00', 0, 'EXPENSE_ENTERED', false, false);
+
+
+-- create appearance records
+insert into juror_mod.appearance (attendance_date, juror_number, pool_number, loc_code, time_in, misc_total_paid,
+                                  appearance_stage, non_attendance, is_draft_expense)
+values ('2024-09-10', '641500023', '415230103', '415', '08:00', 0, 'EXPENSE_ENTERED', false, false),
+       ('2024-09-11', '641500023', '415230103', '415', '08:00', 0, 'EXPENSE_ENTERED', false, false),
+       ('2024-09-10', '641500024', '415230103', '415', '08:00', 0, 'EXPENSE_ENTERED', false, false),
+       ('2024-09-11', '641500024', '415230103', '415', '08:00', 0, 'EXPENSE_ENTERED', false, false),
+       ('2024-09-10', '641500026', '415230104', '415', '08:00', 0, 'EXPENSE_ENTERED', false, false),
+       ('2024-09-11', '641500026', '415230104', '415', '08:00', 0, 'EXPENSE_ENTERED', false, false);

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/report/grouped/UnpaidAttendanceSummaryReport.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/report/grouped/UnpaidAttendanceSummaryReport.java
@@ -37,7 +37,7 @@ public class UnpaidAttendanceSummaryReport extends AbstractGroupedReport {
         super(poolRequestRepository,
             QAppearance.appearance,
             ReportGroupBy.builder()
-                .dataType(DataType.POOL_NUMBER_BY_APPEARANCE)
+                .dataType(DataType.ATTENDANCE_DATE)
                 .removeGroupByFromResponse(true)
                 .build(),
             DataType.JUROR_NUMBER,
@@ -63,8 +63,7 @@ public class UnpaidAttendanceSummaryReport extends AbstractGroupedReport {
         query.where(QAppearance.appearance.attendanceDate.between(request.getFromDate(), request.getToDate()));
 
         query.orderBy(QAppearance.appearance.attendanceDate.asc(), QJuror.juror.jurorNumber.asc());
-        addGroupBy(query, DataType.JUROR_NUMBER, DataType.POOL_NUMBER_BY_APPEARANCE, DataType.ATTENDANCE_DATE);
-
+        addGroupBy(query, DataType.JUROR_NUMBER, DataType.ATTENDANCE_DATE);
     }
 
     @Override

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/report/grouped/UnpaidAttendanceSummaryReportTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/report/grouped/UnpaidAttendanceSummaryReportTest.java
@@ -36,10 +36,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@SuppressWarnings({
-    "PMD.LawOfDemeter",
-    "PMD.ExcessiveImports"
-})
+@SuppressWarnings("PMD.ExcessiveImports")
 class UnpaidAttendanceSummaryReportTest extends AbstractGroupedReportTestSupport<UnpaidAttendanceSummaryReport> {
 
     private MockedStatic<SecurityUtil> securityUtilMockedStatic;
@@ -49,7 +46,7 @@ class UnpaidAttendanceSummaryReportTest extends AbstractGroupedReportTestSupport
         super(QAppearance.appearance,
             UnpaidAttendanceSummaryReport.RequestValidator.class,
             ReportGroupBy.builder()
-                .dataType(DataType.POOL_NUMBER_BY_APPEARANCE)
+                .dataType(DataType.ATTENDANCE_DATE)
                 .removeGroupByFromResponse(true)
                 .build(),
             DataType.JUROR_NUMBER,
@@ -108,7 +105,6 @@ class UnpaidAttendanceSummaryReportTest extends AbstractGroupedReportTestSupport
 
         verify(report, times(1)).addGroupBy(query,
             DataType.JUROR_NUMBER,
-            DataType.POOL_NUMBER_BY_APPEARANCE,
             DataType.ATTENDANCE_DATE);
 
     }


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-6491)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=436)


### Change description ###
|JMRSM 15:|The system shall enable officers to generate an unpaid attendance summary report|
|Requirement Description|The system shall enable officer to generate an unpaid attendance summary reprort.
 
# The system shall allow the officer to enter the following details:
#* Date from
#** Must be a real date
#* Date to
#** Must be a real date
#** Must be after attendance from
# The system shall allow the officer to continue and show the following values in the header:
#* Date from
#* Date to
#* Total unpaid attendances
#* Report created
#* Time created
#* Court name
# The system shall display the following columns that are separated in to section for each day:
#* Juror number (hyperlink)
#* First name
#* Last name
#* Total (per day)
# The system hall allow the officer to print the report and a PDF
Dev note
The list contain juror with unpaid attendances for that court for the days in the date range|
|Owner|Product Owner|
|Additional Details|*Existing Juror heritage Screens*
[Juror expenditure report (low level report) - Juror Rewrite Project - Confluence (atlassian.net)|https://centralgovernmentcgi.atlassian.net/wiki/spaces/JD/pages/2950791225/Juror+expenditure+report+low+level+report]
[Juror expenditure report (high level report) - Juror Rewrite Project - Confluence (atlassian.net)|https://centralgovernmentcgi.atlassian.net/wiki/spaces/JD/pages/2950332455/Juror+expenditure+report+high+level+report]
[Attendance Graph - Juror Rewrite Project - Confluence (atlassian.net)|https://centralgovernmentcgi.atlassian.net/wiki/spaces/JD/pages/2950037587/Attendance+Graph]
[Generate and view statistics - Incomplete service report - Juror Rewrite Project - Confluence (atlassian.net)|https://centralgovernmentcgi.atlassian.net/wiki/spaces/JD/pages/2950660146/Generate+and+view+statistics+-+Incomplete+service+report]
[Generate and view statistics - Monthly Report (Wastage & utilisation) - Juror Rewrite Project - Confluence (atlassian.net)|https://centralgovernmentcgi.atlassian.net/wiki/spaces/JD/pages/2949677188/Generate+and+view+statistics+-+Monthly+Report+Wastage+utilisation]
[Generate and view statistics - Monthly Report (Wastage & utilisation) - Juror Rewrite Project - Confluence (atlassian.net)|https://centralgovernmentcgi.atlassian.net/wiki/spaces/JD/pages/2949677188/Generate+and+view+statistics+-+Monthly+Report+Wastage+utilisation]
[Generate a report - Juror Rewrite Project - Confluence (atlassian.net)|https://centralgovernmentcgi.atlassian.net/wiki/spaces/JD/pages/2950856733/Generate+a+report]
[Generate a report of jurors due to attend - Juror Rewrite Project - Confluence (atlassian.net)|https://centralgovernmentcgi.atlassian.net/wiki/spaces/JD/pages/2950201383/Generate+a+report+of+jurors+due+to+attend]
*Data type for user inputs*
* System generated
* Alphanumeric
* System generated
* Numeric
* Numeric
* Numeric
* Numeric
* System generated
 
*High level requirements*
JRC-HLR-04, JRB-HLR-17, JRB-HLR-18, JRB-HLR-19, JRB-HLR-20, JRB-HLR-21, JRB-HLR-22, JRB-HLR-23, JRB-HLR-24, JRB-HLR-25, JRB-HLR-26, JRC-HLR-12, JRC-HLR-13, JRC-HLR-21, JRC-HLR-33, JRC-HLR-34, JRC-HLR-35, JRC-HLR-36, JRC-HLR-31, JRC-HLR-32
 
*New Screen Design*
[Reports (SPEC) – Figma|https://www.figma.com/file/YvdqYIgmd4q0VLg7Npw9O4/Reports-(SPEC)?type=design&node-id=0-1&mode=design&t=cA1tq98yplBWevF1-0]|

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
