### PR TITLE
Hotfix/jm 7534

### DIFF
--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/report/bespoke/JurorAmendmentByDateReportITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/report/bespoke/JurorAmendmentByDateReportITest.java
@@ -64,7 +64,7 @@ class JurorAmendmentByDateReportITest extends AbstractJurorAmendmentReportITest 
                                     .build(),
                                 StandardReportResponse.TableData.Heading.builder()
                                     .id("from")
-                                    .name("From")
+                                    .name("Changed from")
                                     .dataType("String")
                                     .headings(null)
                                     .build(),

--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/report/bespoke/JurorAmendmentByJurorReportITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/report/bespoke/JurorAmendmentByJurorReportITest.java
@@ -55,8 +55,8 @@ class JurorAmendmentByJurorReportITest extends AbstractJurorAmendmentReportITest
                                     .headings(null)
                                     .build(),
                                 StandardReportResponse.TableData.Heading.builder()
-                                    .id("to")
-                                    .name("To")
+                                    .id("from")
+                                    .name("Changed from")
                                     .dataType("String")
                                     .headings(null)
                                     .build(),

--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/report/bespoke/JurorAmendmentByPoolReportITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/report/bespoke/JurorAmendmentByPoolReportITest.java
@@ -73,7 +73,7 @@ class JurorAmendmentByPoolReportITest extends AbstractJurorAmendmentReportITest 
                                     .build(),
                                 StandardReportResponse.TableData.Heading.builder()
                                     .id("from")
-                                    .name("From")
+                                    .name("Changed from")
                                     .dataType("String")
                                     .headings(null)
                                     .build(),

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/report/bespoke/AbstractJurorAmendmentReport.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/report/bespoke/AbstractJurorAmendmentReport.java
@@ -128,10 +128,9 @@ public abstract class AbstractJurorAmendmentReport implements IReport {
             .name("Changed")
             .dataType(String.class.getSimpleName())
             .build());
-
         headings.add(AbstractReportResponse.TableData.Heading.builder()
             .id("from")
-            .name("From")
+            .name("Changed from")
             .dataType(String.class.getSimpleName())
             .build());
         headings.add(AbstractReportResponse.TableData.Heading.builder()

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/report/bespoke/JurorAmendmentByJurorReport.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/report/bespoke/JurorAmendmentByJurorReport.java
@@ -49,7 +49,7 @@ public class JurorAmendmentByJurorReport extends AbstractJurorAmendmentReport {
         });
         tableData.getHeadings().removeIf(heading ->
             "juror_number".equalsIgnoreCase(heading.getId())
-                || "from".equalsIgnoreCase(heading.getId()));
+                || "to".equalsIgnoreCase(heading.getId()));
 
         JurorAmendmentReportResponse response = new JurorAmendmentReportResponse();
         response.setTableData(tableData);


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://centralgovernmentcgi.atlassian.net/browse/JM-7534

### Change description ###

Corrects the column to be displayed on the juror amendment by juror number report. Also corrects the name of the 'from' column to match designs across al three amendment reports.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
