### PR TITLE
Pool attendance audit report number list (BE)

### DIFF
--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/AuditControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/AuditControllerITest.java
@@ -1,0 +1,104 @@
+package uk.gov.hmcts.juror.api.moj.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.hmcts.juror.api.AbstractControllerIntegrationTest;
+import uk.gov.hmcts.juror.api.moj.domain.UserType;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Set;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DisplayName("Controller: " + AuditControllerITest.BASE_URL)
+@RequiredArgsConstructor(onConstructor = @__(@Autowired))
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")//False positive
+public class AuditControllerITest {
+    public static final String BASE_URL = "/api/v1/moj/audit";
+    private final TestRestTemplate template;
+
+
+    @Nested
+    @DisplayName("GET  " + AuditControllerITest.GetAllPoolAuditsForDay.URL)
+    @Sql({
+        "/db/mod/truncate.sql",
+        "/db/administration/createJudges.sql",
+        "/db/administration/createCourtRooms.sql",
+        "/db/mod/reports/PoolAttendanceAuditReportITest_typical.sql"
+    })
+    class GetAllPoolAuditsForDay extends AbstractControllerIntegrationTest<Void, List<String>> {
+        public static final String URL = BASE_URL + "/{date}/pool";
+
+        protected GetAllPoolAuditsForDay() {
+            super(HttpMethod.GET, template, HttpStatus.OK);
+        }
+
+        private String toUrl(LocalDate date) {
+            return toUrl(DateTimeFormatter.ISO_DATE.format(date));
+        }
+
+        private String toUrl(String date) {
+            return URL.replace("{date}", date);
+        }
+
+        @Override
+        protected String getValidUrl() {
+            return toUrl(LocalDate.of(2024, 1, 1));
+        }
+
+        @Override
+        protected String getValidJwt() {
+            return createJwt("test_court_primary", "415",
+                UserType.COURT, Set.of(), "415");
+        }
+
+        @Override
+        protected Void getValidPayload() {
+            return null;
+        }
+
+        @Test
+        void positiveTypical() {
+            testBuilder()
+                .triggerValid()
+                .assertEquals(List.of("P1234", "P12345678"));
+        }
+
+        @Test
+        void positiveNotFound() {
+            testBuilder()
+                .url(toUrl(LocalDate.of(2023, 1, 1)))
+                .triggerValid()
+                .assertEquals(List.of());
+        }
+
+        @Test
+        void negativeIsBureau() {
+            testBuilder()
+                .jwt(getBureauJwt())
+                .triggerInvalid()
+                .assertForbiddenResponse();
+        }
+
+        @Test
+        void negativeInvalidDateFormat() {
+            testBuilder()
+                .url(toUrl("INVALID"))
+                .triggerInvalid()
+                .printResponse()
+                .assertInvalidPathParam("INVALID is the incorrect data type or is not in the expected format (date)");
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/AuditController.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/AuditController.java
@@ -27,11 +27,10 @@ import java.util.List;
 @RestController
 @Validated
 @RequestMapping(value = "/api/v1/moj/audit", produces = MediaType.APPLICATION_JSON_VALUE)
-@Tag(name = "Administration - Judges")
+@Tag(name = "Audit")
 @RequiredArgsConstructor(onConstructor_ = {@Autowired})
 @PreAuthorize(SecurityUtil.IS_COURT)
 public class AuditController {
-
 
     private final JurorAuditService jurorAuditService;
 

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/AuditController.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/AuditController.java
@@ -1,0 +1,49 @@
+package uk.gov.hmcts.juror.api.moj.controller;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.hmcts.juror.api.moj.service.audit.JurorAuditService;
+import uk.gov.hmcts.juror.api.moj.utils.SecurityUtil;
+import uk.gov.hmcts.juror.api.validation.ValidationConstants;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@Validated
+@RequestMapping(value = "/api/v1/moj/audit", produces = MediaType.APPLICATION_JSON_VALUE)
+@Tag(name = "Administration - Judges")
+@RequiredArgsConstructor(onConstructor_ = {@Autowired})
+@PreAuthorize(SecurityUtil.IS_COURT)
+public class AuditController {
+
+
+    private final JurorAuditService jurorAuditService;
+
+    @GetMapping("/{date}/pool")
+    @Operation(summary = "View all pool audits")
+    @ResponseStatus(HttpStatus.OK)
+    public ResponseEntity<List<String>> getAllPoolAuditsForDay(
+        @PathVariable("date")
+        @Parameter(description = "date", required = true)
+        @JsonFormat(pattern = ValidationConstants.DATE_FORMAT)
+        @Valid LocalDate date
+    ) {
+        return ResponseEntity.ok(jurorAuditService.getAllPoolAuditsForDay(date));
+    }
+}

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/audit/JurorAuditService.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/audit/JurorAuditService.java
@@ -12,4 +12,6 @@ public interface JurorAuditService {
                                                            List<String> locCodes);
 
     JurorAudit getPreviousJurorAudit(JurorAudit juror);
+
+    List<String> getAllPoolAuditsForDay(LocalDate date);
 }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/audit/JurorAuditServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/audit/JurorAuditServiceImpl.java
@@ -8,8 +8,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.juror.api.moj.audit.dto.JurorAudit;
 import uk.gov.hmcts.juror.api.moj.audit.dto.QJurorAudit;
+import uk.gov.hmcts.juror.api.moj.domain.QAppearance;
 import uk.gov.hmcts.juror.api.moj.domain.QJurorPool;
-import uk.gov.hmcts.juror.api.moj.service.JurorPoolService;
 import uk.gov.hmcts.juror.api.moj.utils.DateUtils;
 import uk.gov.hmcts.juror.api.moj.utils.SecurityUtil;
 
@@ -23,9 +23,6 @@ public class JurorAuditServiceImpl implements JurorAuditService {
 
     @PersistenceContext
     EntityManager entityManager;
-
-    private final JurorPoolService jurorPoolService;
-
 
     JPAQueryFactory getQueryFactory() {
         return new JPAQueryFactory(entityManager);
@@ -69,5 +66,17 @@ public class JurorAuditServiceImpl implements JurorAuditService {
             return null;
         }
         return data.get(0);
+    }
+
+    @Override
+    public List<String> getAllPoolAuditsForDay(LocalDate date) {
+        return getQueryFactory()
+            .selectDistinct(QAppearance.appearance.attendanceAuditNumber)
+            .from(QAppearance.appearance)
+            .where(QAppearance.appearance.locCode.eq(SecurityUtil.getLocCode()))
+            .where(QAppearance.appearance.attendanceDate.eq(date))
+            .where(QAppearance.appearance.attendanceAuditNumber.isNotNull())
+            .where(QAppearance.appearance.attendanceAuditNumber.startsWith("P"))
+            .fetch();
     }
 }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/audit/JurorAuditServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/audit/JurorAuditServiceImpl.java
@@ -77,6 +77,7 @@ public class JurorAuditServiceImpl implements JurorAuditService {
             .where(QAppearance.appearance.attendanceDate.eq(date))
             .where(QAppearance.appearance.attendanceAuditNumber.isNotNull())
             .where(QAppearance.appearance.attendanceAuditNumber.startsWith("P"))
+            .orderBy(QAppearance.appearance.attendanceAuditNumber.asc())
             .fetch();
     }
 }

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/controller/AuditControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/controller/AuditControllerTest.java
@@ -1,0 +1,89 @@
+package uk.gov.hmcts.juror.api.moj.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import uk.gov.hmcts.juror.api.TestUtils;
+import uk.gov.hmcts.juror.api.moj.exception.RestResponseEntityExceptionHandler;
+import uk.gov.hmcts.juror.api.moj.service.audit.JurorAuditService;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(controllers = AuditController.class,
+    excludeAutoConfiguration = {SecurityAutoConfiguration.class})
+@ContextConfiguration(
+    classes = {
+        AuditController.class,
+        RestResponseEntityExceptionHandler.class
+    }
+)
+@DisplayName("Controller: " + AuthenticationControllerTest.BASE_URL)
+public class AuditControllerTest {
+
+    public static final String BASE_URL = "/api/v1/moj/audit";
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private JurorAuditService jurorAuditService;
+    @InjectMocks
+    private AuditController auditController;
+
+    @Nested
+    @DisplayName("GET " + AuditControllerTest.GetAllPoolAuditsForDay.URL)
+    class GetAllPoolAuditsForDay {
+        public static final String URL = BASE_URL + "/{date}/pool";
+
+        private String toUrl(LocalDate date) {
+            return URL.replace("{date}", DateTimeFormatter.ISO_DATE.format(date));
+        }
+
+        @Test
+        void positiveTypical() throws Exception {
+            List<String> audits = List.of("P123", "P456", "789");
+            LocalDate date = LocalDate.of(2024, 1, 1);
+            doReturn(audits).when(jurorAuditService).getAllPoolAuditsForDay(date);
+
+            mockMvc.perform(get(toUrl(date))
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isOk())
+                .andExpect(content().json(TestUtils.asJsonString(audits)));
+
+            verify(jurorAuditService, times(1))
+                .getAllPoolAuditsForDay(date);
+            verifyNoMoreInteractions(jurorAuditService);
+        }
+
+        @Test
+        void negativeInvalidDate() throws Exception {
+            mockMvc.perform(get(URL.replace("{date}", "INVALID"))
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isBadRequest());
+            verifyNoMoreInteractions(jurorAuditService);
+        }
+    }
+}


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7475)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=455)


### Change description ###
In order to access the pool audit report from the FE Attendance tab, we need to provide a list of audit numbers for the user to select from.

A new endpoint needs created to provide this information.



!image-20240604-122126.png|width=2220,height=986,alt="image-20240604-122126.png"!

[https://www.figma.com/design/YvdqYIgmd4q0VLg7Npw9O4/Reports-(SPEC)?node-id=565-74394&t=QsWJYvA1ihlIPsRO-4|https://www.figma.com/design/YvdqYIgmd4q0VLg7Npw9O4/Reports-(SPEC)?node-id=565-74394&t=QsWJYvA1ihlIPsRO-4|smart-link] 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
