### PR TITLE
hotfix - Changing status of response sets CHANGED date to NULL on juror_response_aud

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/moj/domain/jurorresponse/JurorResponseAuditMod.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/domain/jurorresponse/JurorResponseAuditMod.java
@@ -4,13 +4,13 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
+import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
-import uk.gov.hmcts.juror.api.bureau.domain.JurorResponseAudit;
 import uk.gov.hmcts.juror.api.juror.domain.ProcessingStatus;
 
 import java.time.LocalDateTime;
@@ -19,7 +19,7 @@ import java.time.LocalDateTime;
 @Table(name = "juror_response_aud", schema = "juror_mod")
 @Data
 @Qualifier("NewJurorResponseAudit")
-@IdClass(JurorResponseAudit.class)
+@IdClass(JurorResponseAuditModKey.class)
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -42,4 +42,8 @@ public class JurorResponseAuditMod {
     @Column(name = "new_processing_status")
     private ProcessingStatus newProcessingStatus;
 
+    @PrePersist
+    void prePersist() {
+        this.changed = LocalDateTime.now();
+    }
 }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/domain/jurorresponse/JurorResponseAuditMod.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/domain/jurorresponse/JurorResponseAuditMod.java
@@ -2,6 +2,8 @@ package uk.gov.hmcts.juror.api.moj.domain.jurorresponse;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
 import jakarta.persistence.PrePersist;
@@ -37,9 +39,11 @@ public class JurorResponseAuditMod {
     private String login;
 
     @Column(name = "old_processing_status")
+    @Enumerated(EnumType.STRING)
     private ProcessingStatus oldProcessingStatus;
 
     @Column(name = "new_processing_status")
+    @Enumerated(EnumType.STRING)
     private ProcessingStatus newProcessingStatus;
 
     @PrePersist

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/domain/jurorresponse/JurorResponseAuditModKey.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/domain/jurorresponse/JurorResponseAuditModKey.java
@@ -1,0 +1,12 @@
+package uk.gov.hmcts.juror.api.moj.domain.jurorresponse;
+
+import lombok.EqualsAndHashCode;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+@EqualsAndHashCode
+public class JurorResponseAuditModKey implements Serializable {
+    private String jurorNumber;
+    private LocalDateTime changed;
+}

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/jurorresponse/JurorResponseAuditRepositoryMod.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/jurorresponse/JurorResponseAuditRepositoryMod.java
@@ -2,9 +2,10 @@ package uk.gov.hmcts.juror.api.moj.repository.jurorresponse;
 
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
-import uk.gov.hmcts.juror.api.bureau.domain.JurorResponseAuditKey;
 import uk.gov.hmcts.juror.api.moj.domain.jurorresponse.JurorResponseAuditMod;
+import uk.gov.hmcts.juror.api.moj.domain.jurorresponse.JurorResponseAuditModKey;
 
 @Repository
-public interface JurorResponseAuditRepositoryMod extends CrudRepository<JurorResponseAuditMod, JurorResponseAuditKey> {
+public interface JurorResponseAuditRepositoryMod extends CrudRepository<JurorResponseAuditMod,
+    JurorResponseAuditModKey> {
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://centralgovernmentcgi.atlassian.net/browse/JM-7640


### Change description ###
Fixed issue where the audit class was not populating the created field



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
