### PR TITLE
Jury Summoning Monitor - courts with no data erroring

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/report/JurySummoningMonitorReportServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/report/JurySummoningMonitorReportServiceImpl.java
@@ -21,6 +21,7 @@ import uk.gov.hmcts.juror.api.moj.utils.SecurityUtil;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -78,7 +79,12 @@ public class JurySummoningMonitorReportServiceImpl implements JurySummoningMonit
 
     private void setupResponseDto(JurySummoningMonitorReportResponse response, String result) {
         if (result != null && !result.isEmpty()) {
-            List<String> values = List.of(result.split(","));
+            List<String> values = Arrays.stream(result.split(",")).map(item -> {
+                if (item.equals("null")) {
+                    return "0";
+                }
+                return item;
+            }).toList();
             setupResponse(response, values);
         }
     }


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7564)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=%pullRequestNumber%)


### Change description ###
Select courts currently erroring when making a search on the jury summoning monitor report. By the looks of it, it is courts which have no data.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
