### PR TITLE
Response shows in summons response search twice when juror is reassigned to a new pool

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/jurorresponse/JurorResponseCommonRepositoryModImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/jurorresponse/JurorResponseCommonRepositoryModImpl.java
@@ -94,7 +94,9 @@ public class JurorResponseCommonRepositoryModImpl implements JurorResponseCommon
                 JUROR_RESPONSE_COMMON.replyType.type.as("reply_type"))
             .from(JUROR_RESPONSE_COMMON)
             .join(JUROR_POOL)
-            .on(JUROR_RESPONSE_COMMON.jurorNumber.eq(JUROR_POOL.juror.jurorNumber));
+            .on(JUROR_RESPONSE_COMMON.jurorNumber
+                .eq(JUROR_POOL.juror.jurorNumber)
+                .and(JUROR_POOL.isActive.eq(true)));
 
         // add filters to query
         addCommonFilters(request, query);


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://centralgovernmentcgi.atlassian.net/browse/JM-7474


### Change description ###
Added condition to join to include active juror_pool records only.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
