### PR TITLE
Fix (JM-7614) update expense LocalDateTime formatter to ISO

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/response/expense/SimplifiedExpenseDetailDto.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/response/expense/SimplifiedExpenseDetailDto.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import uk.gov.hmcts.juror.api.moj.enumeration.AttendanceType;
+import uk.gov.hmcts.juror.api.validation.ValidationConstants;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -45,7 +46,7 @@ public class SimplifiedExpenseDetailDto {
 
     private BigDecimal balanceToPay;
 
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @JsonFormat(pattern = ValidationConstants.DATETIME_FORMAT)
     private LocalDateTime auditCreatedOn;
 
     public BigDecimal getFinancialLoss() {


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://centralgovernmentcgi.atlassian.net/browse/JM-7614

### Change description ###

Updated the JSON formatter for the audit timestamp on expenses to use ISO rather than nearly ISO.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
