### PR TITLE
When editing a trial the trial date does not show the date originally set, shows todays date instead

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/response/trial/TrialSummaryDto.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/response/trial/TrialSummaryDto.java
@@ -1,11 +1,13 @@
 package uk.gov.hmcts.juror.api.moj.controller.response.trial;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import uk.gov.hmcts.juror.api.validation.ValidationConstants;
 
 import java.time.LocalDate;
 
@@ -32,6 +34,7 @@ public class TrialSummaryDto {
     private CourtroomsDto courtroomsDto;
 
     @JsonProperty("start_date")
+    @JsonFormat(pattern = ValidationConstants.DATE_FORMAT)
     private LocalDate trialStartDate;
 
     @JsonProperty("protected")


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7406)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=458)


### Change description ###
Steps:

* create a trial with any date
* edit the trial and see todays date instead of the original





!image-20240524-093550.png|width=819,height=403,alt="image-20240524-093550.png"!



!image-20240524-093601.png|width=1002,height=852,alt="image-20240524-093601.png"!

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
