### PR TITLE
As as Bureau or court officer I need to generate a pool selection list (BE)

### DIFF
--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/report/standard/PoolSelectionReportITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/report/standard/PoolSelectionReportITest.java
@@ -1,0 +1,167 @@
+package uk.gov.hmcts.juror.api.moj.report.standard;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.test.context.jdbc.Sql;
+import uk.gov.hmcts.juror.api.moj.controller.reports.request.StandardReportRequest;
+import uk.gov.hmcts.juror.api.moj.controller.reports.response.StandardReportResponse;
+import uk.gov.hmcts.juror.api.moj.controller.reports.response.StandardTableData;
+import uk.gov.hmcts.juror.api.moj.report.AbstractStandardReportControllerITest;
+import uk.gov.hmcts.juror.api.moj.report.ReportHashMap;
+import uk.gov.hmcts.juror.api.moj.report.ReportLinkedMap;
+
+import java.util.List;
+
+@Sql({
+    "/db/truncate.sql",
+    "/db/mod/truncate.sql",
+    "/db/administration/createUsers.sql",
+    "/db/mod/reports/NextAttendanceDayReportITest_typical.sql"
+})
+class PoolSelectionReportITest extends AbstractStandardReportControllerITest {
+    @Autowired
+    public PoolSelectionReportITest(TestRestTemplate template) {
+        super(template, PoolSelectionListReport.class);
+    }
+
+    @Override
+    protected String getValidJwt() {
+        return getCourtJwt("415");
+    }
+
+    @Override
+    protected StandardReportRequest getValidPayload() {
+        return addReportType(StandardReportRequest.builder()
+            .poolNumber("415230103")
+            .build());
+    }
+
+    @Test
+    @SuppressWarnings({
+        "PMD.JUnitTestsShouldIncludeAssert"//False positive
+    })
+    void positiveTypicalCourt() {
+        testBuilder()
+            .triggerValid()
+            .responseConsumer(this::verifyAndRemoveReportCreated)
+            .assertEquals(getTypicalResponse());
+    }
+
+    @Test
+    @SuppressWarnings({
+        "PMD.JUnitTestsShouldIncludeAssert"//False positive
+    })
+    void positiveTypicalBureau() {
+        testBuilder()
+            .jwt(getBureauJwt())
+            .triggerValid()
+            .responseConsumer(this::verifyAndRemoveReportCreated)
+            .assertEquals(getTypicalResponse());
+    }
+
+    @Test
+    @SuppressWarnings({
+        "PMD.JUnitTestsShouldIncludeAssert"//False positive
+    })
+    void negativeInvalidPayload() {
+        StandardReportRequest request = getValidPayload();
+        request.setPoolNumber(null);
+        testBuilder()
+            .payload(addReportType(request))
+            .triggerInvalid()
+            .assertInvalidPathParam("poolNumber: must not be null");
+    }
+
+    @Test
+    @SuppressWarnings({
+        "PMD.JUnitTestsShouldIncludeAssert"//False positive
+    })
+    void negativeUnauthorised() {
+        testBuilder()
+            .jwt(getCourtJwt("414"))
+            .triggerInvalid()
+            .assertMojForbiddenResponse("User not allowed to access this pool");
+    }
+
+    private StandardReportResponse getTypicalResponse() {
+        return StandardReportResponse.builder()
+            .headings(new ReportHashMap<String, StandardReportResponse.DataTypeValue>()
+                .add("service_start_date", StandardReportResponse.DataTypeValue.builder()
+                    .displayName("Service Start Date")
+                    .dataType("LocalDate")
+                    .value("2023-01-05")
+                    .build())
+                .add("pool_number", StandardReportResponse.DataTypeValue.builder()
+                    .displayName("Pool Number")
+                    .dataType("String")
+                    .value("415230103")
+                    .build())
+                .add("court_name", StandardReportResponse.DataTypeValue.builder()
+                    .displayName("Court Name")
+                    .dataType("String")
+                    .value("CHESTER (415)")
+                    .build())
+                .add("pool_type", StandardReportResponse.DataTypeValue.builder()
+                    .displayName("Pool Type")
+                    .dataType("String")
+                    .value("CROWN COURT")
+                    .build()))
+            .tableData(
+                StandardReportResponse.TableData.<StandardTableData>builder()
+                    .headings(List.of(
+                        StandardReportResponse.TableData.Heading.builder()
+                            .id("juror_number")
+                            .name("Juror Number")
+                            .dataType("String")
+                            .headings(null)
+                            .build(),
+                        StandardReportResponse.TableData.Heading.builder()
+                            .id("first_name")
+                            .name("First Name")
+                            .dataType("String")
+                            .headings(null)
+                            .build(),
+                        StandardReportResponse.TableData.Heading.builder()
+                            .id("last_name")
+                            .name("Last Name")
+                            .dataType("String")
+                            .headings(null)
+                            .build(),
+                        StandardReportResponse.TableData.Heading.builder()
+                            .id("juror_postcode")
+                            .name("Postcode")
+                            .dataType("String")
+                            .headings(null)
+                            .build(),
+                        StandardReportResponse.TableData.Heading.builder()
+                            .id("disqualified_on_selection")
+                            .name("Disqualified on selection")
+                            .dataType("String")
+                            .headings(null)
+                            .build()))
+                    .data(StandardTableData.of(
+                        new ReportLinkedMap<String, Object>()
+                            .add("juror_number", "641500023")
+                            .add("first_name", "John3")
+                            .add("last_name", "Smith3")
+                            .add("juror_postcode", "AB1 3CD"),
+                        new ReportLinkedMap<String, Object>()
+                            .add("juror_number", "641500024")
+                            .add("first_name", "John4")
+                            .add("last_name", "Smith4")
+                            .add("juror_postcode", "AB1 4CD"),
+                        new ReportLinkedMap<String, Object>()
+                            .add("juror_number", "641500025")
+                            .add("first_name", "John5")
+                            .add("last_name", "Smith5")
+                            .add("juror_postcode", "AB1 5CD"),
+                        new ReportLinkedMap<String, Object>()
+                            .add("juror_number", "641500026")
+                            .add("first_name", "John6")
+                            .add("last_name", "Smith6")
+                            .add("juror_postcode", "AB1 6CD")))
+                    .build())
+            .build();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/reports/request/StandardReportRequest.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/reports/request/StandardReportRequest.java
@@ -57,6 +57,7 @@ public class StandardReportRequest {
         "ManualJurorReport",
         "JuryCostBill",
         "AvailableListByPoolReport",
+        "PoolSelectionListReport",
         //Grouped
         "AbsencesReport",
         "PostponedListByDateReport",

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/report/DataType.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/report/DataType.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.juror.api.moj.report;
 import com.querydsl.core.types.EntityPath;
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
 import lombok.Getter;
 import uk.gov.hmcts.juror.api.moj.domain.IJurorStatus;
@@ -285,6 +286,10 @@ public enum DataType implements IDataType {
             .otherwise(0L).sum(),
         QJurorPool.jurorPool
     ),
+
+    //Due to new the updated system we no longer disqualify people on selection instead we simply do not select them
+    DISQUALIFIED_ON_SELECTION("Disqualified on selection", String.class,
+        Expressions.nullExpression(), QJuror.juror),
     ;
 
 

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/report/standard/AvailableListByPoolReport.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/report/standard/AvailableListByPoolReport.java
@@ -48,7 +48,8 @@ public class AvailableListByPoolReport extends AbstractStandardReport implements
         addStandardFilters(query, request);
         query.where(QJurorPool.jurorPool.pool.poolNumber.eq(request.getPoolNumber()));
         query.orderBy(
-            QJurorPool.jurorPool.pool.poolNumber.asc()
+            QJurorPool.jurorPool.pool.poolNumber.asc(),
+            QJurorPool.jurorPool.juror.jurorNumber.asc()
         );
     }
 

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/report/standard/PoolSelectionListReport.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/report/standard/PoolSelectionListReport.java
@@ -1,0 +1,53 @@
+package uk.gov.hmcts.juror.api.moj.report.standard;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQuery;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.juror.api.moj.controller.reports.request.StandardReportRequest;
+import uk.gov.hmcts.juror.api.moj.controller.reports.response.StandardReportResponse;
+import uk.gov.hmcts.juror.api.moj.controller.reports.response.StandardTableData;
+import uk.gov.hmcts.juror.api.moj.domain.QJurorPool;
+import uk.gov.hmcts.juror.api.moj.report.AbstractStandardReport;
+import uk.gov.hmcts.juror.api.moj.report.DataType;
+import uk.gov.hmcts.juror.api.moj.repository.PoolRequestRepository;
+
+import java.util.Map;
+
+@Component
+public class PoolSelectionListReport extends AbstractStandardReport {
+    @Autowired
+    public PoolSelectionListReport(PoolRequestRepository poolRequestRepository) {
+        super(poolRequestRepository,
+            QJurorPool.jurorPool,
+            DataType.JUROR_NUMBER,
+            DataType.FIRST_NAME,
+            DataType.LAST_NAME,
+            DataType.JUROR_POSTCODE,
+            DataType.DISQUALIFIED_ON_SELECTION);
+    }
+
+    @Override
+    public Class<? extends Validators.AbstractRequestValidator> getRequestValidatorClass() {
+        return RequestValidator.class;
+    }
+
+    @Override
+    protected void preProcessQuery(JPAQuery<Tuple> query, StandardReportRequest request) {
+        query.where(QJurorPool.jurorPool.pool.poolNumber.eq(request.getPoolNumber()));
+        query.orderBy(QJurorPool.jurorPool.juror.jurorNumber.asc());
+    }
+
+    @Override
+    public Map<String, StandardReportResponse.DataTypeValue> getHeadings(
+        StandardReportRequest request,
+        StandardReportResponse.TableData<StandardTableData> tableData) {
+        return loadStandardPoolHeaders(request, true, true);
+    }
+
+    public interface RequestValidator extends
+        Validators.AbstractRequestValidator,
+        Validators.RequirePoolNumber {
+
+    }
+}

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/report/standard/AvailableListByPoolReportTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/report/standard/AvailableListByPoolReportTest.java
@@ -58,7 +58,8 @@ class AvailableListByPoolReportTest extends AbstractStandardReportTestSupport<Av
         verify(query, times(1))
             .where(QJurorPool.jurorPool.pool.poolNumber.eq(request.getPoolNumber()));
         verify(query, times(1))
-            .orderBy(QJurorPool.jurorPool.pool.poolNumber.asc());
+            .orderBy(QJurorPool.jurorPool.pool.poolNumber.asc(),
+                QJurorPool.jurorPool.juror.jurorNumber.asc());
         verify(report, times(1))
             .addStandardFilters(query, request);
     }

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/report/standard/PoolSelectionReportTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/report/standard/PoolSelectionReportTest.java
@@ -1,0 +1,79 @@
+package uk.gov.hmcts.juror.api.moj.report.standard;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQuery;
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.juror.api.TestConstants;
+import uk.gov.hmcts.juror.api.moj.controller.reports.request.StandardReportRequest;
+import uk.gov.hmcts.juror.api.moj.controller.reports.response.AbstractReportResponse;
+import uk.gov.hmcts.juror.api.moj.controller.reports.response.StandardReportResponse;
+import uk.gov.hmcts.juror.api.moj.controller.reports.response.StandardTableData;
+import uk.gov.hmcts.juror.api.moj.domain.QJurorPool;
+import uk.gov.hmcts.juror.api.moj.report.AbstractStandardReportTestSupport;
+import uk.gov.hmcts.juror.api.moj.report.DataType;
+import uk.gov.hmcts.juror.api.moj.repository.PoolRequestRepository;
+
+import java.util.Map;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class PoolSelectionReportTest extends AbstractStandardReportTestSupport<PoolSelectionListReport> {
+    public PoolSelectionReportTest() {
+        super(QJurorPool.jurorPool,
+            PoolSelectionListReport.RequestValidator.class,
+            DataType.JUROR_NUMBER,
+            DataType.FIRST_NAME,
+            DataType.LAST_NAME,
+            DataType.JUROR_POSTCODE,
+            DataType.DISQUALIFIED_ON_SELECTION);
+    }
+
+    @Override
+    public PoolSelectionListReport createReport(PoolRequestRepository poolRequestRepository) {
+        return new PoolSelectionListReport(poolRequestRepository);
+    }
+
+    @Override
+    protected StandardReportRequest getValidRequest() {
+        return StandardReportRequest.builder()
+            .reportType(report.getName())
+            .poolNumber(TestConstants.VALID_POOL_NUMBER)
+            .build();
+    }
+
+
+    @Override
+    public void positivePreProcessQueryTypical(JPAQuery<Tuple> query, StandardReportRequest request) {
+        report.preProcessQuery(query, request);
+        verify(query, times(1))
+            .where(QJurorPool.jurorPool.pool.poolNumber.eq(TestConstants.VALID_POOL_NUMBER));
+        verify(query, times(1))
+            .orderBy(QJurorPool.jurorPool.juror.jurorNumber.asc());
+    }
+
+    @Override
+    public Map<String, StandardReportResponse.DataTypeValue> positiveGetHeadingsTypical(
+        StandardReportRequest request,
+        AbstractReportResponse.TableData<StandardTableData> tableData,
+        StandardTableData data) {
+
+        Map<String, StandardReportResponse.DataTypeValue> map = report.getHeadings(request, tableData);
+        assertHeadingContains(map, request, true, Map.of());
+        return map;
+    }
+
+    @Test
+    void negativeMissingPoolNumber() {
+        StandardReportRequest request = getValidRequest();
+        request.setPoolNumber(null);
+        assertValidationFails(request, new ValidationFailure("poolNumber", "must not be null"));
+    }
+
+    @Test
+    void negativeInvalidPoolNumber() {
+        StandardReportRequest request = getValidRequest();
+        request.setPoolNumber(TestConstants.INVALID_POOL_NUMBER);
+        assertValidationFails(request, new ValidationFailure("poolNumber", "must match \"^\\d{9}$\""));
+    }
+}


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7499)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=464)


### Change description ###
he system shall enable the court or bureau officer to generate a pool selection list.

 

# The system shall ask the officer to enter a pool number ( can be partial)
#* The system shall error if no pool number entered.
# The system shall display all pools that meet the search criteria for bureau this is across all court for courts only the court you are logged in as:
#* Pool number (hyperlink)
#* Court name
#* Pool stage
#* Pool status
#* Pool type
#* Service start date
# The system shall allow the officer to continue with the selected pool
# The system shall display the following details in the report header
#* Pool number
#* Pool type
#* Service start date
#* Report created
#* Time created
#* Court name
# The system shall display the following columns for the report
#* Juror number (hyperlink)
#* First name
#* Last name
#* Postcode
#* Disqualified on selection
# The system shall allow the officer to print the report as a PDF
# The system shall allow the officer to export the data as a PDF in the same columns as the report

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
