### PR TITLE
Juror number being used in place of pool number on Unpaid Attendance

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/IAppearanceRepositoryImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/IAppearanceRepositoryImpl.java
@@ -372,7 +372,7 @@ public class IAppearanceRepositoryImpl implements IAppearanceRepository {
             SortMethod.DESC,
             tuple -> UnpaidExpenseSummaryResponseDto.builder()
                 .jurorNumber(tuple.get(QAppearance.appearance.jurorNumber))
-                .poolNumber(tuple.get(QAppearance.appearance.jurorNumber))
+                .poolNumber(tuple.get(QAppearance.appearance.poolNumber))
                 .firstName(tuple.get(QJuror.juror.firstName))
                 .lastName(tuple.get(QJuror.juror.lastName))
                 .totalUnapproved(tuple.get(UnpaidExpenseSummaryRequestDto.TOTAL_OUTSTANDING_EXPRESSION))


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7456)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=442)


### Change description ###
The juror number is being used in place of the pool number on the unpaid attendance screen, which is causing failures elsewhere.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
