### PR TITLE
When search results is limited by APP_SETTING.SEARCH_RESULT_LIMIT_TEAM* setting, message isnt shown indicating that it's a limited results set

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/response/summonsmanagement/JurorResponseRetrieveResponseDto.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/response/summonsmanagement/JurorResponseRetrieveResponseDto.java
@@ -25,6 +25,14 @@ public class JurorResponseRetrieveResponseDto {
     @Schema(name = "Record count", description = "The number or responses retrieved matching the search criteria")
     private int recordCount;
 
+    @JsonProperty("limit")
+    @Schema(name = "limit", description = "The limit for the number of search results")
+    private int limit;
+
+    @JsonProperty("limit_exceeded")
+    @Schema(name = "Limit Exceeded", description = "Was the limit exceeded?")
+    private boolean limitExceeded;
+
     @JsonProperty("juror_response")
     @Schema(name = "Juror response", description = "List of juror response records retrieved based on search criteria")
     @Singular("jurorResponse")

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/jurorresponse/JurorResponseCommonRepositoryMod.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/jurorresponse/JurorResponseCommonRepositoryMod.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.juror.api.moj.repository.jurorresponse;
 
+import com.querydsl.core.QueryResults;
 import com.querydsl.core.Tuple;
 import uk.gov.hmcts.juror.api.moj.controller.request.summonsmanagement.JurorResponseRetrieveRequestDto;
 import uk.gov.hmcts.juror.api.moj.domain.jurorresponse.AbstractJurorResponse;
@@ -8,9 +9,9 @@ import uk.gov.hmcts.juror.api.moj.domain.jurorresponse.JurorResponseCommon;
 import java.util.List;
 
 public interface JurorResponseCommonRepositoryMod {
-    List<Tuple> retrieveJurorResponseDetails(JurorResponseRetrieveRequestDto request,
-                                             boolean isTeamLeader,
-                                             int resultsLimit);
+    QueryResults<Tuple> retrieveJurorResponseDetails(JurorResponseRetrieveRequestDto request,
+                                                     boolean isTeamLeader,
+                                                     int resultsLimit);
 
     AbstractJurorResponse findByJurorNumber(String jurorNumber);
 

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/jurorresponse/JurorResponseCommonRepositoryModImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/jurorresponse/JurorResponseCommonRepositoryModImpl.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.juror.api.moj.repository.jurorresponse;
 
+import com.querydsl.core.QueryResults;
 import com.querydsl.core.Tuple;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -37,8 +38,8 @@ public class JurorResponseCommonRepositoryModImpl implements JurorResponseCommon
     EntityManager entityManager;
 
     @Override
-    public List<Tuple> retrieveJurorResponseDetails(JurorResponseRetrieveRequestDto request,
-                                                    boolean isTeamLeader, int resultsLimit) {
+    public QueryResults<Tuple> retrieveJurorResponseDetails(JurorResponseRetrieveRequestDto request,
+                                                            boolean isTeamLeader, int resultsLimit) {
         // build sql query
         JPAQuery<Tuple> query = sqlRetrieveJurorResponseDetails(request, isTeamLeader);
 
@@ -68,11 +69,11 @@ public class JurorResponseCommonRepositoryModImpl implements JurorResponseCommon
             .fetch();
     }
 
-    private List<Tuple> fetchQueryResults(JPAQuery<Tuple> query, int resultsLimit) {
+    private QueryResults<Tuple> fetchQueryResults(JPAQuery<Tuple> query, int resultsLimit) {
         return query
             .orderBy(JUROR_RESPONSE_COMMON.dateReceived.asc())
             .limit(resultsLimit)
-            .fetch();
+            .fetchResults();
     }
 
     private JPAQuery<Tuple> sqlRetrieveJurorResponseDetails(JurorResponseRetrieveRequestDto request,


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7409)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=%pullRequestNumber%)


### Change description ###
Previously, when a search result was limited because the APP_SETTING.SEARCH_RESULT_LIMIT_TEAM_LEADER or APP_SETTING.SEARCH_RESULT_LIMIT_BUREAU_OFFICER was set and the results set exceeded that, the user saw the results set and this message, so it was clear that the results set was limited:

{{And I see "The specified search resulted in more than 100 results. This list only shows the oldest 100." on the page}}

Now this message is not displayed to the user, and it appears that the complete results set is shown (there are >100 rows when I increase the setting)

!image-20240524-101000.png|width=1229,height=698,alt="image-20240524-101000.png"!

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
