### PR TITLE
Unable to deny deferral request when its not the first deferral

### DIFF
--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/DeferralRequestControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/DeferralRequestControllerITest.java
@@ -101,7 +101,7 @@ public class DeferralRequestControllerITest extends AbstractIntegrationTest {
 
         assertThat(response.getStatusCode())
             .as("Expect the HTTP PUT request to be OK")
-            .isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+            .isEqualTo(HttpStatus.OK);
     }
 
     @Test
@@ -208,6 +208,23 @@ public class DeferralRequestControllerITest extends AbstractIntegrationTest {
         assertThat(response.getStatusCode())
             .as("Expect the HTTP PUT request to be OK")
             .isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    @Sql({"/db/mod/truncate.sql", "/db/DeferralRequestController_createInitialPoolRecords.sql"})
+    public void grant_Deferral_unhappyPath_deferred_before() {
+        String jurorNumber = "987654321";
+        String deferralReason = "B";
+
+        DeferralRequestDto requestDto = createGrantDeferralDecisionDto(jurorNumber, deferralReason);
+        requestDto.setAllowMultipleDeferrals(false);
+        ResponseEntity<DeferralRequestDto> response =
+            restTemplate.exchange(new RequestEntity<>(requestDto, httpHeaders, HttpMethod.PUT,
+                URI.create("/api/v1/moj/deferral-response/juror/" + jurorNumber)), DeferralRequestDto.class);
+
+        assertThat(response.getStatusCode())
+            .as("Expect the HTTP PUT request to be OK")
+            .isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @Test

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/DeferralResponseServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/DeferralResponseServiceImpl.java
@@ -77,14 +77,14 @@ public class DeferralResponseServiceImpl implements DeferralResponseService {
             log.debug("Cannot decline first deferral for juror {}", jurorNumber);
             throw new MojException.BusinessRuleViolation("Cannot decline first deferral request for juror",
                 CANNOT_REFUSE_FIRST_DEFERRAL);
+        } else if (deferralRequestDto.getDeferralDecision().equals(DeferralDecision.REFUSE)) {
+            log.debug("Begin processing decline deferral juror {} by user {}", jurorNumber, payload.getLogin());
+            declineDeferralForJurorPool(payload, deferralRequestDto, jurorPool);
         } else if (!deferralRequestDto.isAllowMultipleDeferrals() && !firstDeferral) {
             log.debug("Can not defer juror multiple times without allowMultipleDeferrals flag. Juror {}", jurorNumber);
             throw new MojException.BusinessRuleViolation("Juror has been deferred before. Please use "
                 + "allow_multiple_deferrals to bypass this error.",
                 MojException.BusinessRuleViolation.ErrorCode.JUROR_HAS_BEEN_DEFERRED_BEFORE);
-        } else if (deferralRequestDto.getDeferralDecision().equals(DeferralDecision.REFUSE)) {
-            log.debug("Begin processing decline deferral juror {} by user {}", jurorNumber, payload.getLogin());
-            declineDeferralForJurorPool(payload, deferralRequestDto, jurorPool);
         } else if (deferralRequestDto.getDeferralDecision().equals(DeferralDecision.GRANT)) {
             log.info("Begin processing grant deferral juror {} by user {}", jurorNumber, payload.getLogin());
             grantDeferralForJurorPool(payload, deferralRequestDto, jurorPool);

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/DeferralResponseServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/DeferralResponseServiceImplTest.java
@@ -95,12 +95,13 @@ public class DeferralResponseServiceImplTest {
     }
 
     @Test
-    public void test_unhappyPath_multiple_deferals() {
+    public void test_unhappyPath_multiple_deferrals() {
         String jurorNumber = "987654321";
         BureauJwtPayload payload = TestUtils.createJwt("415", "SOME_USER");
 
         DeferralRequestDto deferralRequestDto = createTestDeferralRequestDto(jurorNumber);
         deferralRequestDto.setAllowMultipleDeferrals(false);
+        deferralRequestDto.setDeferralDecision(DeferralDecision.GRANT);
 
         MojException.BusinessRuleViolation exception = assertThrows(
             MojException.BusinessRuleViolation.class,


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7467)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=%pullRequestNumber%)


### Change description ###
Have deferred a juror once already, now processing a second deferral request and trying to refuse, get the following screen 

!image-20240603-165003.png|width=1456,height=1214,alt="image-20240603-165003.png"!

This issue seems to be on the backend as it shows the following error logs

* crit: Failed to process deferral update:  … responseId=641500012, timestamp=2024-06-03 16:01:22, message=Juror has been deferred before. Please use allow_multiple_deferrals to bypass this error., code=JUROR_HAS_BEEN_DEFERRED_BEFORE

This message indicates the wrong logic is run in back end - there needs to be a check for granted decision in following code {{ else if (!deferralRequestDto.isAllowMultipleDeferrals() && !firstDeferral) }} in the {{respondToDeferralRequest}} method.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
