### PR TITLE
Mark as undeliverable (bulk) (FE)

### DIFF
--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorRecordControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorRecordControllerITest.java
@@ -54,6 +54,7 @@ import uk.gov.hmcts.juror.api.moj.controller.response.JurorDetailsCommonResponse
 import uk.gov.hmcts.juror.api.moj.controller.response.JurorDetailsResponseDto;
 import uk.gov.hmcts.juror.api.moj.controller.response.JurorNotesDto;
 import uk.gov.hmcts.juror.api.moj.controller.response.JurorOverviewResponseDto;
+import uk.gov.hmcts.juror.api.moj.controller.response.JurorPoolDetailsDto;
 import uk.gov.hmcts.juror.api.moj.controller.response.JurorRecordSearchDto;
 import uk.gov.hmcts.juror.api.moj.controller.response.JurorSummonsReplyResponseDto;
 import uk.gov.hmcts.juror.api.moj.controller.response.NameDetails;
@@ -4489,6 +4490,54 @@ class JurorRecordControllerITest extends AbstractIntegrationTest {
             }
 
             @Test
+            void typicalBureauGetAllDetails() {
+                setAuthorization("BUREAU_USER", "400", UserType.BUREAU, Role.MANAGER);
+
+                ResponseEntity<FilterableJurorDetailsResponseDto[]> responseEntity = triggerValid(
+                    createDto(TestConstants.VALID_JUROR_NUMBER, null,
+                              FilterableJurorDetailsRequestDto.IncludeType.NAME_DETAILS,
+                              FilterableJurorDetailsRequestDto.IncludeType.PAYMENT_DETAILS,
+                              FilterableJurorDetailsRequestDto.IncludeType.ADDRESS_DETAILS,
+                              FilterableJurorDetailsRequestDto.IncludeType.ACTIVE_POOL)
+                );
+
+                //Count validated in triggerValid so no need to do here
+                FilterableJurorDetailsResponseDto responseDto = Objects.requireNonNull(responseEntity.getBody())[0];
+                assertThat(responseDto.getJurorNumber()).isEqualTo(TestConstants.VALID_JUROR_NUMBER);
+                assertThat(responseDto.getJurorVersion()).isNull();
+
+                assertThat(responseDto.getNameDetails()).isNotNull();
+                assertThat(responseDto.getPaymentDetails()).isNotNull();
+                assertThat(responseDto.getAddress()).isNotNull();
+                assertThat(responseDto.getActivePool()).isNotNull();
+
+
+                NameDetails nameDetails = responseDto.getNameDetails();
+                assertThat(nameDetails.getTitle()).isEqualTo("Mr");
+                assertThat(nameDetails.getFirstName()).isEqualTo("FNAME");
+                assertThat(nameDetails.getLastName()).isEqualTo("LNAME");
+
+                PaymentDetails paymentDetails = responseDto.getPaymentDetails();
+                assertThat(paymentDetails.getSortCode()).isEqualTo("112233");
+                assertThat(paymentDetails.getBankAccountName()).isEqualTo("Bank NAME");
+                assertThat(paymentDetails.getBankAccountNumber()).isEqualTo("12345678");
+                assertThat(paymentDetails.getBuildingSocietyRollNumber()).isNull();
+
+                JurorAddressDto jurorAddressDto = responseDto.getAddress();
+                assertThat(jurorAddressDto.getLineOne()).isEqualTo("Address Line 1");
+                assertThat(jurorAddressDto.getLineTwo()).isEqualTo("Address Line 2");
+                assertThat(jurorAddressDto.getLineThree()).isEqualTo("Address Line 3");
+                assertThat(jurorAddressDto.getTown()).isEqualTo("Address Line 4");
+                assertThat(jurorAddressDto.getCounty()).isEqualTo("Address Line 5");
+                assertThat(jurorAddressDto.getPostcode()).isEqualTo("CH1 2AN");
+
+                JurorPoolDetailsDto jurorPoolDetailsDto = responseDto.getActivePool();
+                assertThat(jurorPoolDetailsDto.getPoolNumber()).isEqualTo("415220502");
+                assertThat(jurorPoolDetailsDto.getCourtName()).isEqualTo("CHESTER");
+                assertThat(jurorPoolDetailsDto.getStatus()).isEqualTo("Responded");
+            }
+
+            @Test
             void testGSingleGetNameDetails() {
                 ResponseEntity<FilterableJurorDetailsResponseDto[]> responseEntity = triggerValid(
                     createDto(TestConstants.VALID_JUROR_NUMBER, null,
@@ -4712,6 +4761,27 @@ class JurorRecordControllerITest extends AbstractIntegrationTest {
                 assertThat(jurorAddressDto3.getCounty()).isEqualTo("Country123");
                 assertThat(jurorAddressDto3.getPostcode()).isEqualTo("BH2 4AN");
             }
+
+            @Test
+            void typicalCourtGetActivePoolDetails() {
+                ResponseEntity<FilterableJurorDetailsResponseDto[]> responseEntity = triggerValid(
+                    createDto(TestConstants.VALID_JUROR_NUMBER, null,
+                        FilterableJurorDetailsRequestDto.IncludeType.ACTIVE_POOL));
+                //Count validated in triggerValid so no need to do here
+                FilterableJurorDetailsResponseDto responseDto = Objects.requireNonNull(responseEntity.getBody())[0];
+                assertThat(responseDto.getJurorNumber()).isEqualTo(TestConstants.VALID_JUROR_NUMBER);
+                assertThat(responseDto.getJurorVersion()).isNull();
+
+                assertThat(responseDto.getNameDetails()).isNull();
+                assertThat(responseDto.getPaymentDetails()).isNull();
+                assertThat(responseDto.getAddress()).isNull();
+                assertThat(responseDto.getActivePool()).isNotNull();
+
+                JurorPoolDetailsDto jurorPoolDetailsDto = responseDto.getActivePool();
+                assertThat(jurorPoolDetailsDto.getPoolNumber()).isEqualTo("415220502");
+                assertThat(jurorPoolDetailsDto.getCourtName()).isEqualTo("CHESTER");
+                assertThat(jurorPoolDetailsDto.getStatus()).isEqualTo("Responded");
+            }
         }
 
         @DisplayName("Negative")
@@ -4753,18 +4823,6 @@ class JurorRecordControllerITest extends AbstractIntegrationTest {
 
                 assertInvalidPathParam(triggerInvalid(request),
                     "getJurorDetailsBulkFilterable.request[0].jurorNumber: must match \"^\\d{9}$\"");
-            }
-
-            @Test
-            @DisplayName("Unauthorised - none court user")
-            void unauthorisedNoneCourtUser() {
-                List<FilterableJurorDetailsRequestDto> request =
-                    List.of(createDto(TestConstants.VALID_JUROR_NUMBER, null,
-                        FilterableJurorDetailsRequestDto.IncludeType.PAYMENT_DETAILS));
-                setAuthorization("BUREAU_USER", "400", UserType.BUREAU, Role.MANAGER);
-
-                assertForbiddenResponse(restTemplate.exchange(
-                    new RequestEntity<>(request, httpHeaders, POST, URI.create(URL)), String.class), URL);
             }
 
             @Test

--- a/src/integration-test/resources/db/JurorRecordControllerITest_getJurorDetailsFiltered_typical.sql
+++ b/src/integration-test/resources/db/JurorRecordControllerITest_getJurorDetailsFiltered_typical.sql
@@ -38,3 +38,10 @@ VALUES (1, 1, '123456789',
         'Mr3', 'FNAME3', 'LNAME3',
         '3Address Line 1', '3Address Line 2', '3Address Line 3', '3Address Line 4', '3Address Line 5', 'CH3 2AN',
         '333333', '3Bank NAME', '33333333', null);
+
+INSERT INTO juror_mod.pool
+(pool_no, "owner", return_date, total_no_required, no_requested, pool_type, loc_code, new_request)
+VALUES ('415220502', '415', '2022-05-03', 5, 5, 'CRO', '415', 'N');
+
+INSERT INTO juror_mod.juror_pool (owner, juror_number, pool_number, is_active, next_date, status)
+VALUES ('415', '123456789', '415220502', true, '2022-05-03', 2);

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/JurorRecordController.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/JurorRecordController.java
@@ -105,7 +105,6 @@ public class JurorRecordController {
     @PostMapping("/details")
     @Operation(summary = "Get juror details for a juror number",
         description = "Retrieve details of a single juror by his/her juror number")
-    @IsCourtUser
     public ResponseEntity<List<FilterableJurorDetailsResponseDto>> getJurorDetailsBulkFilterable(
         @Valid
         @NotNull

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/response/JurorPoolDetailsDto.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/response/JurorPoolDetailsDto.java
@@ -14,14 +14,17 @@ public class JurorPoolDetailsDto {
     @JsonProperty("pool_number")
     private String poolNumber;
 
-
     @JsonProperty("status")
     private String status;
+
+    @JsonProperty("court_name")
+    private String courtName;
 
     public static JurorPoolDetailsDto from(JurorPool jurorPool) {
         return JurorPoolDetailsDto.builder()
             .poolNumber(jurorPool.getPoolNumber())
             .status(jurorPool.getStatus().getStatusDesc())
+            .courtName(jurorPool.getCourt().getName())
             .build();
     }
 }


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7588)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=503)


### Change description ###
Bureau Only (all bureau officers)

In the summons reply module we need a new heading Mark as undeliverable

The system shall allow the officer to enter or scan in Jurors and build up a list with the following columns:

Juror number (hyperlink)

First name

Last name

Address

Postcode

Court

they system shall allow the officer to submit the jurors to mark an undeliverable

The system shall display a a holding screen to confirm the action. ‘this will mark X jurors as undeliverable status’ 

the system shall allow the juror to continue and display the success banner ‘x number of jurors marked as undeliverable’

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
