### PR TITLE
UAT - It shows the wrong time and message in pool history when editing the pool and adding a comment

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/EditPoolServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/EditPoolServiceImpl.java
@@ -35,6 +35,7 @@ public class EditPoolServiceImpl implements EditPoolService {
     private final PoolCommentRepository poolCommentRepository;
 
     @Override
+    @Transactional
     public void editPool(BureauJwtPayload payload, PoolEditRequestDto poolEditRequestDto) {
         String payloadOwner = payload.getOwner();
 
@@ -137,7 +138,9 @@ public class EditPoolServiceImpl implements EditPoolService {
                 poolRequest.setTotalNoRequired(totalRequired);
                 poolRequest.setLastUpdate(LocalDateTime.now());
                 poolRequestRepository.saveAndFlush(poolRequest);
-                String otherInformation = "Total Req was " + currentTotalNoRequired;
+                String otherInformation =
+                    "Pool capacity changed from " + currentTotalNoRequired + " to " + totalRequired
+                        + "\nReason for change: " + poolEditRequestDto.getReasonForChange();
                 updatePoolHistory(payload, poolNumber, otherInformation);
             }
 

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/EditPoolServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/EditPoolServiceImpl.java
@@ -65,7 +65,9 @@ public class EditPoolServiceImpl implements EditPoolService {
             if (currentNoRequested != noRequested) {
                 poolRequest.setNumberRequested(noRequested);
                 poolRequestRepository.saveAndFlush(poolRequest);
-                String otherInformation = "No Requested was " + currentNoRequested;
+                String otherInformation =
+                    "Jurors Requested changed from " + currentNoRequested + " to " + noRequested
+                        + "\nReason for change: " + poolEditRequestDto.getReasonForChange();
                 updatePoolHistory(payload, poolNumber, otherInformation);
             }
 

--- a/src/main/resources/db/migration/V1_140__pool_history_length_update.sql
+++ b/src/main/resources/db/migration/V1_140__pool_history_length_update.sql
@@ -1,0 +1,2 @@
+alter table juror_mod.pool_history
+    ALTER COLUMN other_information type varchar(150);


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7180)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=512)


### Change description ###
It shows the wrong time and message in pool history when adding a comment to a pool edit



!image-20240430-150013.png|width=451,height=276,alt="image-20240430-150013.png"!

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
