### PR TITLE
Deferred List - Court name report picking up total from days instead of Number of deferred

### DIFF
--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/report/grouped/DeferredListByCourtReportITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/report/grouped/DeferredListByCourtReportITest.java
@@ -67,7 +67,7 @@ class DeferredListByCourtReportITest extends AbstractGroupedReportControllerITes
     }
 
     private GroupedReportResponse getTypicalResponse() {
-        return createResponse(4,
+        return createResponse(5,
             new GroupedTableData()
                 .add("CHESTER (415)", List.of(
                     new ReportLinkedMap<String, Object>()
@@ -86,7 +86,7 @@ class DeferredListByCourtReportITest extends AbstractGroupedReportControllerITes
     }
 
     private GroupedReportResponse getTypicalResponseBureau() {
-        return createResponse(5,
+        return createResponse(8,
             new GroupedTableData()
                 .add("CHESTER (415)", List.of(
                     new ReportLinkedMap<String, Object>()

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/report/grouped/DeferredListByCourtReport.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/report/grouped/DeferredListByCourtReport.java
@@ -22,8 +22,6 @@ import java.util.concurrent.ConcurrentHashMap;
 @Component
 public class DeferredListByCourtReport extends AbstractGroupedReport {
 
-    private final PoolRequestRepository poolRequestRepository;
-
     @Autowired
     public DeferredListByCourtReport(PoolRequestRepository poolRequestRepository) {
         super(poolRequestRepository,
@@ -34,7 +32,6 @@ public class DeferredListByCourtReport extends AbstractGroupedReport {
                 .build(),
             DataType.DEFERRED_TO,
             DataType.NUMBER_DEFERRED);
-        this.poolRequestRepository = poolRequestRepository;
     }
 
 
@@ -62,7 +59,10 @@ public class DeferredListByCourtReport extends AbstractGroupedReport {
         headings.put("total_deferred", GroupedReportResponse.DataTypeValue.builder()
             .displayName("Total deferred")
             .dataType(Long.class.getSimpleName())
-            .value(tableData.getData().getSize())
+            .value(tableData.getData().getAllDataItems()
+                .stream()
+                .map(row -> (Long) row.get(DataType.NUMBER_DEFERRED.getId()))
+                .reduce(0L, Long::sum))
             .build());
 
         return headings;

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/report/grouped/DeferredListByCourtReportTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/report/grouped/DeferredListByCourtReportTest.java
@@ -20,6 +20,7 @@ import uk.gov.hmcts.juror.api.moj.report.ReportGroupBy;
 import uk.gov.hmcts.juror.api.moj.repository.PoolRequestRepository;
 import uk.gov.hmcts.juror.api.moj.utils.SecurityUtil;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.mockito.Mockito.RETURNS_SELF;
@@ -112,8 +113,16 @@ class DeferredListByCourtReportTest extends AbstractGroupedReportTestSupport<Def
         StandardReportRequest request,
         AbstractReportResponse.TableData<GroupedTableData> tableData,
         GroupedTableData data) {
-
-        when(data.getSize()).thenReturn(3L);
+        when(data.getAllDataItems()).thenReturn(
+            List.of(
+                new GroupedTableData()
+                    .add("number_deferred", 2L),
+                new GroupedTableData()
+                    .add("number_deferred", 3L),
+                new GroupedTableData()
+                    .add("number_deferred", 4L)
+            )
+        );
 
         securityUtilMockedStatic.when(SecurityUtil::getActiveOwner).thenReturn(TestConstants.VALID_COURT_LOCATION);
 
@@ -126,7 +135,7 @@ class DeferredListByCourtReportTest extends AbstractGroupedReportTestSupport<Def
                 StandardReportResponse.DataTypeValue.builder()
                     .displayName("Total deferred")
                     .dataType(Long.class.getSimpleName())
-                    .value(3L)
+                    .value(9L)
                     .build()
             ));
         verify(tableData, times(1)).getData();


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7523)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=%pullRequestNumber%)


### Change description ###
Both court name and by date reports for deferred list should pick up the number of deferred jurors. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
