### PR TITLE
Updated jwt expiry to be a long instead of a string

### DIFF
--- a/charts/juror-api/Chart.yaml
+++ b/charts/juror-api/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for juror-api App
 name: juror-api
 home: https://github.com/hmcts/juror-api
-version: 0.0.9
+version: 0.0.10
 maintainers:
   - name: HMCTS juror team
 dependencies:

--- a/charts/juror-api/values.yaml
+++ b/charts/juror-api/values.yaml
@@ -56,3 +56,4 @@ java:
     PNC_CHECK_SERVICE_SUBJECT: juror-back-end
     PNC_CHECK_SERVICE_HOST: juror-pnc.{{ .Values.global.environment }}.platform.hmcts.net
     PNC_CHECK_SERVICE_PORT: 443
+    TOKEN_EXPIRY: 30m

--- a/charts/juror-api/values.yaml
+++ b/charts/juror-api/values.yaml
@@ -56,4 +56,3 @@ java:
     PNC_CHECK_SERVICE_SUBJECT: juror-back-end
     PNC_CHECK_SERVICE_HOST: juror-pnc.{{ .Values.global.environment }}.platform.hmcts.net
     PNC_CHECK_SERVICE_PORT: 443
-    TOKEN_EXPIRY: 3600000

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/JwtServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/JwtServiceImpl.java
@@ -109,7 +109,7 @@ public class JwtServiceImpl implements JwtService {
             case "h" -> number * 3600000;
             case "m" -> number * 60000;
             case "s" -> number * 1000;
-            default -> throw new MojException.InternalServerError("Unkonwn number format:  '" + value + "'", null);
+            default -> throw new MojException.InternalServerError("Unknown number format:  '" + value + "'", null);
         };
     }
 }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/JwtServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/JwtServiceImpl.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.juror.api.config.InvalidJwtAuthenticationException;
 import uk.gov.hmcts.juror.api.config.bureau.BureauJwtPayload;
+import uk.gov.hmcts.juror.api.moj.exception.MojException;
 
 import java.security.Key;
 import java.time.Clock;
@@ -27,7 +28,7 @@ public class JwtServiceImpl implements JwtService {
     private String bureauSecret;
 
     @Value("${jwt.expiry.bureau}")
-    private Long bureauExpiry;
+    private String bureauExpiry;
 
     @Autowired
     public JwtServiceImpl(Clock clock) {
@@ -95,9 +96,20 @@ public class JwtServiceImpl implements JwtService {
             id,
             "juror",
             null,
-            bureauExpiry,
+            timeUnitToMilliseconds(bureauExpiry),
             getSigningKey(bureauSecret),
             payload.toClaims()
         );
+    }
+
+    private long timeUnitToMilliseconds(String value) {
+        String lastDigit = value.substring(value.length() - 1).toLowerCase();
+        long number = Long.parseLong(value.substring(0, value.length() - 2));
+        return switch (lastDigit) {
+            case "h" -> number * 3600000;
+            case "m" -> number * 60000;
+            case "s" -> number * 1000;
+            default -> throw new MojException.InternalServerError("Unkonwn number format:  '" + value + "'", null);
+        };
     }
 }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/JwtServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/JwtServiceImpl.java
@@ -27,7 +27,7 @@ public class JwtServiceImpl implements JwtService {
     private String bureauSecret;
 
     @Value("${jwt.expiry.bureau}")
-    private String bureauExpiry;
+    private Long bureauExpiry;
 
     @Autowired
     public JwtServiceImpl(Clock clock) {
@@ -95,7 +95,7 @@ public class JwtServiceImpl implements JwtService {
             id,
             "juror",
             null,
-            Long.parseLong(bureauExpiry),
+            bureauExpiry,
             getSigningKey(bureauSecret),
             payload.toClaims()
         );

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/JwtServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/JwtServiceImpl.java
@@ -104,7 +104,7 @@ public class JwtServiceImpl implements JwtService {
 
     private long timeUnitToMilliseconds(String value) {
         String lastDigit = value.substring(value.length() - 1).toLowerCase();
-        long number = Long.parseLong(value.substring(0, value.length() - 2));
+        long number = Long.parseLong(value.substring(0, value.length() - 1));
         return switch (lastDigit) {
             case "h" -> number * 3600000;
             case "m" -> number * 60000;

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -17,7 +17,7 @@
     },
     {
       "name": "jwt.expiry.bureau",
-      "type": "java.lang.String",
+      "type": "java.lang.Long",
       "description": "Expiry in milliseconds."
     }
   ]

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -17,8 +17,8 @@
     },
     {
       "name": "jwt.expiry.bureau",
-      "type": "java.lang.Long",
-      "description": "Expiry in milliseconds."
+      "type": "java.lang.String",
+      "description": "Expiry 1h = 1 hour. 1m = 1 minute. 1s = 1 second."
     }
   ]
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,7 @@ management:
         include: health, info
 jwt:
   expiry:
-    bureau: ${TOKEN_EXPIRY:3600000}
+    bureau: ${TOKEN_EXPIRY:30m}
   secret:
     hmac: ${JWT_SECRET_HMAC:}
     public: ${JWT_SECRET_PUBLIC:}

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/JwtServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/JwtServiceImplTest.java
@@ -55,7 +55,7 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings({"unchecked", "PMD.ExcessiveImports"})
 @TestPropertySource(properties = {
     "jwt.secret.bureau=" + TestConstants.JWT_SECRET,
-    "jwt.expiry.bureau=" + TestConstants.JWT_EXPIRY
+    "jwt.expiry.bureau=" + TestConstants.JWT_EXPIRY_STR
 })
 class JwtServiceImplTest {
 

--- a/src/test/java/uk/gov/hmcts/juror/api/utils/TestConstants.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/utils/TestConstants.java
@@ -3,7 +3,8 @@ package uk.gov.hmcts.juror.api.utils;
 public class TestConstants {
     public static final String JWT = "GeneratedJwtFromSecret";
     public static final String JWT_SECRET = "dGhpcy1pcy1hLXRlc3Qta2V5LWZvci11cy13aGVuLWNyZWF0aW5nLXNlY3JldHM=";
-    public static final long JWT_EXPIRY = 36000;
+    public static final String JWT_EXPIRY_STR = "1m";
+    public static final long JWT_EXPIRY = 60000;
 
     protected TestConstants() {
 


### PR DESCRIPTION
### Change description ###
Updated jwt expiry to be a long instead of a string


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
