### PR TITLE
Mark as undeliverable (bulk) (BE)

### DIFF
--- a/src/integration-test/resources/db/UndeliverableResponseController_createInitialPoolRecords.sql
+++ b/src/integration-test/resources/db/UndeliverableResponseController_createInitialPoolRecords.sql
@@ -12,9 +12,11 @@ INSERT INTO JUROR_MOD.POOL (OWNER, POOL_NO, RETURN_DATE, TOTAL_NO_REQUIRED, NO_R
 
 INSERT INTO juror_mod.juror (juror_number, last_name, first_name, dob, address_line_1, address_line_4, postcode, responded)
 VALUES ('123456789', 'LNAME', 'FNAME', CURRENT_DATE - interval '30 years', '540 STREET NAME', 'ANYTOWN', 'CH1 2AN', false),
+       ('123456788', 'LNAME', 'FNAME', CURRENT_DATE - interval '30 years', '540 STREET NAME', 'ANYTOWN', 'CH1 2AN', false),
 ('222222224', 'LNAME', 'FNAME', CURRENT_DATE - interval '30 years', '540 STREET NAME', 'ANYTOWN','CH1 2AN', false);
 
 INSERT INTO juror_mod.juror_pool (owner, juror_number, pool_number, is_active, next_date, status, def_date)
 VALUES
 ('400', '123456789', '415220502', true, CURRENT_DATE + interval '6 weeks', 9, '2022-10-03'),
+('400', '123456788', '415220502', true, CURRENT_DATE + interval '6 weeks', 9, '2022-10-03'),
 ('415', '222222224', '415220502', true, CURRENT_DATE + interval '6 weeks', 9, '2022-10-03');

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/UndeliverableResponseController.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/UndeliverableResponseController.java
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.juror.api.bureau.exception.ExcusalException;
-import uk.gov.hmcts.juror.api.config.security.IsBureauUser;
 import uk.gov.hmcts.juror.api.moj.controller.request.JurorNumberListDto;
 import uk.gov.hmcts.juror.api.moj.service.UndeliverableResponseService;
 

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/UndeliverableResponseController.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/UndeliverableResponseController.java
@@ -25,7 +25,6 @@ import uk.gov.hmcts.juror.api.moj.service.UndeliverableResponseService;
 @RequiredArgsConstructor(onConstructor_ = {@Autowired})
 @Validated
 @Tag(name = "Summons Management")
-@IsBureauUser
 public class UndeliverableResponseController {
     private final UndeliverableResponseService undeliverableResponseService;
 

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/UndeliverableResponseController.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/UndeliverableResponseController.java
@@ -2,25 +2,22 @@ package uk.gov.hmcts.juror.api.moj.controller;
 
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.juror.api.bureau.exception.ExcusalException;
-import uk.gov.hmcts.juror.api.config.bureau.BureauJwtPayload;
+import uk.gov.hmcts.juror.api.config.security.IsBureauUser;
+import uk.gov.hmcts.juror.api.moj.controller.request.JurorNumberListDto;
 import uk.gov.hmcts.juror.api.moj.service.UndeliverableResponseService;
-import uk.gov.hmcts.juror.api.validation.JurorNumber;
 
 @Slf4j
 @RestController
@@ -28,16 +25,15 @@ import uk.gov.hmcts.juror.api.validation.JurorNumber;
 @RequiredArgsConstructor(onConstructor_ = {@Autowired})
 @Validated
 @Tag(name = "Summons Management")
+@IsBureauUser
 public class UndeliverableResponseController {
-    @NonNull
     private final UndeliverableResponseService undeliverableResponseService;
 
-    @PutMapping("/{jurorNumber}")
     @Operation(summary = "Mark a Juror as undeliverable with information provided")
+    @PatchMapping
     public ResponseEntity<Void> markJurorAsUndeliverable(
-        @Parameter(hidden = true) @AuthenticationPrincipal BureauJwtPayload payload,
-        @PathVariable(name = "jurorNumber") @JurorNumber @Valid String jurorNumber) throws ExcusalException {
-        undeliverableResponseService.markAsUndeliverable(payload, jurorNumber);
+        @RequestBody @Valid JurorNumberListDto jurorNumbers) throws ExcusalException {
+        undeliverableResponseService.markAsUndeliverable(jurorNumbers.getJurorNumbers());
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/JurorHistoryService.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/JurorHistoryService.java
@@ -69,4 +69,6 @@ public interface JurorHistoryService {
     void createPoolAttendanceHistory(JurorPool jurorPool, String otherInfo);
 
     public String getHistoryDescription(String historyCode);
+
+    void createUndeliveredSummonsHistory(JurorPool jurorPool);
 }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/JurorHistoryServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/JurorHistoryServiceImpl.java
@@ -55,6 +55,7 @@ public class JurorHistoryServiceImpl implements JurorHistoryService {
         return getHistoryCodeMap().get(historyCode);
     }
 
+
     @Override
     public void createPoliceCheckDisqualifyHistory(JurorPool jurorPool) {
         registerHistorySystem(jurorPool, HistoryCodeMod.POLICE_CHECK_FAILED, "Failed");
@@ -239,6 +240,12 @@ public class JurorHistoryServiceImpl implements JurorHistoryService {
     @Override
     public void createIdentityConfirmedHistory(JurorPool jurorPool) {
         registerHistorySystem(jurorPool, HistoryCodeMod.CHECK_ID, "Id confirmed");
+    }
+
+    @Override
+    public void createUndeliveredSummonsHistory(JurorPool jurorPool) {
+        registerHistoryLoginUser(jurorPool, HistoryCodeMod.UNDELIVERED_SUMMONS, null);
+
     }
 
     public void createPostponementLetterHistory(JurorPool jurorPool, String confirmationLetter) {

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/UndeliverableResponseService.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/UndeliverableResponseService.java
@@ -1,11 +1,10 @@
 package uk.gov.hmcts.juror.api.moj.service;
 
-import uk.gov.hmcts.juror.api.config.bureau.BureauJwtPayload;
+import java.util.List;
 
 public interface UndeliverableResponseService {
-
     /**
      * Mark a Juror as Undeliverable with specific code.
      */
-    void markAsUndeliverable(BureauJwtPayload payload, String jurorNumber);
+    void markAsUndeliverable(List<String> jurorNumber);
 }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/utils/JurorPoolUtils.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/utils/JurorPoolUtils.java
@@ -188,7 +188,6 @@ public final class JurorPoolUtils {
         List<JurorPool> jurorPoolDetails = jurorPoolRepository
             .findByJurorJurorNumberAndIsActive(jurorNumber, true);
         log.debug("{} Active Juror Record(s) found for Juror Number: {}", jurorPoolDetails.size(), jurorNumber);
-
         switch (jurorPoolDetails.size()) {
             case 0 -> throw new MojException.NotFound(String.format("Unable to find a Juror Pool association for"
                 + "Juror Number %s", jurorNumber), null);

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/UndeliverableResponseServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/UndeliverableResponseServiceTest.java
@@ -1,12 +1,15 @@
 package uk.gov.hmcts.juror.api.moj.service;
 
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.hmcts.juror.api.TestUtils;
 import uk.gov.hmcts.juror.api.config.bureau.BureauJwtPayload;
 import uk.gov.hmcts.juror.api.juror.domain.CourtLocation;
 import uk.gov.hmcts.juror.api.moj.domain.Juror;
@@ -14,7 +17,6 @@ import uk.gov.hmcts.juror.api.moj.domain.JurorPool;
 import uk.gov.hmcts.juror.api.moj.domain.JurorStatus;
 import uk.gov.hmcts.juror.api.moj.domain.PoolRequest;
 import uk.gov.hmcts.juror.api.moj.exception.MojException;
-import uk.gov.hmcts.juror.api.moj.repository.JurorHistoryRepository;
 import uk.gov.hmcts.juror.api.moj.repository.JurorPoolRepository;
 
 import java.util.ArrayList;
@@ -23,21 +25,37 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-@RunWith(SpringRunner.class)
-public class UndeliverableResponseServiceTest {
+@ExtendWith(SpringExtension.class)
+class UndeliverableResponseServiceTest {
 
     @Mock
-    private JurorHistoryRepository jurorHistoryRepository;
+    private JurorHistoryService jurorHistoryService;
     @Mock
     private JurorPoolRepository jurorPoolRepository;
 
     @InjectMocks
-    UndeliverableResponseServiceImpl undeliverableResponseService;
+    private UndeliverableResponseServiceImpl undeliverableResponseService;
 
+    private static final String LOGIN = "BUREAU_USER";
+    private static final String OWNER = "400";
+
+    @BeforeEach
+    void beforeEach() {
+        TestUtils.mockSecurityUtil(
+            BureauJwtPayload.builder()
+                .owner(OWNER)
+                .login(LOGIN)
+                .build()
+        );
+    }
+
+    @AfterEach
+    void afterAll() {
+        TestUtils.afterAll();
+    }
 
     @Test
-    public void test_jurorRecordDoesNotExist() {
-        String owner = "400";
+    void negativeJurorRecordDoesNotExist() {
         String jurorNumber = "111111111";
 
         List<JurorPool> members = new ArrayList<>();
@@ -45,63 +63,84 @@ public class UndeliverableResponseServiceTest {
         Mockito.doReturn(members).when(jurorPoolRepository)
             .findByJurorJurorNumberAndIsActive(jurorNumber, true);
         assertThatExceptionOfType(MojException.NotFound.class).isThrownBy(
-            () -> undeliverableResponseService.markAsUndeliverable(buildPayload(owner), jurorNumber));
+            () -> undeliverableResponseService.markAsUndeliverable(List.of(jurorNumber)));
 
         Mockito.verify(jurorPoolRepository, Mockito.times(1))
             .findByJurorJurorNumberAndIsActive(jurorNumber, true);
         Mockito.verify(jurorPoolRepository, Mockito.never()).save(Mockito.any());
-        Mockito.verify(jurorHistoryRepository, Mockito.never()).save(Mockito.any());
+        Mockito.verify(jurorHistoryService, Mockito.never()).createUndeliveredSummonsHistory(Mockito.any());
     }
 
 
     @Test
-    public void test_jurorRecordIsNotOwned() {
-        String owner = "415";
+    void negativeJurorRecordIsNotOwned() {
         String jurorNumber = "123456789";
 
         List<JurorPool> members = new ArrayList<>();
-        members.add(createValidJurorPool(jurorNumber, "400"));
+        members.add(createValidJurorPool(jurorNumber, "415"));
 
         Mockito.doReturn(members).when(jurorPoolRepository)
             .findByJurorJurorNumberAndIsActive(jurorNumber, true);
 
         assertThatExceptionOfType(MojException.Forbidden.class).isThrownBy(
-            () -> undeliverableResponseService.markAsUndeliverable(buildPayload(owner), jurorNumber));
+            () -> undeliverableResponseService.markAsUndeliverable(List.of(jurorNumber)));
 
         Mockito.verify(jurorPoolRepository, Mockito.times(1))
             .findByJurorJurorNumberAndIsActive(jurorNumber, true);
         Mockito.verify(jurorPoolRepository, Mockito.never()).save(Mockito.any());
-        Mockito.verify(jurorHistoryRepository, Mockito.never()).save(Mockito.any());
+        Mockito.verify(jurorHistoryService, Mockito.never()).createUndeliveredSummonsHistory(Mockito.any());
 
     }
 
     @Test
-    public void test_markJurorAsUndeliverable() {
-        String owner = "400";
+    void positiveMarkJurorAsUndeliverable() {
         String jurorNumber = "222222225";
 
-        JurorPool jurorPool = createValidJurorPool(jurorNumber, owner);
+        JurorPool jurorPool = createValidJurorPool(jurorNumber, OWNER);
         List<JurorPool> members = new ArrayList<>();
         members.add(jurorPool);
 
         Mockito.doReturn(members).when(jurorPoolRepository)
             .findByJurorJurorNumberAndIsActive(jurorNumber, true);
 
-        undeliverableResponseService.markAsUndeliverable(buildPayload(owner), jurorNumber);
+        undeliverableResponseService.markAsUndeliverable(List.of(jurorNumber));
 
         Mockito.verify(jurorPoolRepository, Mockito.times(1))
             .findByJurorJurorNumberAndIsActive(Mockito.any(), Mockito.anyBoolean());
         Mockito.verify(jurorPoolRepository, Mockito.times(1)).save(Mockito.any());
-        Mockito.verify(jurorHistoryRepository, Mockito.times(1)).save(Mockito.any());
-
+        Mockito.verify(jurorHistoryService, Mockito.times(1)).createUndeliveredSummonsHistory(jurorPool);
     }
 
-    private BureauJwtPayload buildPayload(String owner) {
-        return BureauJwtPayload.builder()
-            .userLevel("99")
-            .login("BUREAU_USER")
-            .owner(owner)
-            .build();
+    @Test
+    void positiveMarkJurorAsUndeliverableMultiple() {
+        String jurorNumber1 = "222222225";
+        String jurorNumber2 = "222222226";
+
+        JurorPool jurorPool1 = createValidJurorPool(jurorNumber1, OWNER);
+        JurorPool jurorPool2 = createValidJurorPool(jurorNumber2, OWNER);
+        List<JurorPool> members1 = new ArrayList<>();
+        members1.add(jurorPool1);
+
+        List<JurorPool> members2 = new ArrayList<>();
+        members2.add(jurorPool2);
+
+        Mockito.doReturn(members1).when(jurorPoolRepository)
+            .findByJurorJurorNumberAndIsActive(jurorNumber1, true);
+        Mockito.doReturn(members2).when(jurorPoolRepository)
+            .findByJurorJurorNumberAndIsActive(jurorNumber2, true);
+
+        undeliverableResponseService.markAsUndeliverable(List.of(jurorNumber1, jurorNumber2));
+
+        Mockito.verify(jurorPoolRepository, Mockito.times(1))
+            .findByJurorJurorNumberAndIsActive(jurorNumber1, true);
+        Mockito.verify(jurorPoolRepository, Mockito.times(1))
+            .findByJurorJurorNumberAndIsActive(jurorNumber2, true);
+        Mockito.verify(jurorPoolRepository, Mockito.times(1)).save(jurorPool1);
+        Mockito.verify(jurorPoolRepository, Mockito.times(1)).save(jurorPool2);
+        Mockito.verify(jurorHistoryService, Mockito.times(1))
+            .createUndeliveredSummonsHistory(jurorPool1);
+        Mockito.verify(jurorHistoryService, Mockito.times(1))
+            .createUndeliveredSummonsHistory(jurorPool2);
     }
 
     private JurorPool createValidJurorPool(String jurorNumber, String owner) {


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7589)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=500)


### Change description ###
Bureau Only (all bureau officers)

In the summons reply module we need a new heading Mark as undeliverable

The system shall allow the officer to enter or scan in Jurors and build up a list with the following columns:

Juror number (hyperlink)

First name

Last name

Address

Postcode

Court

they system shall allow the officer to submit the jurors to mark an undeliverable

The system shall display a a holding screen to confirm the action. ‘this will mark X jurors as undeliverable status’ 

the system shall allow the juror to continue and display the success banner ‘x number of jurors marked as undeliverable’

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
