### PR TITLE
As a Bureau officer I want to generate a pool ratio report (BE)

### DIFF
--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/report/standard/PoolRatioReportITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/report/standard/PoolRatioReportITest.java
@@ -53,7 +53,7 @@ class PoolRatioReportITest extends AbstractStandardReportControllerITest {
             .responseConsumer(this::verifyAndRemoveReportCreated)
             .assertEquals(buildStandardReportResponse(StandardTableData.of(
                 new ReportLinkedMap<String, Object>()
-                    .add("court_location_name_and_code", "CHESTER (415)")
+                    .add("court_location_name_and_code_jp", "CHESTER (415)")
                     .add("total_requested", 15)
                     .add("total_deferred", 4)
                     .add("total_summoned", 12)
@@ -61,7 +61,7 @@ class PoolRatioReportITest extends AbstractStandardReportControllerITest {
                     .add("ratio_1", 0.7272727272727273)
                     .add("ratio_2", 1.0),
                 new ReportLinkedMap<String, Object>()
-                    .add("court_location_name_and_code", "Chelmsford  (414)")
+                    .add("court_location_name_and_code_jp", "Chelmsford  (414)")
                     .add("total_requested", 15)
                     .add("total_deferred", 5)
                     .add("total_summoned", 10)
@@ -69,7 +69,7 @@ class PoolRatioReportITest extends AbstractStandardReportControllerITest {
                     .add("ratio_1", 0.5)
                     .add("ratio_2", 1.6666666666666667),
                 new ReportLinkedMap<String, Object>()
-                    .add("court_location_name_and_code", "The Central Criminal Court (413)")
+                    .add("court_location_name_and_code_jp", "The Central Criminal Court (413)")
                     .add("total_requested", 10)
                     .add("total_deferred", 1)
                     .add("total_summoned", 9)

--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/report/standard/PoolRatioReportITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/report/standard/PoolRatioReportITest.java
@@ -105,7 +105,7 @@ class PoolRatioReportITest extends AbstractStandardReportControllerITest {
                     .headings(List.of(
                         StandardReportResponse.TableData.Heading.builder()
                             .id("court_location_name_and_code_jp")
-                            .name("Court Location Name And Code")
+                            .name("Court")
                             .dataType("String")
                             .headings(null)
                             .build(),

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/report/DataType.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/report/DataType.java
@@ -218,7 +218,7 @@ public enum DataType implements IDataType {
     COURT_LOCATION_NAME_AND_CODE("Court Location Name And Code", String.class,
         QPoolRequest.poolRequest.courtLocation.name.concat(" (")
             .concat(QPoolRequest.poolRequest.courtLocation.locCode).concat(")"), QPoolRequest.poolRequest),
-    COURT_LOCATION_NAME_AND_CODE_JP("Court Location Name And Code", String.class,
+    COURT_LOCATION_NAME_AND_CODE_JP("Court", String.class,
         QJurorPool.jurorPool.pool.courtLocation.name.concat(" (")
             .concat(QJurorPool.jurorPool.pool.courtLocation.locCode).concat(")"), QJurorPool.jurorPool),
 

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/report/standard/PoolRatioReport.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/report/standard/PoolRatioReport.java
@@ -148,6 +148,9 @@ public class PoolRatioReport extends AbstractStandardReport {
         query.where(QJurorPool.jurorPool.pool.returnDate.between(request.getFromDate(), request.getToDate()));
         query.where(QJurorPool.jurorPool.pool.courtLocation.locCode.in(request.getCourts()));
 
+        query.orderBy(QJurorPool.jurorPool.pool.courtLocation.name.asc(),
+            QJurorPool.jurorPool.pool.courtLocation.locCode.asc());
+
         query.groupBy(
             QJurorPool.jurorPool.pool.poolNumber,
             QJurorPool.jurorPool.pool.numberRequested,

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/report/standard/PoolRatioReport.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/report/standard/PoolRatioReport.java
@@ -110,7 +110,7 @@ public class PoolRatioReport extends AbstractStandardReport {
                     String key = entry.getKey();
                     TableData value = entry.getValue();
                     LinkedHashMap<String, Object> map = new LinkedHashMap<>();
-                    map.put(DataType.COURT_LOCATION_NAME_AND_CODE.getId(), key);
+                    map.put(DataType.COURT_LOCATION_NAME_AND_CODE_JP.getId(), key);
                     map.put(DataType.TOTAL_REQUESTED.getId(), value.getRequested());
                     map.put(DataType.TOTAL_DEFERRED.getId(), value.getDeferred());
                     map.put(DataType.TOTAL_SUMMONED.getId(), value.getSummoned());

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/report/standard/PoolRatioReportTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/report/standard/PoolRatioReportTest.java
@@ -64,6 +64,9 @@ public class PoolRatioReportTest extends AbstractStandardReportTestSupport<PoolR
                 .between(FROM_DATE, TO_DATE));
         verify(query, times(1))
             .where(QJurorPool.jurorPool.pool.courtLocation.locCode.in(COURTS));
+        verify(query, times(1))
+            .orderBy(QJurorPool.jurorPool.pool.courtLocation.name.asc(),
+                QJurorPool.jurorPool.pool.courtLocation.locCode.asc());
 
         verify(query, times(1))
             .groupBy(


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-6527)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=445)


### Change description ###
|JMRSM 18:|The system shall enable the Bureau officers to generate a pool ratio report|
|Requirement Description|The system shall enable the bureau officer to generate a pool ratio report.
 
# The system shall ask the officer to enter a date range for the report
#* Date from (date picker)
#** Must be a real date
#* Date to (date picker)
#** Must be a real date
# The system shall allow the officer to select one or multiple courts to run the report for
#* Text filter
#** Filter using name or location code
#* Select all button
#* List of all courts wit a button to select each individually
# The system shall allow the officer to continue and generate the report
# The report shall display the following header
#* Date from
#* Date to
#* Report created
#* Time created
# The system shall display the following columns:
#* Court
#* Requested (1)
#* Deferred (2)
#* Summoned (3)
#* Supplied (4)
#* Ratio 1 (3-2) /(1-2)
#* Ratio 2 (3-2) /(4-2)
# The system shall allow the officer to print the report as a PDF
# The system shall allow the officer to export the data as a PDF in the same columns as the report|
|Owner|Product Owner|
|Additional Details|*Existing Juror heritage Screens*
[Juror expenditure report (low level report) - Juror Rewrite Project - Confluence (atlassian.net)|https://centralgovernmentcgi.atlassian.net/wiki/spaces/JD/pages/2950791225/Juror+expenditure+report+low+level+report]
[Juror expenditure report (high level report) - Juror Rewrite Project - Confluence (atlassian.net)|https://centralgovernmentcgi.atlassian.net/wiki/spaces/JD/pages/2950332455/Juror+expenditure+report+high+level+report]
[Attendance Graph - Juror Rewrite Project - Confluence (atlassian.net)|https://centralgovernmentcgi.atlassian.net/wiki/spaces/JD/pages/2950037587/Attendance+Graph]
[Generate and view statistics - Incomplete service report - Juror Rewrite Project - Confluence (atlassian.net)|https://centralgovernmentcgi.atlassian.net/wiki/spaces/JD/pages/2950660146/Generate+and+view+statistics+-+Incomplete+service+report]
[Generate and view statistics - Monthly Report (Wastage & utilisation) - Juror Rewrite Project - Confluence (atlassian.net)|https://centralgovernmentcgi.atlassian.net/wiki/spaces/JD/pages/2949677188/Generate+and+view+statistics+-+Monthly+Report+Wastage+utilisation]
[Generate and view statistics - Monthly Report (Wastage & utilisation) - Juror Rewrite Project - Confluence (atlassian.net)|https://centralgovernmentcgi.atlassian.net/wiki/spaces/JD/pages/2949677188/Generate+and+view+statistics+-+Monthly+Report+Wastage+utilisation]
[Generate a report - Juror Rewrite Project - Confluence (atlassian.net)|https://centralgovernmentcgi.atlassian.net/wiki/spaces/JD/pages/2950856733/Generate+a+report]
[Generate a report of jurors due to attend - Juror Rewrite Project - Confluence (atlassian.net)|https://centralgovernmentcgi.atlassian.net/wiki/spaces/JD/pages/2950201383/Generate+a+report+of+jurors+due+to+attend]
*Data type for user inputs*
* System generated
* Alphanumeric
* System generated
* Numeric
* Numeric
* Numeric
* Numeric
* System generated
 
*High level requirements*
JRC-HLR-04, JRB-HLR-17, JRB-HLR-18, JRB-HLR-19, JRB-HLR-20, JRB-HLR-21, JRB-HLR-22, JRB-HLR-23, JRB-HLR-24, JRB-HLR-25, JRB-HLR-26, JRC-HLR-12, JRC-HLR-13, JRC-HLR-21, JRC-HLR-33, JRC-HLR-34, JRC-HLR-35, JRC-HLR-36, JRC-HLR-31, JRC-HLR-32
 
*New Screen Design*
[Reports (SPEC) – Figma|https://www.figma.com/file/YvdqYIgmd4q0VLg7Npw9O4/Reports-(SPEC)?type=design&node-id=0-1&mode=design&t=cA1tq98yplBWevF1-0]|

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
