### PR TITLE
WELSH - record a paper response for a NON-WELSH court with welsh flag ticked, then welsh flag is not saved

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/response/JurorDetailsCommonResponseDto.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/response/JurorDetailsCommonResponseDto.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.validator.constraints.Length;
 import org.springframework.beans.factory.annotation.Autowired;
+import uk.gov.hmcts.juror.api.juror.domain.WelshCourtLocationRepository;
 import uk.gov.hmcts.juror.api.moj.domain.Juror;
 import uk.gov.hmcts.juror.api.moj.domain.JurorPool;
 import uk.gov.hmcts.juror.api.moj.domain.JurorStatus;
@@ -80,6 +81,9 @@ public class JurorDetailsCommonResponseDto {
     @Schema(name = "Court name", description = "Name of court Juror will attend")
     private String courtName;
 
+    @JsonProperty("is_welsh_court")
+    private boolean isWelshCourt;
+
     @JsonProperty("excusalRejected")
     @Schema(name = "Excusal Rejected flag", description = "Flag to indicate if an excusal was rejected for juror")
     private String excusalRejected;
@@ -143,7 +147,8 @@ public class JurorDetailsCommonResponseDto {
     @Autowired
     public JurorDetailsCommonResponseDto(JurorPool jurorPool,
                                          JurorStatusRepository jurorStatusRepository,
-                                         PendingJurorRepository pendingJurorRepository) {
+                                         PendingJurorRepository pendingJurorRepository,
+                                         WelshCourtLocationRepository welshCourtLocationRepository) {
         Juror juror = jurorPool.getJuror();
         this.owner = jurorPool.getOwner();
         this.title = juror.getTitle();
@@ -160,6 +165,8 @@ public class JurorDetailsCommonResponseDto {
         this.deferralCode = jurorPool.getDeferralCode();
         this.disqualifyCode = juror.getDisqualifyCode();
         this.courtName = jurorPool.getCourt().getLocCourtName();
+        this.isWelshCourt =
+            welshCourtLocationRepository.existsByLocCode(jurorPool.getCourt().getLocCode());
         this.hasSummonsResponse = juror.getJurorResponse() != null;
 
         if (this.excusalCode != null) {

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/response/JurorDetailsResponseDto.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/response/JurorDetailsResponseDto.java
@@ -8,8 +8,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.validator.constraints.Length;
 import org.springframework.beans.factory.annotation.Autowired;
-import uk.gov.hmcts.juror.api.bureau.service.ResponseExcusalService;
 import uk.gov.hmcts.juror.api.juror.controller.request.JurorResponseDto;
+import uk.gov.hmcts.juror.api.juror.domain.WelshCourtLocationRepository;
 import uk.gov.hmcts.juror.api.moj.domain.Juror;
 import uk.gov.hmcts.juror.api.moj.domain.JurorPool;
 import uk.gov.hmcts.juror.api.moj.domain.PoliceCheck;
@@ -122,13 +122,13 @@ public class JurorDetailsResponseDto {
     @Autowired
     public JurorDetailsResponseDto(JurorPool jurorPool,
                                    JurorStatusRepository jurorStatusRepository,
-                                   ResponseExcusalService responseExcusalService,
+                                   WelshCourtLocationRepository welshCourtLocationRepository,
                                    PendingJurorRepository pendingJurorRepository) {
 
         Juror juror = jurorPool.getJuror();
 
         this.commonDetails = new JurorDetailsCommonResponseDto(jurorPool, jurorStatusRepository,
-            pendingJurorRepository);
+            pendingJurorRepository, welshCourtLocationRepository);
 
         this.dateOfBirth = juror.getDateOfBirth();
 
@@ -163,7 +163,6 @@ public class JurorDetailsResponseDto {
      * if we have two numbers, mobile and either home/work, use mobile as primary and the other as secondary
      * if we have two numbers, home and work, use home as primary and work as secondary
      * otherwise we have just one number and use that as primary.
-     *
      */
     private void setPhoneNumbers(String homePhone, String mobilePhone, String workPhone) {
 

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/response/JurorOverviewResponseDto.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/response/JurorOverviewResponseDto.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.validator.constraints.Length;
 import org.springframework.beans.factory.annotation.Autowired;
+import uk.gov.hmcts.juror.api.juror.domain.WelshCourtLocationRepository;
 import uk.gov.hmcts.juror.api.moj.domain.Appearance;
 import uk.gov.hmcts.juror.api.moj.domain.Juror;
 import uk.gov.hmcts.juror.api.moj.domain.JurorPool;
@@ -97,9 +98,10 @@ public class JurorOverviewResponseDto {
                                     JurorStatusRepository jurorStatusRepository,
                                     PanelRepository panelRepository,
                                     AppearanceRepository appearanceRepository,
-                                    PendingJurorRepository pendingJurorRepository) {
+                                    PendingJurorRepository pendingJurorRepository,
+                                    WelshCourtLocationRepository welshCourtLocationRepository) {
         this.commonDetails = new JurorDetailsCommonResponseDto(jurorPool, jurorStatusRepository,
-            pendingJurorRepository);
+            pendingJurorRepository, welshCourtLocationRepository);
 
 
         List<Appearance> appearanceList = appearanceRepository

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/response/JurorSummonsReplyResponseDto.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/response/JurorSummonsReplyResponseDto.java
@@ -6,7 +6,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.validator.constraints.Length;
 import org.springframework.beans.factory.annotation.Autowired;
-import uk.gov.hmcts.juror.api.bureau.service.ResponseExcusalService;
+import uk.gov.hmcts.juror.api.juror.domain.WelshCourtLocationRepository;
 import uk.gov.hmcts.juror.api.moj.domain.JurorPool;
 import uk.gov.hmcts.juror.api.moj.repository.JurorStatusRepository;
 import uk.gov.hmcts.juror.api.moj.repository.PendingJurorRepository;
@@ -45,9 +45,9 @@ public class JurorSummonsReplyResponseDto {
     @Autowired
     public JurorSummonsReplyResponseDto(JurorPool jurorPool,
                                         JurorStatusRepository jurorStatusRepository,
-                                        ResponseExcusalService responseExcusalService,
+                                        WelshCourtLocationRepository welshCourtLocationRepository,
                                         PendingJurorRepository pendingJurorRepository) {
         this.commonDetails = new JurorDetailsCommonResponseDto(jurorPool, jurorStatusRepository,
-            pendingJurorRepository);
+            pendingJurorRepository, welshCourtLocationRepository);
     }
 }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/JurorRecordServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/JurorRecordServiceImpl.java
@@ -22,6 +22,7 @@ import uk.gov.hmcts.juror.api.config.security.IsCourtUser;
 import uk.gov.hmcts.juror.api.juror.controller.request.JurorResponseDto;
 import uk.gov.hmcts.juror.api.juror.domain.CourtLocation;
 import uk.gov.hmcts.juror.api.juror.domain.ProcessingStatus;
+import uk.gov.hmcts.juror.api.juror.domain.WelshCourtLocationRepository;
 import uk.gov.hmcts.juror.api.moj.controller.request.ConfirmIdentityDto;
 import uk.gov.hmcts.juror.api.moj.controller.request.ContactLogRequestDto;
 import uk.gov.hmcts.juror.api.moj.controller.request.EditJurorRecordRequestDto;
@@ -188,6 +189,7 @@ public class JurorRecordServiceImpl implements JurorRecordService {
     private final UserServiceModImpl userServiceModImpl;
     private final PanelRepository panelRepository;
     private final HistoryTemplateService historyTemplateService;
+    private final WelshCourtLocationRepository welshCourtLocationRepository;
 
     @Override
     @Transactional
@@ -317,7 +319,7 @@ public class JurorRecordServiceImpl implements JurorRecordService {
 
         DigitalResponse jurorResponse = jurorResponseRepository.findByJurorNumber(jurorNumber);
         JurorDetailsResponseDto jurorDetailsResponseDto = new JurorDetailsResponseDto(jurorPool,
-            jurorStatusRepository, responseExcusalService, pendingJurorRepository);
+            jurorStatusRepository, welshCourtLocationRepository, pendingJurorRepository);
 
         // need to send reply method and status so front end can determine if edit should be from response or juror
         // record
@@ -411,7 +413,7 @@ public class JurorRecordServiceImpl implements JurorRecordService {
 
     private JurorOverviewResponseDto getJurorOverviewResponseDto(JurorPool jurorPool) {
         return new JurorOverviewResponseDto(jurorPool,
-            jurorStatusRepository, panelRepository, appearanceRepository, pendingJurorRepository);
+            jurorStatusRepository, panelRepository, appearanceRepository, pendingJurorRepository,welshCourtLocationRepository);
     }
 
     @Override
@@ -725,7 +727,7 @@ public class JurorRecordServiceImpl implements JurorRecordService {
         }
 
         return new ContactLogListDto(contactLogDataList, new JurorDetailsCommonResponseDto(jurorPool,
-            jurorStatusRepository, pendingJurorRepository));
+            jurorStatusRepository, pendingJurorRepository, welshCourtLocationRepository));
     }
 
     /**
@@ -786,7 +788,7 @@ public class JurorRecordServiceImpl implements JurorRecordService {
         Juror juror = jurorPool.getJuror();
 
         return new JurorNotesDto(juror.getNotes(), new JurorDetailsCommonResponseDto(jurorPool, jurorStatusRepository,
-            pendingJurorRepository));
+            pendingJurorRepository, welshCourtLocationRepository));
     }
 
     @Override
@@ -926,7 +928,7 @@ public class JurorRecordServiceImpl implements JurorRecordService {
             && juror.getSummonsFile() != null
             && juror.getSummonsFile().equals("Disq. on selection")) {
             //return just the common details
-            return new JurorSummonsReplyResponseDto(jurorPool, jurorStatusRepository, responseExcusalService,
+            return new JurorSummonsReplyResponseDto(jurorPool, jurorStatusRepository, welshCourtLocationRepository,
                 pendingJurorRepository);
         }
 
@@ -938,13 +940,13 @@ public class JurorRecordServiceImpl implements JurorRecordService {
 
         if (Objects.equals(jurorPool.getStatus().getStatus(), IJurorStatus.SUMMONED)
             && jurorResponse == null && jurorPaperResponse == null) {
-            return new JurorSummonsReplyResponseDto(jurorPool, jurorStatusRepository, responseExcusalService,
+            return new JurorSummonsReplyResponseDto(jurorPool, jurorStatusRepository, welshCourtLocationRepository,
                 pendingJurorRepository);
         }
 
         if (jurorResponse != null) {
             JurorSummonsReplyResponseDto jurorSummonsReplyResponseDto = new JurorSummonsReplyResponseDto(jurorPool,
-                jurorStatusRepository, responseExcusalService, pendingJurorRepository);
+                jurorStatusRepository, welshCourtLocationRepository, pendingJurorRepository);
             jurorSummonsReplyResponseDto.setReplyMethod(REPLY_METHOD_ONLINE);
             jurorSummonsReplyResponseDto.setReplyDate(jurorResponse.getDateReceived().toLocalDate());
             jurorSummonsReplyResponseDto.setReplyStatus(jurorResponse.getProcessingStatus().getDescription());
@@ -953,7 +955,7 @@ public class JurorRecordServiceImpl implements JurorRecordService {
 
         if (jurorPaperResponse != null) {
             JurorSummonsReplyResponseDto jurorSummonsReplyResponseDto = new JurorSummonsReplyResponseDto(jurorPool,
-                jurorStatusRepository, responseExcusalService, pendingJurorRepository);
+                jurorStatusRepository, welshCourtLocationRepository, pendingJurorRepository);
             jurorSummonsReplyResponseDto.setReplyMethod(REPLY_METHOD_PAPER);
             jurorSummonsReplyResponseDto.setReplyDate(jurorPaperResponse.getDateReceived().toLocalDate());
             jurorSummonsReplyResponseDto.setReplyStatus(jurorPaperResponse.getProcessingStatus().getDescription());
@@ -973,7 +975,7 @@ public class JurorRecordServiceImpl implements JurorRecordService {
 
             if (!jurorHistFiltered.isEmpty()) {
                 JurorSummonsReplyResponseDto jurorSummonsReplyResponseDto =
-                    new JurorSummonsReplyResponseDto(jurorPool, jurorStatusRepository, responseExcusalService,
+                    new JurorSummonsReplyResponseDto(jurorPool, jurorStatusRepository, welshCourtLocationRepository,
                         pendingJurorRepository);
                 jurorSummonsReplyResponseDto.setReplyMethod(REPLY_METHOD_PAPER);
                 return jurorSummonsReplyResponseDto;
@@ -982,7 +984,7 @@ public class JurorRecordServiceImpl implements JurorRecordService {
 
         //send the default response
         JurorSummonsReplyResponseDto jurorSummonsReplyResponseDto = new JurorSummonsReplyResponseDto(jurorPool,
-            jurorStatusRepository, responseExcusalService, pendingJurorRepository);
+            jurorStatusRepository, welshCourtLocationRepository, pendingJurorRepository);
 
         jurorSummonsReplyResponseDto.setReplyMethod(REPLY_METHOD_NOT_AVAILABLE);
         return jurorSummonsReplyResponseDto;
@@ -1143,7 +1145,7 @@ public class JurorRecordServiceImpl implements JurorRecordService {
             jurorHistoryService.createPoliceCheckDisqualifyHistory(jurorPool);
             if (SecurityUtil.BUREAU_OWNER.equals(jurorPool.getOwner())) {
                 printDataService.printWithdrawalLetter(jurorPool);
-                jurorHistoryService.createWithdrawHistory(jurorPool, "Withdrawal Letter Auto","E");
+                jurorHistoryService.createWithdrawHistory(jurorPool, "Withdrawal Letter Auto", "E");
             }
         } else if (newPoliceCheckValue == PoliceCheck.IN_PROGRESS) {
             log.debug("Juror {} police check is in progress adding part history", jurorNumber);
@@ -1185,7 +1187,6 @@ public class JurorRecordServiceImpl implements JurorRecordService {
         jurorHistoryService.createFailedToAttendHistory(jurorPool);
         jurorPoolRepository.save(jurorPool);
     }
-
 
 
     @Override

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/JurorRecordServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/JurorRecordServiceTest.java
@@ -28,6 +28,7 @@ import uk.gov.hmcts.juror.api.bureau.service.ResponseExcusalService;
 import uk.gov.hmcts.juror.api.config.bureau.BureauJwtPayload;
 import uk.gov.hmcts.juror.api.juror.domain.CourtLocation;
 import uk.gov.hmcts.juror.api.juror.domain.JurorResponse;
+import uk.gov.hmcts.juror.api.juror.domain.WelshCourtLocationRepository;
 import uk.gov.hmcts.juror.api.moj.controller.request.ConfirmIdentityDto;
 import uk.gov.hmcts.juror.api.moj.controller.request.ContactLogRequestDto;
 import uk.gov.hmcts.juror.api.moj.controller.request.EditJurorRecordRequestDto;
@@ -168,6 +169,8 @@ class JurorRecordServiceTest {
     private PanelRepository panelRepository;
     @Mock
     private HistoryTemplateService historyTemplateService;
+    @Mock
+    private WelshCourtLocationRepository welshCourtLocationRepository;
     @Mock
     private JurorRepository jurorRepository;
     @Mock


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7675)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=%pullRequestNumber%)


### Change description ###
As a bureau user, it is possible to set the welsh flag for a juror at a non-welsh court. If it is selected, then it is not saved to the record. I am sure at one point the welsh checkbox was only available on welsh court juror records.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
