### PR TITLE
When viewing expense records created as part of the End Trial and Confirm Attendance flow a technical error is displayed

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/moj/domain/Appearance.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/domain/Appearance.java
@@ -274,11 +274,6 @@ public class Appearance implements Serializable {
     @Column(name = "attendance_audit_number")
     private String attendanceAuditNumber;
 
-    public String getIdString() {
-        return "JurorNumber: " + this.jurorNumber + ", "
-            + "AttendanceDate: " + this.attendanceDate + ", "
-            + "CourtLocation: " + this.courtLocation;
-    }
 
     //Does not include smart card reduction
     public BigDecimal getTotalDue() {

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceService.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceService.java
@@ -56,4 +56,6 @@ public interface JurorAppearanceService {
     void modifyConfirmedAttendance(ModifyConfirmedAttendanceDto request);
 
     boolean hasAttendances(String jurorNumber);
+
+    void realignAttendanceType(Appearance appearance);
 }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/trial/TrialServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/trial/TrialServiceImpl.java
@@ -39,6 +39,7 @@ import uk.gov.hmcts.juror.api.moj.repository.trial.JudgeRepository;
 import uk.gov.hmcts.juror.api.moj.repository.trial.PanelRepository;
 import uk.gov.hmcts.juror.api.moj.repository.trial.TrialRepository;
 import uk.gov.hmcts.juror.api.moj.service.CompleteServiceService;
+import uk.gov.hmcts.juror.api.moj.service.jurormanagement.JurorAppearanceService;
 import uk.gov.hmcts.juror.api.moj.utils.JurorHistoryUtils;
 import uk.gov.hmcts.juror.api.moj.utils.PanelUtils;
 import uk.gov.hmcts.juror.api.moj.utils.RepositoryUtils;
@@ -82,6 +83,9 @@ public class TrialServiceImpl implements TrialService {
     private JurorPoolRepository jurorPoolRepository;
     @Autowired
     private CompleteServiceService completeService;
+
+    @Autowired
+    private JurorAppearanceService jurorAppearanceService;
 
     private static final int PAGE_SIZE = 25;
     private static final String CANNOT_FIND_TRIAL_ERROR_MESSAGE = "Cannot find trial with number: %s for "
@@ -257,6 +261,7 @@ public class TrialServiceImpl implements TrialService {
                     appearance.setTimeOut(LocalTime.parse(returnJuryDto.getCheckOut()));
                     log.debug("setting time out for juror %s".formatted(jurorNumber));
                 }
+                jurorAppearanceService.realignAttendanceType(appearance);
 
                 appearance.setSatOnJury(true);
                 appearanceRepository.saveAndFlush(appearance);

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/trial/TrialServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/trial/TrialServiceImplTest.java
@@ -44,6 +44,7 @@ import uk.gov.hmcts.juror.api.moj.repository.trial.JudgeRepository;
 import uk.gov.hmcts.juror.api.moj.repository.trial.PanelRepository;
 import uk.gov.hmcts.juror.api.moj.repository.trial.TrialRepository;
 import uk.gov.hmcts.juror.api.moj.service.CompleteServiceServiceImpl;
+import uk.gov.hmcts.juror.api.moj.service.jurormanagement.JurorAppearanceService;
 
 import java.time.LocalTime;
 import java.util.ArrayList;
@@ -91,6 +92,8 @@ class TrialServiceImplTest {
     private JurorPoolRepository jurorPoolRepository;
     @Mock
     private CompleteServiceServiceImpl completeService;
+    @Mock
+    private JurorAppearanceService jurorAppearanceService;
 
     @InjectMocks
     TrialServiceImpl trialService;


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7488)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=462)


### Change description ###
Cannot invoke "uk.gov.hmcts.juror.api.moj.enumeration.AttendanceType.getPayAttendanceType()" because the return value of "uk.gov.hmcts.juror.api.moj.domain.Appearance.getAttendanceType()" is null



!Screen Recording 2024-06-05 at 18.14.48.mov|width=3112,height=1678,alt="Screen Recording 2024-06-05 at 18.14.48.mov"!

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
