### PR TITLE
Export contact details via juror number not working

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/MessagingController.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/MessagingController.java
@@ -100,7 +100,7 @@ public class MessagingController {
 
     @PostMapping(value = "/csv/{loc_code}",
         consumes = MediaType.APPLICATION_JSON_VALUE,
-        produces = "text/csv;")
+        produces = {"text/csv;", MediaType.APPLICATION_JSON_VALUE})
     @Operation(summary = "Convert message to CSV")
     @ResponseStatus(HttpStatus.OK)
     @PreAuthorize(SecurityUtil.LOC_CODE_AUTH + " or " + SecurityUtil.IS_BUREAU)


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7669)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=551)


### Change description ###
Attempting to export contact details via juror number currently doesn’t work. Nothing happens when a csv file is expected to be downloaded. All other options work as expected.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
