### PR TITLE
Paper responses currently not tracking when they get the processing status updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -278,10 +278,10 @@ checkstyle {
 }
 
 pmdTest {
-    maxFailures = 312
+    maxFailures = 304
 }
 pmdMain {
-    maxFailures = 815
+    maxFailures = 799
 }
 pmd {
     maxFailures = 0

--- a/src/main/java/uk/gov/hmcts/juror/api/bureau/service/ResponseDisqualifyServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/bureau/service/ResponseDisqualifyServiceImpl.java
@@ -17,7 +17,6 @@ import uk.gov.hmcts.juror.api.moj.domain.DisqualifiedCode;
 import uk.gov.hmcts.juror.api.moj.domain.IJurorStatus;
 import uk.gov.hmcts.juror.api.moj.domain.JurorPool;
 import uk.gov.hmcts.juror.api.moj.domain.jurorresponse.DigitalResponse;
-import uk.gov.hmcts.juror.api.moj.domain.jurorresponse.JurorResponseAuditMod;
 import uk.gov.hmcts.juror.api.moj.repository.DisqualifiedCodeRepository;
 import uk.gov.hmcts.juror.api.moj.repository.JurorPoolRepository;
 import uk.gov.hmcts.juror.api.moj.repository.JurorStatusRepository;
@@ -93,8 +92,7 @@ public class ResponseDisqualifyServiceImpl implements ResponseDisqualifyService 
             savedResponse.setVersion(disqualifyCodeDto.getVersion());
 
             //update response
-            final ProcessingStatus oldProcessingStatus = savedResponse.getProcessingStatus();
-            savedResponse.setProcessingStatus(ProcessingStatus.CLOSED);
+            savedResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.CLOSED);
 
             // JDB-2685: if no staff assigned, assign current login
             if (null == savedResponse.getStaff()) {
@@ -112,14 +110,6 @@ public class ResponseDisqualifyServiceImpl implements ResponseDisqualifyService 
                 }
                 throw new DisqualifyException.OptimisticLockingFailure(jurorId);
             }
-
-            //audit response status change
-            jurorResponseAuditRepository.save(JurorResponseAuditMod.builder()
-                .jurorNumber(jurorId)
-                .login(login)
-                .oldProcessingStatus(oldProcessingStatus)
-                .newProcessingStatus(savedResponse.getProcessingStatus())
-                .build());
 
             // update juror pool entry
             JurorPool jurorDetails = detailsRepository.findByJurorJurorNumber(savedResponse.getJurorNumber());

--- a/src/main/java/uk/gov/hmcts/juror/api/bureau/service/ResponseExcusalServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/bureau/service/ResponseExcusalServiceImpl.java
@@ -18,7 +18,6 @@ import uk.gov.hmcts.juror.api.moj.domain.IJurorStatus;
 import uk.gov.hmcts.juror.api.moj.domain.JurorHistory;
 import uk.gov.hmcts.juror.api.moj.domain.JurorPool;
 import uk.gov.hmcts.juror.api.moj.domain.jurorresponse.DigitalResponse;
-import uk.gov.hmcts.juror.api.moj.domain.jurorresponse.JurorResponseAuditMod;
 import uk.gov.hmcts.juror.api.moj.enumeration.ExcusalCodeEnum;
 import uk.gov.hmcts.juror.api.moj.enumeration.HistoryCodeMod;
 import uk.gov.hmcts.juror.api.moj.repository.JurorHistoryRepository;
@@ -100,8 +99,7 @@ public class ResponseExcusalServiceImpl implements ResponseExcusalService {
             savedResponse.setVersion(excusalCodeDto.getVersion());
 
             //update response
-            final ProcessingStatus oldProcessingStatus = savedResponse.getProcessingStatus();
-            savedResponse.setProcessingStatus(ProcessingStatus.CLOSED);
+            savedResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.CLOSED);
 
             // JDB-2685: if no staff assigned, assign current login
             if (null == savedResponse.getStaff()) {
@@ -119,14 +117,6 @@ public class ResponseExcusalServiceImpl implements ResponseExcusalService {
                 }
                 throw new ExcusalException.OptimisticLockingFailure(jurorId, e);
             }
-
-            //audit response status change
-            jurorResponseAuditRepository.save(JurorResponseAuditMod.builder()
-                .jurorNumber(jurorId)
-                .login(login)
-                .oldProcessingStatus(oldProcessingStatus)
-                .newProcessingStatus(savedResponse.getProcessingStatus())
-                .build());
 
             // update juror pool entry
             JurorPool poolDetails = detailsRepository.findByJurorJurorNumber(savedResponse.getJurorNumber());
@@ -201,8 +191,7 @@ public class ResponseExcusalServiceImpl implements ResponseExcusalService {
             savedResponse.setVersion(excusalCodeDto.getVersion());
 
             //update response
-            final ProcessingStatus oldProcessingStatus = savedResponse.getProcessingStatus();
-            savedResponse.setProcessingStatus(ProcessingStatus.CLOSED);
+            savedResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.CLOSED);
 
             // JDB-2685: if no staff assigned, assign current login
             if (null == savedResponse.getStaff()) {
@@ -220,14 +209,6 @@ public class ResponseExcusalServiceImpl implements ResponseExcusalService {
                 }
                 throw new ExcusalException.OptimisticLockingFailure(jurorId, e);
             }
-
-            //audit response status change
-            jurorResponseAuditRepository.save(JurorResponseAuditMod.builder()
-                .jurorNumber(jurorId)
-                .login(login)
-                .oldProcessingStatus(oldProcessingStatus)
-                .newProcessingStatus(savedResponse.getProcessingStatus())
-                .build());
 
             // update juror pool entry
             JurorPool poolDetails = detailsRepository.findByJurorJurorNumber(savedResponse.getJurorNumber());

--- a/src/main/java/uk/gov/hmcts/juror/api/juror/domain/ProcessingStatus.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/juror/domain/ProcessingStatus.java
@@ -1,8 +1,11 @@
 package uk.gov.hmcts.juror.api.juror.domain;
 
+import lombok.Getter;
+
 /**
  * Enum of values of a juror response "processing status".
  */
+@Getter
 public enum ProcessingStatus {
     TODO("To Do"),
 
@@ -20,7 +23,4 @@ public enum ProcessingStatus {
         this.description = description;
     }
 
-    public String getDescription() {
-        return description;
-    }
 }

--- a/src/main/java/uk/gov/hmcts/juror/api/juror/service/StraightThroughProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/juror/service/StraightThroughProcessorImpl.java
@@ -17,7 +17,6 @@ import uk.gov.hmcts.juror.api.moj.domain.JurorHistory;
 import uk.gov.hmcts.juror.api.moj.domain.JurorPool;
 import uk.gov.hmcts.juror.api.moj.domain.User;
 import uk.gov.hmcts.juror.api.moj.domain.jurorresponse.DigitalResponse;
-import uk.gov.hmcts.juror.api.moj.domain.jurorresponse.JurorResponseAuditMod;
 import uk.gov.hmcts.juror.api.moj.enumeration.HistoryCodeMod;
 import uk.gov.hmcts.juror.api.moj.repository.JurorHistoryRepository;
 import uk.gov.hmcts.juror.api.moj.repository.JurorPoolRepository;
@@ -266,21 +265,13 @@ public class StraightThroughProcessorImpl implements StraightThroughProcessor {
                     "Response must be in summoned state to qualify for straight-through");
             }
 
-            savedDigitalResponse.setProcessingStatus(ProcessingStatus.CLOSED);
+            savedDigitalResponse.setProcessingStatus(jurorResponseAuditRepositoryMod, ProcessingStatus.CLOSED);
 
             savedDigitalResponse.setStaff(staffMember(AUTO_USER));
             savedDigitalResponse.setStaffAssignmentDate(LocalDate.now());
 
             // save the response
             mergeService.mergeResponse(savedDigitalResponse, AUTO_USER);
-
-            //audit response status change
-            jurorResponseAuditRepositoryMod.save(JurorResponseAuditMod.builder()
-                .jurorNumber(savedDigitalResponse.getJurorNumber())
-                .login(AUTO_USER)
-                .oldProcessingStatus(ProcessingStatus.TODO)
-                .newProcessingStatus(savedDigitalResponse.getProcessingStatus())
-                .build());
 
             // update juror entry
             //   final Pool updatedDetails = detailsRepository.findByJurorNumber(savedDigitalResponse.getJurorNumber());
@@ -363,20 +354,12 @@ public class StraightThroughProcessorImpl implements StraightThroughProcessor {
             }
 
             //update response
-            savedDigitalResponse.setProcessingStatus(ProcessingStatus.CLOSED);
+            savedDigitalResponse.setProcessingStatus(jurorResponseAuditRepositoryMod, ProcessingStatus.CLOSED);
             savedDigitalResponse.setStaff(staffMember(AUTO_USER));
             savedDigitalResponse.setStaffAssignmentDate(LocalDate.now());
 
             // save the response
             mergeService.mergeResponse(savedDigitalResponse, AUTO_USER);
-
-            //audit response status change
-            jurorResponseAuditRepositoryMod.save(JurorResponseAuditMod.builder()
-                .jurorNumber(savedDigitalResponse.getJurorNumber())
-                .login(AUTO_USER)
-                .oldProcessingStatus(ProcessingStatus.TODO)
-                .newProcessingStatus(savedDigitalResponse.getProcessingStatus())
-                .build());
 
             // update Juror
             jurorDetails.getJuror().setResponded(true);
@@ -464,20 +447,12 @@ public class StraightThroughProcessorImpl implements StraightThroughProcessor {
             }
 
             //update response
-            savedDigitalResponse.setProcessingStatus(ProcessingStatus.CLOSED);
+            savedDigitalResponse.setProcessingStatus(jurorResponseAuditRepositoryMod, ProcessingStatus.CLOSED);
             savedDigitalResponse.setStaff(staffMember(AUTO_USER));
             savedDigitalResponse.setStaffAssignmentDate(LocalDate.now());
 
             // save the response
             mergeService.mergeResponse(savedDigitalResponse, AUTO_USER);
-
-            //audit response status change
-            jurorResponseAuditRepositoryMod.save(JurorResponseAuditMod.builder()
-                .jurorNumber(savedDigitalResponse.getJurorNumber())
-                .login(AUTO_USER)
-                .oldProcessingStatus(ProcessingStatus.TODO)
-                .newProcessingStatus(savedDigitalResponse.getProcessingStatus())
-                .build());
 
             // update Juror
             jurorDetails.getJuror().setResponded(true);

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/jurorresponse/JurorResponseAuditRepositoryMod.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/jurorresponse/JurorResponseAuditRepositoryMod.java
@@ -6,6 +6,6 @@ import uk.gov.hmcts.juror.api.moj.domain.jurorresponse.JurorResponseAuditMod;
 import uk.gov.hmcts.juror.api.moj.domain.jurorresponse.JurorResponseAuditModKey;
 
 @Repository
-public interface JurorResponseAuditRepositoryMod extends CrudRepository<JurorResponseAuditMod,
-    JurorResponseAuditModKey> {
+public interface JurorResponseAuditRepositoryMod
+    extends CrudRepository<JurorResponseAuditMod, JurorResponseAuditModKey> {
 }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/ExcusalResponseServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/ExcusalResponseServiceImpl.java
@@ -30,6 +30,7 @@ import uk.gov.hmcts.juror.api.moj.repository.JurorStatusRepository;
 import uk.gov.hmcts.juror.api.moj.repository.UserRepository;
 import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorDigitalResponseRepositoryMod;
 import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorPaperResponseRepositoryMod;
+import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorResponseAuditRepositoryMod;
 import uk.gov.hmcts.juror.api.moj.utils.DataUtils;
 import uk.gov.hmcts.juror.api.moj.utils.JurorPoolUtils;
 import uk.gov.hmcts.juror.api.moj.utils.RepositoryUtils;
@@ -69,6 +70,7 @@ public class ExcusalResponseServiceImpl implements ExcusalResponseService {
     @NonNull
     private final PrintDataService printDataService;
     private final JurorHistoryService jurorHistoryService;
+    private final JurorResponseAuditRepositoryMod jurorResponseAuditRepositoryMod;
 
     @Override
     @Transactional
@@ -135,7 +137,7 @@ public class ExcusalResponseServiceImpl implements ExcusalResponseService {
 
         log.info(String.format("PAPER response found for Juror %s", jurorNumber));
 
-        jurorPaperResponse.setProcessingStatus(ProcessingStatus.CLOSED);
+        jurorPaperResponse.setProcessingStatus(jurorResponseAuditRepositoryMod, ProcessingStatus.CLOSED);
 
         if (jurorPaperResponse.getStaff() == null) {
             log.info(String.format("No staff assigned to PAPER response for Juror %s", jurorNumber));
@@ -160,7 +162,7 @@ public class ExcusalResponseServiceImpl implements ExcusalResponseService {
 
         log.info(String.format("DIGITAL response found for Juror %s", jurorNumber));
 
-        jurorResponse.setProcessingStatus(ProcessingStatus.CLOSED);
+        jurorResponse.setProcessingStatus(jurorResponseAuditRepositoryMod, ProcessingStatus.CLOSED);
 
         if (jurorResponse.getStaff() == null) {
             log.info(String.format("No staff assigned to DIGITAL response for Juror %s", jurorNumber));

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/JurorRecordServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/JurorRecordServiceImpl.java
@@ -16,7 +16,6 @@ import uk.gov.hmcts.juror.api.JurorDigitalApplication;
 import uk.gov.hmcts.juror.api.bureau.controller.response.BureauJurorDetailDto;
 import uk.gov.hmcts.juror.api.bureau.domain.DisCode;
 import uk.gov.hmcts.juror.api.bureau.service.BureauService;
-import uk.gov.hmcts.juror.api.bureau.service.ResponseExcusalService;
 import uk.gov.hmcts.juror.api.config.bureau.BureauJwtPayload;
 import uk.gov.hmcts.juror.api.config.security.IsCourtUser;
 import uk.gov.hmcts.juror.api.juror.controller.request.JurorResponseDto;
@@ -101,6 +100,7 @@ import uk.gov.hmcts.juror.api.moj.repository.juror.JurorPaymentsSummaryRepositor
 import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorDigitalResponseRepositoryMod;
 import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorPaperResponseRepositoryMod;
 import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorReasonableAdjustmentRepository;
+import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorResponseAuditRepositoryMod;
 import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorResponseCommonRepositoryMod;
 import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.ReasonableAdjustmentsRepository;
 import uk.gov.hmcts.juror.api.moj.repository.trial.PanelRepository;
@@ -170,7 +170,6 @@ public class JurorRecordServiceImpl implements JurorRecordService {
     private final ContactLogRepository contactLogRepository;
     private final JurorDetailRepositoryMod jurorDetailRepositoryMod;
     private final BureauService bureauService;
-    private final ResponseExcusalService responseExcusalService;
     private final JurorAuditChangeService jurorAuditChangeService;
     private final PrintDataService printDataService;
     private final GeneratePoolNumberService generatePoolNumberService;
@@ -187,6 +186,7 @@ public class JurorRecordServiceImpl implements JurorRecordService {
     private final PanelRepository panelRepository;
     private final HistoryTemplateService historyTemplateService;
     private final WelshCourtLocationRepository welshCourtLocationRepository;
+    private final JurorResponseAuditRepositoryMod jurorResponseAuditRepository;
 
     @Override
     @Transactional
@@ -833,7 +833,7 @@ public class JurorRecordServiceImpl implements JurorRecordService {
         JurorUtils.checkOwnershipForCurrentUser(juror, owner);
         juror.setOpticRef(opticsRef);
         jurorRepository.save(juror);
-        response.setProcessingStatus(ProcessingStatus.AWAITING_COURT_REPLY);
+        response.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.AWAITING_COURT_REPLY);
 
         if (ReplyMethod.DIGITAL.getDescription().equals(response.getReplyType().getType())) {
             jurorResponseRepository.save((DigitalResponse) response);

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/StraightThroughProcessorServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/StraightThroughProcessorServiceImpl.java
@@ -25,6 +25,7 @@ import uk.gov.hmcts.juror.api.moj.repository.JurorStatusRepository;
 import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorDigitalResponseRepositoryMod;
 import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorPaperResponseRepositoryMod;
 import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorReasonableAdjustmentRepository;
+import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorResponseAuditRepositoryMod;
 import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorResponseCjsEmploymentRepositoryMod;
 import uk.gov.hmcts.juror.api.moj.utils.DataUtils;
 import uk.gov.hmcts.juror.api.moj.utils.JurorPoolUtils;
@@ -51,6 +52,7 @@ public class StraightThroughProcessorServiceImpl implements StraightThroughProce
     private final SummonsReplyMergeService mergeService;
     private final PrintDataService printDataService;
     private final JurorHistoryService jurorHistoryService;
+    private final JurorResponseAuditRepositoryMod jurorResponseAuditRepository;
 
 
     /**
@@ -214,7 +216,7 @@ public class StraightThroughProcessorServiceImpl implements StraightThroughProce
 
         JurorPoolUtils.checkOwnershipForCurrentUser(jurorPool, owner);
 
-        jurorResponse.setProcessingStatus(ProcessingStatus.CLOSED);
+        jurorResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.CLOSED);
 
         processJurorAgeDisqualification(jurorPool, jurorNumber, owner, username);
 

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/utils/SecurityUtil.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/utils/SecurityUtil.java
@@ -15,6 +15,7 @@ import java.util.List;
 public final class SecurityUtil {
 
     public static final String BUREAU_OWNER = "400";
+    public static String AUTO_USER = "AUTO";
 
     public static final String IS_MANAGER = "hasRole('ROLE_MANAGER')";
     public static final String IS_SJO = "hasRole('ROLE_SENIOR_JUROR_OFFICER')";
@@ -64,6 +65,15 @@ public final class SecurityUtil {
         Authentication authentication = securityContext.getAuthentication();
         if (authentication instanceof BureauJwtAuthentication bureauJwtAuthentication) {
             return bureauJwtAuthentication;
+        }
+        throw new MojException.Forbidden("User must be authorised with BureauJwtAuthentication", null);
+    }
+
+    public static PublicJwtAuthentication getActiveUsersPublicJwtAuthentication() {
+        SecurityContext securityContext = SecurityContextHolder.getContext();
+        Authentication authentication = securityContext.getAuthentication();
+        if (authentication instanceof PublicJwtAuthentication publicJwtAuthentication) {
+            return publicJwtAuthentication;
         }
         throw new MojException.Forbidden("User must be authorised with BureauJwtAuthentication", null);
     }

--- a/src/test/java/uk/gov/hmcts/juror/api/bureau/scheduler/UrgentStatusSchedulerTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/bureau/scheduler/UrgentStatusSchedulerTest.java
@@ -17,6 +17,7 @@ import uk.gov.hmcts.juror.api.moj.domain.jurorresponse.DigitalResponse;
 import uk.gov.hmcts.juror.api.moj.repository.JurorPoolRepository;
 import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorDigitalResponseRepositoryMod;
 import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorPaperResponseRepositoryMod;
+import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorResponseAuditRepositoryMod;
 
 import java.time.LocalDateTime;
 import java.util.LinkedList;
@@ -39,6 +40,8 @@ public class UrgentStatusSchedulerTest {
     private JurorDigitalResponseRepositoryMod jurorResponseRepo;
     @Mock
     private JurorPaperResponseRepositoryMod paperJurorResponseRepo;
+    @Mock
+    private JurorResponseAuditRepositoryMod jurorResponseAuditRepository;
 
     @Mock
     private UserService userService;
@@ -67,7 +70,7 @@ public class UrgentStatusSchedulerTest {
         jurorBureauDetail.setHearingDate(responseReceived.toLocalDate());
 
         DigitalResponse jurorResponse = new DigitalResponse();
-        jurorResponse.setProcessingStatus(uk.gov.hmcts.juror.api.juror.domain.ProcessingStatus.TODO);
+        jurorResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
         jurorResponse.setDateReceived(responseReceived);
 
         poolDetails = new JurorPool();
@@ -79,7 +82,7 @@ public class UrgentStatusSchedulerTest {
         DigitalResponse response = new DigitalResponse();
         response.setJurorNumber("12345678");
         response.setDateReceived(LocalDateTime.from(now.minusHours(1)));
-        response.setProcessingStatus(ProcessingStatus.TODO);
+        response.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
         response.setUrgent(false);
         responseBacklog.add(response);
 

--- a/src/test/java/uk/gov/hmcts/juror/api/bureau/service/BureauBacklogCountServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/bureau/service/BureauBacklogCountServiceImplTest.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.juror.api.juror.domain.JurorResponseQueries;
 import uk.gov.hmcts.juror.api.juror.domain.ProcessingStatus;
 import uk.gov.hmcts.juror.api.moj.domain.jurorresponse.DigitalResponse;
 import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorDigitalResponseRepositoryMod;
+import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorResponseAuditRepositoryMod;
 
 import java.time.LocalDateTime;
 import java.util.LinkedList;
@@ -25,11 +26,15 @@ public class BureauBacklogCountServiceImplTest {
     @Mock
     private JurorDigitalResponseRepositoryMod responseRepo;
 
+    @Mock
+    private JurorResponseAuditRepositoryMod jurorResponseAuditRepository;
+
     @InjectMocks
     private BureauBacklogCountServiceImpl backlogCountService;
 
 
     private List<DigitalResponse> backlog;
+
 
 
     @Before
@@ -47,32 +52,32 @@ public class BureauBacklogCountServiceImplTest {
         }
         DigitalResponse  response1 = new DigitalResponse();
         response1.setUrgent(true);
-        response1.setProcessingStatus(ProcessingStatus.TODO);
+        response1.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
         response1.setStaff(null);
         backlog.add(response1);
 
         DigitalResponse  response2 = new DigitalResponse();
         response2.setUrgent(true);
-        response2.setProcessingStatus(ProcessingStatus.TODO);
+        response2.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
         response2.setStaff(null);
         backlog.add(response2);
 
         DigitalResponse  response3 = new DigitalResponse();
         response3.setUrgent(false);
-        response3.setProcessingStatus(ProcessingStatus.TODO);
+        response3.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
         response3.setStaff(null);
 
         backlog.add(response3);
 
         DigitalResponse  response4 = new DigitalResponse();
         response4.setUrgent(false);
-        response4.setProcessingStatus(ProcessingStatus.TODO);
+        response4.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
         response4.setStaff(null);
         backlog.add(response4);
 
         DigitalResponse  response5 = new DigitalResponse();
         response5.setUrgent(false);
-        response5.setProcessingStatus(ProcessingStatus.TODO);
+        response5.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
         response5.setStaff(null);
         backlog.add(response5);
 

--- a/src/test/java/uk/gov/hmcts/juror/api/bureau/service/BureauJurorDetailUrgencyTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/bureau/service/BureauJurorDetailUrgencyTest.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.juror.api.moj.domain.JurorPool;
 import uk.gov.hmcts.juror.api.moj.domain.ModJurorDetail;
 import uk.gov.hmcts.juror.api.moj.domain.jurorresponse.DigitalResponse;
 import uk.gov.hmcts.juror.api.moj.repository.AppSettingRepository;
+import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorResponseAuditRepositoryMod;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -53,6 +54,8 @@ public class BureauJurorDetailUrgencyTest {
 
     @Mock
     private AppSettingRepository mockAppSettingRepository;
+    @Mock
+    private JurorResponseAuditRepositoryMod jurorResponseAuditRepository;
 
     @InjectMocks
     private UrgencyServiceImpl urgency;
@@ -77,7 +80,7 @@ public class BureauJurorDetailUrgencyTest {
         testDetail.setHearingDate(hearingDateValid.toLocalDate());
 
         jurorResponse = new DigitalResponse();
-        jurorResponse.setProcessingStatus(uk.gov.hmcts.juror.api.juror.domain.ProcessingStatus.TODO);
+        jurorResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
         jurorResponse.setDateReceived(responseReceived);
 
         poolDetails = new JurorPool();
@@ -107,7 +110,6 @@ public class BureauJurorDetailUrgencyTest {
         final LocalDate urgentHearingDate = (hearingDateUrgent.plusDays(1L).plusHours(1L).toLocalDate());
         testDetail.setHearingDate(urgentHearingDate);
         poolDetails.setNextDate(urgentHearingDate);
-        // poolDetails.setReadOnly(Boolean.FALSE);
         poolDetails.setOwner(OWNER_IS_BUREAU);
 
 

--- a/src/test/java/uk/gov/hmcts/juror/api/bureau/service/ResponseDisqualifyServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/bureau/service/ResponseDisqualifyServiceImplTest.java
@@ -128,12 +128,10 @@ public class ResponseDisqualifyServiceImplTest {
         // assertions
         assertThat(result).isTrue();
         verify(jurorResponseRepository).findByJurorNumber(any(String.class));
-        verify(jurorResponse).setProcessingStatus(ProcessingStatus.CLOSED);
+        verify(jurorResponse).setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.CLOSED);
         verify(mergeService).mergeResponse(jurorResponse, login);
 
-        verify(jurorResponseAuditRepository).save(any(JurorResponseAuditMod.class));
-
-        verify(poolDetails,times(3)).getJuror();
+        verify(poolDetails, times(3)).getJuror();
         verify(juror).setResponded(true);
         verify(juror).setDisqualifyDate(any(LocalDate.class));
         verify(juror).setDisqualifyCode(disqualifyCode);
@@ -143,7 +141,7 @@ public class ResponseDisqualifyServiceImplTest {
         verify(poolDetails).setNextDate(null);
         verify(poolRepository).save(poolDetails);
 
-        verify(jurorHistoryService).createDisqualifyHistory(poolDetails,disqualifyCode);
+        verify(jurorHistoryService).createDisqualifyHistory(poolDetails, disqualifyCode);
         verify(printDataService).printWithdrawalLetter(poolDetails);
     }
 
@@ -172,7 +170,7 @@ public class ResponseDisqualifyServiceImplTest {
             // assertions
             assertThat(e.getClass()).isEqualTo(DisqualifyException.RequestedCodeNotValid.class);
             verify(jurorResponseRepository, times(0)).findByJurorNumber(any(String.class));
-            verify(jurorResponse, times(0)).setProcessingStatus(ProcessingStatus.CLOSED);
+            verify(jurorResponse, times(0)).setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.CLOSED);
             verify(jurorResponseRepository, times(0)).save(jurorResponse);
 
             verify(jurorResponseAuditRepository, times(0)).save(any(JurorResponseAuditMod.class));
@@ -214,7 +212,7 @@ public class ResponseDisqualifyServiceImplTest {
             // assertions
             assertThat(e.getClass()).isEqualTo(DisqualifyException.JurorNotFound.class);
             verify(jurorResponseRepository, times(1)).findByJurorNumber(any(String.class));
-            verify(jurorResponse, times(0)).setProcessingStatus(ProcessingStatus.CLOSED);
+            verify(jurorResponse, times(0)).setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.CLOSED);
             verify(jurorResponseRepository, times(0)).save(jurorResponse);
 
             verify(jurorResponseAuditRepository, times(0)).save(any(JurorResponseAuditMod.class));

--- a/src/test/java/uk/gov/hmcts/juror/api/bureau/service/ResponseExcusalServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/bureau/service/ResponseExcusalServiceImplTest.java
@@ -125,10 +125,8 @@ public class ResponseExcusalServiceImplTest {
         // assertions
         assertThat(result).isEqualTo(true);
         verify(jurorResponseRepository).findByJurorNumber(any(String.class));
-        verify(jurorResponse).setProcessingStatus(ProcessingStatus.CLOSED);
+        verify(jurorResponse).setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.CLOSED);
         verify(mergeService).mergeResponse(jurorResponse, login);
-
-        verify(jurorResponseAuditRepository).save(any(JurorResponseAuditMod.class));
 
         verify(poolDetails, times(3)).getJuror();
         verify(juror).setResponded(true);
@@ -168,7 +166,7 @@ public class ResponseExcusalServiceImplTest {
             // assertions
             assertThat(e.getClass()).isEqualTo(ExcusalException.RequestedCodeNotValid.class);
             verify(jurorResponseRepository, times(0)).findByJurorNumber(any(String.class));
-            verify(jurorResponse, times(0)).setProcessingStatus(ProcessingStatus.CLOSED);
+            verify(jurorResponse, times(0)).setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.CLOSED);
             verify(jurorResponseRepository, times(0)).save(jurorResponse);
 
             verify(jurorResponseAuditRepository, times(0)).save(any(JurorResponseAuditMod.class));
@@ -210,7 +208,7 @@ public class ResponseExcusalServiceImplTest {
             // assertions
             assertThat(e.getClass()).isEqualTo(ExcusalException.JurorNotFound.class);
             verify(jurorResponseRepository, times(1)).findByJurorNumber(any(String.class));
-            verify(jurorResponse, times(0)).setProcessingStatus(ProcessingStatus.CLOSED);
+            verify(jurorResponse, times(0)).setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.CLOSED);
             verify(jurorResponseRepository, times(0)).save(jurorResponse);
 
             verify(jurorResponseAuditRepository, times(0)).save(any(JurorResponseAuditMod.class));
@@ -259,10 +257,8 @@ public class ResponseExcusalServiceImplTest {
         // assertions
         assertThat(result).isEqualTo(true);
         verify(jurorResponseRepository).findByJurorNumber(any(String.class));
-        verify(jurorResponse).setProcessingStatus(ProcessingStatus.CLOSED);
+        verify(jurorResponse).setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.CLOSED);
         verify(mergeService).mergeResponse(jurorResponse, login);
-
-        verify(jurorResponseAuditRepository).save(any(JurorResponseAuditMod.class));
 
         verify(poolDetails, times(4)).getJuror();
         verify(juror).setResponded(true);
@@ -303,7 +299,7 @@ public class ResponseExcusalServiceImplTest {
             // assertions
             assertThat(e.getClass()).isEqualTo(ExcusalException.RequestedCodeNotValid.class);
             verify(jurorResponseRepository, times(0)).findByJurorNumber(any(String.class));
-            verify(jurorResponse, times(0)).setProcessingStatus(ProcessingStatus.CLOSED);
+            verify(jurorResponse, times(0)).setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.CLOSED);
             verify(mergeService, times(0)).mergeResponse(jurorResponse, login);
 
             verify(jurorResponseAuditRepository, times(0)).save(any(JurorResponseAuditMod.class));
@@ -342,7 +338,7 @@ public class ResponseExcusalServiceImplTest {
         } catch (ExcusalException e) {
             // assertions
             assertThat(e.getClass()).isEqualTo(ExcusalException.JurorNotFound.class);
-            verify(jurorResponse, times(0)).setProcessingStatus(ProcessingStatus.CLOSED);
+            verify(jurorResponse, times(0)).setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.CLOSED);
             verify(mergeService, times(0)).mergeResponse(jurorResponse, login);
 
             verify(jurorResponseAuditRepository, times(0)).save(any(JurorResponseAuditMod.class));

--- a/src/test/java/uk/gov/hmcts/juror/api/bureau/service/ResponseStatusUpdateServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/bureau/service/ResponseStatusUpdateServiceImplTest.java
@@ -90,7 +90,7 @@ public class ResponseStatusUpdateServiceImplTest {
         // Verify mock interactions
         verify(entityManager).detach(mockJurorResponse);
         verify(mockJurorResponse).setVersion(version);
-        verify(mockJurorResponse).setProcessingStatus(statusToChangeTo);
+        verify(mockJurorResponse).setProcessingStatus(auditRepository, statusToChangeTo);
         verify(jurorResponseRepository).save(mockJurorResponse);
 
         // as we're not setting the status to CLOSED, we should not be merging data to Juror
@@ -122,7 +122,7 @@ public class ResponseStatusUpdateServiceImplTest {
         // Verify mock interactions
         verify(entityManager).detach(mockJurorResponse);
         verify(mockJurorResponse).setVersion(version);
-        verify(mockJurorResponse).setProcessingStatus(statusToChangeTo);
+        verify(mockJurorResponse).setProcessingStatus(auditRepository, statusToChangeTo);
         verify(jurorResponseRepository).save(mockJurorResponse);
 
         // as we're not setting the status to CLOSED, we should not be merging data to Juror
@@ -154,7 +154,7 @@ public class ResponseStatusUpdateServiceImplTest {
         // Verify mock interactions
         verify(entityManager).detach(mockJurorResponse);
         verify(mockJurorResponse).setVersion(version);
-        verify(mockJurorResponse).setProcessingStatus(statusToChangeTo);
+        verify(mockJurorResponse).setProcessingStatus(auditRepository, statusToChangeTo);
         verify(jurorResponseRepository).save(mockJurorResponse);
 
         // as we're not setting the status to CLOSED, we should not be merging data to Juror
@@ -183,7 +183,7 @@ public class ResponseStatusUpdateServiceImplTest {
         // Verify mock interactions
         verify(entityManager).detach(mockJurorResponse);
         verify(mockJurorResponse).setVersion(version);
-        verify(mockJurorResponse).setProcessingStatus(statusToChangeTo);
+        verify(mockJurorResponse).setProcessingStatus(auditRepository, statusToChangeTo);
         verify(jurorResponseRepository).save(mockJurorResponse);
 
         // as we're not setting the status to CLOSED, we should not be merging data to Juror
@@ -223,7 +223,7 @@ public class ResponseStatusUpdateServiceImplTest {
         // Verify mock interactions
         verify(entityManager).detach(mockJurorResponse);
         verify(mockJurorResponse).setVersion(version);
-        verify(mockJurorResponse).setProcessingStatus(statusToChangeTo);
+        verify(mockJurorResponse).setProcessingStatus(auditRepository, statusToChangeTo);
         verify(jurorResponseRepository).save(mockJurorResponse);
 
         // as we're setting the status to CLOSED, we should be merging data to Juror
@@ -254,7 +254,7 @@ public class ResponseStatusUpdateServiceImplTest {
         // Verify mock interactions
         verify(entityManager).detach(mockJurorResponse);
         verify(mockJurorResponse).setVersion(version);
-        verify(mockJurorResponse).setProcessingStatus(statusToChangeTo);
+        verify(mockJurorResponse).setProcessingStatus(auditRepository, statusToChangeTo);
         verify(jurorResponseRepository).save(mockJurorResponse);
 
         // as we're not setting the status to CLOSED, we should not be merging data to Juror

--- a/src/test/java/uk/gov/hmcts/juror/api/juror/service/StraightThroughProcessorImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/juror/service/StraightThroughProcessorImplTest.java
@@ -8,6 +8,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.juror.api.bureau.domain.DisCode;
 import uk.gov.hmcts.juror.api.bureau.service.ResponseMergeService;
+import uk.gov.hmcts.juror.api.juror.domain.ProcessingStatus;
 import uk.gov.hmcts.juror.api.moj.domain.IJurorStatus;
 import uk.gov.hmcts.juror.api.moj.domain.Juror;
 import uk.gov.hmcts.juror.api.moj.domain.JurorHistory;
@@ -117,7 +118,7 @@ public class StraightThroughProcessorImplTest {
 
         // check excusal was successful
         verify(mergeService).mergeResponse(any(DigitalResponse.class), eq(AUTO_USER));
-        verify(jurorResponseAuditRepository).save(any(JurorResponseAuditMod.class));
+        verify(jurorResponse).setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.CLOSED);
 
         verify(jurorPool, times(3)).getJuror();
         verify(juror, times(1)).setResponded(true);
@@ -224,9 +225,9 @@ public class StraightThroughProcessorImplTest {
         // process response
         straightThroughProcessor.processAgeExcusal(jurorResponse);
 
+        verify(jurorResponse).setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.CLOSED);
         // check excusal was successful
         verify(mergeService).mergeResponse(any(DigitalResponse.class), eq(AUTO_USER));
-        verify(jurorResponseAuditRepository).save(any(JurorResponseAuditMod.class));
 
         verify(jurorPool, times(3)).getJuror();
         verify(juror, times(1)).setResponded(true);
@@ -239,7 +240,7 @@ public class StraightThroughProcessorImplTest {
         verify(poolRepository).save(any(JurorPool.class));
 
         verify(partHistRepository, times(1)).save(any(JurorHistory.class));
-        verify(jurorHistoryService).createWithdrawHistory(jurorPool,null,"A");
+        verify(jurorHistoryService).createWithdrawHistory(jurorPool, null, "A");
 
         verify(printDataService).printWithdrawalLetter(any(JurorPool.class));
 
@@ -269,9 +270,9 @@ public class StraightThroughProcessorImplTest {
         // process response
         straightThroughProcessor.processAgeExcusal(jurorResponse);
 
-        // check excusal was successful
+        verify(jurorResponse).setProcessingStatus(jurorResponseAuditRepository,
+            ProcessingStatus.CLOSED);        // check excusal was successful
         verify(mergeService).mergeResponse(any(DigitalResponse.class), eq(AUTO_USER));
-        verify(jurorResponseAuditRepository).save(any(JurorResponseAuditMod.class));
 
         verify(jurorPool, times(3)).getJuror();
         verify(juror).setResponded(true);
@@ -283,7 +284,7 @@ public class StraightThroughProcessorImplTest {
         verify(poolRepository).save(any(JurorPool.class));
 
         verify(partHistRepository, times(1)).save(any(JurorHistory.class));
-        verify(jurorHistoryService).createWithdrawHistory(jurorPool,null,"A");
+        verify(jurorHistoryService).createWithdrawHistory(jurorPool, null, "A");
 
         verify(printDataService).printWithdrawalLetter(jurorPool);
 

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/domain/JurorPaperResponseTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/domain/JurorPaperResponseTest.java
@@ -11,12 +11,14 @@ import org.junit.runner.RunWith;
 import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.hmcts.juror.api.juror.domain.ProcessingStatus;
 import uk.gov.hmcts.juror.api.moj.domain.jurorresponse.PaperResponse;
+import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorResponseAuditRepositoryMod;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static uk.gov.hmcts.juror.api.TestUtils.buildStringToLength;
 
 @RunWith(SpringRunner.class)
@@ -572,7 +574,7 @@ public class JurorPaperResponseTest {
         response.setAddressLine1("Test");
         response.setDateReceived(LocalDateTime.now());
         response.setJurorNumber("123456789");
-        response.setProcessingStatus(ProcessingStatus.AWAITING_CONTACT);
+        response.setProcessingStatus(mock(JurorResponseAuditRepositoryMod.class), ProcessingStatus.AWAITING_CONTACT);
 
         Set<ConstraintViolation<PaperResponse>> violations = validator.validate(response);
         assertThat(violations).as("No validation violations expected").isEmpty();

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/ExcusalResponseServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/ExcusalResponseServiceImplTest.java
@@ -33,6 +33,7 @@ import uk.gov.hmcts.juror.api.moj.repository.JurorStatusRepository;
 import uk.gov.hmcts.juror.api.moj.repository.UserRepository;
 import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorDigitalResponseRepositoryMod;
 import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorPaperResponseRepositoryMod;
+import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorResponseAuditRepositoryMod;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -73,6 +74,8 @@ public class ExcusalResponseServiceImplTest {
     private JurorHistoryRepository jurorHistoryRepository;
     @Mock
     private PrintDataService printDataService;
+    @Mock
+    private JurorResponseAuditRepositoryMod jurorResponseAuditRepository;
 
     @InjectMocks
     private ExcusalResponseServiceImpl excusalResponseService;
@@ -370,7 +373,7 @@ public class ExcusalResponseServiceImplTest {
         final ExcusalDecisionDto excusalDecisionDto = createTestExcusalDecisionRequest();
 
         PaperResponse jurorPaperResponse = createTestJurorPaperResponse(JUROR_NUMBER);
-        jurorPaperResponse.setProcessingStatus(ProcessingStatus.CLOSED);
+        jurorPaperResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.CLOSED);
         excusalDecisionDto.setExcusalDecision(ExcusalDecision.GRANT);
 
         Mockito.doReturn(jurorPaperResponse).when(jurorPaperResponseRepository).findByJurorNumber(JUROR_NUMBER);
@@ -407,7 +410,7 @@ public class ExcusalResponseServiceImplTest {
         excusalDecisionDto.setExcusalDecision(ExcusalDecision.GRANT);
 
         DigitalResponse jurorResponse = createTestJurorDigitalResponse(JUROR_NUMBER);
-        jurorResponse.setProcessingStatus(ProcessingStatus.CLOSED);
+        jurorResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.CLOSED);
         Mockito.doReturn(jurorResponse).when(jurorResponseRepository).findByJurorNumber(JUROR_NUMBER);
 
         JurorPool jurorPool = new JurorPool();
@@ -785,7 +788,7 @@ public class ExcusalResponseServiceImplTest {
         response.setConvictions(false);
 
         response.setSigned(true);
-        response.setProcessingStatus(ProcessingStatus.TODO);
+        response.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
 
         return response;
     }
@@ -815,7 +818,7 @@ public class ExcusalResponseServiceImplTest {
         response.setBail(false);
         response.setConvictions(false);
 
-        response.setProcessingStatus(ProcessingStatus.TODO);
+        response.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
 
         return response;
     }

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/JurorPaperResponseServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/JurorPaperResponseServiceImplTest.java
@@ -44,6 +44,7 @@ import uk.gov.hmcts.juror.api.moj.repository.UserRepository;
 import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorDigitalResponseRepositoryMod;
 import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorPaperResponseRepositoryMod;
 import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorReasonableAdjustmentRepository;
+import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorResponseAuditRepositoryMod;
 import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorResponseCjsEmploymentRepositoryMod;
 
 import java.time.LocalDate;
@@ -92,7 +93,8 @@ public class JurorPaperResponseServiceImplTest {
     private WelshCourtLocationRepository welshCourtLocationRepository;
     @Mock
     private StraightThroughProcessorService straightThroughProcessorService;
-
+    @Mock
+    private JurorResponseAuditRepositoryMod jurorResponseAuditRepository;
     @InjectMocks
     private JurorPaperResponseServiceImpl jurorPaperResponseService;
 
@@ -1503,7 +1505,7 @@ public class JurorPaperResponseServiceImplTest {
         Mockito.doReturn(Collections.singletonList(adjustment)).when(response).getReasonableAdjustments();
 
         response.setSigned(true);
-        response.setProcessingStatus(ProcessingStatus.TODO);
+        response.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
 
         response.setStaff(User.builder().username("SOME_USER").build());
 

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/StraightThroughProcessorServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/StraightThroughProcessorServiceImplTest.java
@@ -28,6 +28,7 @@ import uk.gov.hmcts.juror.api.moj.repository.JurorStatusRepository;
 import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorDigitalResponseRepositoryMod;
 import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorPaperResponseRepositoryMod;
 import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorReasonableAdjustmentRepository;
+import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorResponseAuditRepositoryMod;
 import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorResponseCjsEmploymentRepositoryMod;
 import uk.gov.hmcts.juror.api.validation.ResponseInspector;
 
@@ -67,6 +68,8 @@ public class StraightThroughProcessorServiceImplTest {
     private ResponseInspector responseInspector;
     @Mock
     private SummonsReplyMergeService mergeService;
+    @Mock
+    private JurorResponseAuditRepositoryMod jurorResponseAuditRepository;
 
     @InjectMocks
     private StraightThroughProcessorServiceImpl straightThroughProcessorService;
@@ -525,7 +528,7 @@ public class StraightThroughProcessorServiceImplTest {
         setJurorPoolPersonalDetails(juror);
 
         PaperResponse paperResponse = createPaperResponse(dateOfBirth);
-        paperResponse.setProcessingStatus(ProcessingStatus.TODO);
+        paperResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
         setPaperResponseDetails(paperResponse);
 
         Mockito.doReturn(Collections.singletonList(jurorPool)).when(jurorPoolRepository)
@@ -550,7 +553,7 @@ public class StraightThroughProcessorServiceImplTest {
         juror.setTitle(null);
 
         PaperResponse paperResponse = createPaperResponse(dateOfBirth);
-        paperResponse.setProcessingStatus(ProcessingStatus.TODO);
+        paperResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
         setPaperResponseDetails(paperResponse);
 
         Mockito.doReturn(Collections.singletonList(jurorPool)).when(jurorPoolRepository)
@@ -574,7 +577,7 @@ public class StraightThroughProcessorServiceImplTest {
         setJurorPoolPersonalDetails(juror);
 
         PaperResponse paperResponse = createPaperResponse(dateOfBirth);
-        paperResponse.setProcessingStatus(ProcessingStatus.TODO);
+        paperResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
         setPaperResponseDetails(paperResponse);
         paperResponse.setFirstName("");
 
@@ -599,7 +602,7 @@ public class StraightThroughProcessorServiceImplTest {
         setJurorPoolPersonalDetails(juror);
 
         PaperResponse paperResponse = createPaperResponse(dateOfBirth);
-        paperResponse.setProcessingStatus(ProcessingStatus.TODO);
+        paperResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
         setPaperResponseDetails(paperResponse);
         paperResponse.setLastName(null);
 
@@ -625,7 +628,7 @@ public class StraightThroughProcessorServiceImplTest {
         juror.setAddressLine1("Some Address 1");
 
         PaperResponse paperResponse = createPaperResponse(dateOfBirth);
-        paperResponse.setProcessingStatus(ProcessingStatus.TODO);
+        paperResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
         setPaperResponseDetails(paperResponse);
 
         Mockito.doReturn(Collections.singletonList(jurorPool)).when(jurorPoolRepository)
@@ -650,7 +653,7 @@ public class StraightThroughProcessorServiceImplTest {
         juror.setAddressLine2("Some Address 2");
 
         PaperResponse paperResponse = createPaperResponse(dateOfBirth);
-        paperResponse.setProcessingStatus(ProcessingStatus.TODO);
+        paperResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
         setPaperResponseDetails(paperResponse);
 
         Mockito.doReturn(Collections.singletonList(jurorPool)).when(jurorPoolRepository)
@@ -674,7 +677,7 @@ public class StraightThroughProcessorServiceImplTest {
         setJurorPoolPersonalDetails(juror);
 
         PaperResponse paperResponse = createPaperResponse(dateOfBirth);
-        paperResponse.setProcessingStatus(ProcessingStatus.TODO);
+        paperResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
         setPaperResponseDetails(paperResponse);
         paperResponse.setAddressLine3("Some Address 3");
 
@@ -699,7 +702,7 @@ public class StraightThroughProcessorServiceImplTest {
         setJurorPoolPersonalDetails(juror);
 
         PaperResponse paperResponse = createPaperResponse(dateOfBirth);
-        paperResponse.setProcessingStatus(ProcessingStatus.TODO);
+        paperResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
         setPaperResponseDetails(paperResponse);
         paperResponse.setAddressLine4("Some Town/City");
 
@@ -725,7 +728,7 @@ public class StraightThroughProcessorServiceImplTest {
         juror.setAddressLine5("Some Address 5");
 
         PaperResponse paperResponse = createPaperResponse(dateOfBirth);
-        paperResponse.setProcessingStatus(ProcessingStatus.TODO);
+        paperResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
         setPaperResponseDetails(paperResponse);
 
         Mockito.doReturn(Collections.singletonList(jurorPool)).when(jurorPoolRepository)
@@ -749,7 +752,7 @@ public class StraightThroughProcessorServiceImplTest {
         setJurorPoolPersonalDetails(juror);
 
         PaperResponse paperResponse = createPaperResponse(dateOfBirth);
-        paperResponse.setProcessingStatus(ProcessingStatus.TODO);
+        paperResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
         setPaperResponseDetails(paperResponse);
         paperResponse.setPostcode(null);
 
@@ -774,7 +777,7 @@ public class StraightThroughProcessorServiceImplTest {
         setJurorPoolPersonalDetails(juror);
 
         PaperResponse paperResponse = createPaperResponse(dateOfBirth);
-        paperResponse.setProcessingStatus(ProcessingStatus.TODO);
+        paperResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
         setPaperResponseDetails(paperResponse);
         paperResponse.setDateOfBirth(null);
 
@@ -799,7 +802,7 @@ public class StraightThroughProcessorServiceImplTest {
         setJurorPoolPersonalDetails(juror);
 
         PaperResponse paperResponse = createPaperResponse(dateOfBirth);
-        paperResponse.setProcessingStatus(ProcessingStatus.TODO);
+        paperResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
         setPaperResponseDetails(paperResponse);
 
         Mockito.doReturn(Collections.singletonList(jurorPool)).when(jurorPoolRepository)
@@ -823,7 +826,7 @@ public class StraightThroughProcessorServiceImplTest {
         setJurorPoolPersonalDetails(juror);
 
         PaperResponse paperResponse = createPaperResponse(dateOfBirth);
-        paperResponse.setProcessingStatus(ProcessingStatus.TODO);
+        paperResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
         setPaperResponseDetails(paperResponse);
         paperResponse.setRelationship("Brother");
 
@@ -852,7 +855,7 @@ public class StraightThroughProcessorServiceImplTest {
         jurorPool.setStatus(jurorStatus);
 
         PaperResponse paperResponse = createPaperResponse(dateOfBirth);
-        paperResponse.setProcessingStatus(ProcessingStatus.TODO);
+        paperResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
         setPaperResponseDetails(paperResponse);
 
         Mockito.doReturn(Collections.singletonList(jurorPool)).when(jurorPoolRepository)
@@ -876,7 +879,7 @@ public class StraightThroughProcessorServiceImplTest {
         setJurorPoolPersonalDetails(juror);
 
         PaperResponse paperResponse = createPaperResponse(dateOfBirth);
-        paperResponse.setProcessingStatus(ProcessingStatus.TODO);
+        paperResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
         setPaperResponseDetails(paperResponse);
         paperResponse.setResidency(false);
 
@@ -901,7 +904,7 @@ public class StraightThroughProcessorServiceImplTest {
         setJurorPoolPersonalDetails(juror);
 
         PaperResponse paperResponse = createPaperResponse(dateOfBirth);
-        paperResponse.setProcessingStatus(ProcessingStatus.TODO);
+        paperResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
         setPaperResponseDetails(paperResponse);
         paperResponse.setResidency(null);
 
@@ -926,7 +929,7 @@ public class StraightThroughProcessorServiceImplTest {
         setJurorPoolPersonalDetails(juror);
 
         PaperResponse paperResponse = createPaperResponse(dateOfBirth);
-        paperResponse.setProcessingStatus(ProcessingStatus.TODO);
+        paperResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
         setPaperResponseDetails(paperResponse);
         paperResponse.setMentalHealthAct(true);
 
@@ -951,7 +954,7 @@ public class StraightThroughProcessorServiceImplTest {
         setJurorPoolPersonalDetails(juror);
 
         PaperResponse paperResponse = createPaperResponse(dateOfBirth);
-        paperResponse.setProcessingStatus(ProcessingStatus.TODO);
+        paperResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
         setPaperResponseDetails(paperResponse);
         paperResponse.setMentalHealthAct(null);
 
@@ -976,7 +979,7 @@ public class StraightThroughProcessorServiceImplTest {
         setJurorPoolPersonalDetails(juror);
 
         PaperResponse paperResponse = createPaperResponse(dateOfBirth);
-        paperResponse.setProcessingStatus(ProcessingStatus.TODO);
+        paperResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
         setPaperResponseDetails(paperResponse);
         paperResponse.setMentalHealthCapacity(true);
 
@@ -1001,7 +1004,7 @@ public class StraightThroughProcessorServiceImplTest {
         setJurorPoolPersonalDetails(juror);
 
         PaperResponse paperResponse = createPaperResponse(dateOfBirth);
-        paperResponse.setProcessingStatus(ProcessingStatus.TODO);
+        paperResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
         setPaperResponseDetails(paperResponse);
         paperResponse.setMentalHealthCapacity(null);
 
@@ -1026,7 +1029,7 @@ public class StraightThroughProcessorServiceImplTest {
         setJurorPoolPersonalDetails(juror);
 
         PaperResponse paperResponse = createPaperResponse(dateOfBirth);
-        paperResponse.setProcessingStatus(ProcessingStatus.TODO);
+        paperResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
         setPaperResponseDetails(paperResponse);
         paperResponse.setBail(true);
 
@@ -1051,7 +1054,7 @@ public class StraightThroughProcessorServiceImplTest {
         setJurorPoolPersonalDetails(juror);
 
         PaperResponse paperResponse = createPaperResponse(dateOfBirth);
-        paperResponse.setProcessingStatus(ProcessingStatus.TODO);
+        paperResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
         setPaperResponseDetails(paperResponse);
         paperResponse.setBail(null);
 
@@ -1076,7 +1079,7 @@ public class StraightThroughProcessorServiceImplTest {
         setJurorPoolPersonalDetails(juror);
 
         PaperResponse paperResponse = createPaperResponse(dateOfBirth);
-        paperResponse.setProcessingStatus(ProcessingStatus.TODO);
+        paperResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
         setPaperResponseDetails(paperResponse);
         paperResponse.setConvictions(true);
 
@@ -1101,7 +1104,7 @@ public class StraightThroughProcessorServiceImplTest {
         setJurorPoolPersonalDetails(juror);
 
         PaperResponse paperResponse = createPaperResponse(dateOfBirth);
-        paperResponse.setProcessingStatus(ProcessingStatus.TODO);
+        paperResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
         setPaperResponseDetails(paperResponse);
         paperResponse.setConvictions(null);
 
@@ -1126,7 +1129,7 @@ public class StraightThroughProcessorServiceImplTest {
         setJurorPoolPersonalDetails(juror);
 
         PaperResponse paperResponse = createPaperResponse(dateOfBirth);
-        paperResponse.setProcessingStatus(ProcessingStatus.TODO);
+        paperResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
         setPaperResponseDetails(paperResponse);
         paperResponse.setSigned(false);
 
@@ -1151,7 +1154,7 @@ public class StraightThroughProcessorServiceImplTest {
         setJurorPoolPersonalDetails(juror);
 
         PaperResponse paperResponse = createPaperResponse(dateOfBirth);
-        paperResponse.setProcessingStatus(ProcessingStatus.TODO);
+        paperResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
         setPaperResponseDetails(paperResponse);
         paperResponse.setSigned(null);
 
@@ -1176,7 +1179,7 @@ public class StraightThroughProcessorServiceImplTest {
         setJurorPoolPersonalDetails(juror);
 
         PaperResponse paperResponse = createPaperResponse(dateOfBirth);
-        paperResponse.setProcessingStatus(ProcessingStatus.TODO);
+        paperResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
         setPaperResponseDetails(paperResponse);
         paperResponse.setExcusal(true);
 
@@ -1201,7 +1204,7 @@ public class StraightThroughProcessorServiceImplTest {
         setJurorPoolPersonalDetails(juror);
 
         PaperResponse paperResponse = createPaperResponse(dateOfBirth);
-        paperResponse.setProcessingStatus(ProcessingStatus.TODO);
+        paperResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
         setPaperResponseDetails(paperResponse);
         paperResponse.setDeferral(true);
 
@@ -1226,7 +1229,7 @@ public class StraightThroughProcessorServiceImplTest {
         setJurorPoolPersonalDetails(juror);
 
         PaperResponse paperResponse = createPaperResponse(dateOfBirth);
-        paperResponse.setProcessingStatus(ProcessingStatus.TODO);
+        paperResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
         setPaperResponseDetails(paperResponse);
         paperResponse.setDeferral(null);
         paperResponse.setExcusal(null);
@@ -1252,7 +1255,7 @@ public class StraightThroughProcessorServiceImplTest {
         setJurorPoolPersonalDetails(juror);
 
         PaperResponse paperResponse = createPaperResponse(dateOfBirth);
-        paperResponse.setProcessingStatus(ProcessingStatus.TODO);
+        paperResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
         setPaperResponseDetails(paperResponse);
 
         JurorResponseCjsEmployment cjsEmployment = new JurorResponseCjsEmployment();
@@ -1282,7 +1285,7 @@ public class StraightThroughProcessorServiceImplTest {
         setJurorPoolPersonalDetails(juror);
 
         PaperResponse paperResponse = createPaperResponse(dateOfBirth);
-        paperResponse.setProcessingStatus(ProcessingStatus.TODO);
+        paperResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
         setPaperResponseDetails(paperResponse);
 
         JurorReasonableAdjustment adjustment1 = new JurorReasonableAdjustment();

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/SummonsReplyStatusUpdateServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/SummonsReplyStatusUpdateServiceImplTest.java
@@ -147,7 +147,7 @@ public class SummonsReplyStatusUpdateServiceImplTest {
         PaperResponse response = new PaperResponse();
         response.setJurorNumber(jurorNumber);
         response.setProcessingComplete(false);
-        response.setProcessingStatus(ProcessingStatus.TODO);
+        response.setProcessingStatus(auditRepository, ProcessingStatus.TODO);
 
         final BureauJwtPayload payload = buildPayload();
 
@@ -187,7 +187,7 @@ public class SummonsReplyStatusUpdateServiceImplTest {
         String jurorNumber = "123456789";
         PaperResponse response = createPaperResponse(jurorNumber);
         response.setProcessingComplete(false);
-        response.setProcessingStatus(ProcessingStatus.CLOSED);
+        response.setProcessingStatus(auditRepository, ProcessingStatus.CLOSED);
         response.setPhoneNumber("07123456789");
         response.setAltPhoneNumber("01234567890");
 
@@ -238,7 +238,7 @@ public class SummonsReplyStatusUpdateServiceImplTest {
 
         PaperResponse response = createPaperResponseFromJurorPool(juror);
         response.setProcessingComplete(false);
-        response.setProcessingStatus(ProcessingStatus.CLOSED);
+        response.setProcessingStatus(auditRepository, ProcessingStatus.CLOSED);
         response.setPhoneNumber("01234567890");
         response.setAltPhoneNumber("07123456789");
 
@@ -271,7 +271,7 @@ public class SummonsReplyStatusUpdateServiceImplTest {
         String jurorNumber = "123456789";
         PaperResponse response = createPaperResponse(jurorNumber);
         response.setProcessingComplete(true);
-        response.setProcessingStatus(ProcessingStatus.CLOSED);
+        response.setProcessingStatus(auditRepository, ProcessingStatus.CLOSED);
 
         final BureauJwtPayload payload = buildPayload();
 
@@ -302,7 +302,7 @@ public class SummonsReplyStatusUpdateServiceImplTest {
         String jurorNumber = "123456789";
         PaperResponse response = createPaperResponse(jurorNumber);
         response.setProcessingComplete(false);
-        response.setProcessingStatus(ProcessingStatus.CLOSED);
+        response.setProcessingStatus(auditRepository, ProcessingStatus.CLOSED);
 
         BureauJwtPayload payload = buildPayload();
 
@@ -326,7 +326,7 @@ public class SummonsReplyStatusUpdateServiceImplTest {
         String jurorNumber = "123456789";
         PaperResponse response = createPaperResponse(jurorNumber);
         response.setProcessingComplete(false);
-        response.setProcessingStatus(ProcessingStatus.CLOSED);
+        response.setProcessingStatus(auditRepository, ProcessingStatus.CLOSED);
 
         final BureauJwtPayload payload = buildPayload();
 
@@ -354,7 +354,7 @@ public class SummonsReplyStatusUpdateServiceImplTest {
         String jurorNumber = "123456789";
         PaperResponse response = createPaperResponse(jurorNumber);
         response.setProcessingComplete(false);
-        response.setProcessingStatus(ProcessingStatus.TODO);
+        response.setProcessingStatus(auditRepository, ProcessingStatus.TODO);
 
         final BureauJwtPayload payload = buildPayload();
 
@@ -383,7 +383,7 @@ public class SummonsReplyStatusUpdateServiceImplTest {
         String jurorNumber = "123456789";
         PaperResponse response = createPaperResponse(jurorNumber);
         response.setProcessingComplete(false);
-        response.setProcessingStatus(ProcessingStatus.TODO);
+        response.setProcessingStatus(auditRepository, ProcessingStatus.TODO);
 
         final BureauJwtPayload payload = buildPayload();
 
@@ -436,7 +436,7 @@ public class SummonsReplyStatusUpdateServiceImplTest {
         String jurorNumber = "123456789";
         PaperResponse response = createPaperResponse(jurorNumber);
         response.setProcessingComplete(false);
-        response.setProcessingStatus(ProcessingStatus.TODO);
+        response.setProcessingStatus(auditRepository, ProcessingStatus.TODO);
 
         BureauJwtPayload payload = buildPayload();
         payload.setOwner("415");
@@ -470,7 +470,7 @@ public class SummonsReplyStatusUpdateServiceImplTest {
         String jurorNumber = "123456789";
         PaperResponse response = createPaperResponse(jurorNumber);
         response.setProcessingComplete(false);
-        response.setProcessingStatus(ProcessingStatus.TODO);
+        response.setProcessingStatus(auditRepository, ProcessingStatus.TODO);
 
         BureauJwtPayload payload = buildPayload();
         payload.setOwner("415");
@@ -2275,7 +2275,7 @@ public class SummonsReplyStatusUpdateServiceImplTest {
         String jurorNumber = "123456789";
         PaperResponse response = createPaperResponse(jurorNumber);
         response.setProcessingComplete(true);
-        response.setProcessingStatus(ProcessingStatus.CLOSED);
+        response.setProcessingStatus(auditRepository, ProcessingStatus.CLOSED);
         response.setPhoneNumber("07123456789");
         response.setAltPhoneNumber("01234567890");
 

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/letter/RequestInformationLetterServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/letter/RequestInformationLetterServiceTest.java
@@ -19,6 +19,7 @@ import uk.gov.hmcts.juror.api.moj.enumeration.ReplyMethod;
 import uk.gov.hmcts.juror.api.moj.enumeration.letter.MissingInformation;
 import uk.gov.hmcts.juror.api.moj.exception.MojException;
 import uk.gov.hmcts.juror.api.moj.repository.JurorPoolRepository;
+import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorResponseAuditRepositoryMod;
 import uk.gov.hmcts.juror.api.moj.repository.letter.RequestLetterRepository;
 import uk.gov.hmcts.juror.api.moj.service.JurorHistoryService;
 import uk.gov.hmcts.juror.api.moj.service.PrintDataService;
@@ -56,6 +57,8 @@ public class RequestInformationLetterServiceTest {
     private PrintDataService printDataService;
     @Mock
     private JurorHistoryService jurorHistoryService;
+    @Mock
+    private JurorResponseAuditRepositoryMod jurorResponseAuditRepository;
 
     @InjectMocks
     RequestInformationLetterServiceImpl requestInformationLetterService;
@@ -68,7 +71,7 @@ public class RequestInformationLetterServiceTest {
         String jurorNumber = "123456789";
 
         DigitalResponse jurorResponse = new DigitalResponse();
-        jurorResponse.setProcessingStatus(ProcessingStatus.TODO);
+        jurorResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
 
         final BureauJwtPayload payload = TestUtils.createJwt(owner, "BUREAU_USER");
 
@@ -104,7 +107,7 @@ public class RequestInformationLetterServiceTest {
         String jurorNumber = "123456789";
 
         PaperResponse jurorPaperResponse = new PaperResponse();
-        jurorPaperResponse.setProcessingStatus(ProcessingStatus.TODO);
+        jurorPaperResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
 
         BureauJwtPayload payload = TestUtils.createJwt(owner, "BUREAU_USER");
 
@@ -133,7 +136,7 @@ public class RequestInformationLetterServiceTest {
         String jurorNumber = "123456789";
 
         PaperResponse jurorPaperResponse = new PaperResponse();
-        jurorPaperResponse.setProcessingStatus(ProcessingStatus.TODO);
+        jurorPaperResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
 
         final BureauJwtPayload payload = TestUtils.createJwt(owner, "BUREAU_USER");
 
@@ -172,7 +175,7 @@ public class RequestInformationLetterServiceTest {
         String jurorNumber = "123456789";
 
         PaperResponse jurorPaperResponse = new PaperResponse();
-        jurorPaperResponse.setProcessingStatus(ProcessingStatus.AWAITING_CONTACT);
+        jurorPaperResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.AWAITING_CONTACT);
 
         // an empty list of pool members required for test
         List<JurorPool> jurorPools = new ArrayList<>();
@@ -202,7 +205,7 @@ public class RequestInformationLetterServiceTest {
         String jurorNumber = "123456789";
 
         PaperResponse jurorPaperResponse = new PaperResponse();
-        jurorPaperResponse.setProcessingStatus(ProcessingStatus.AWAITING_CONTACT);
+        jurorPaperResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.AWAITING_CONTACT);
 
         // an empty list of pool members required for test
         Juror juror = new Juror();

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/summonsmanagement/DisqualifyJurorServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/summonsmanagement/DisqualifyJurorServiceImplTest.java
@@ -262,7 +262,6 @@ public class DisqualifyJurorServiceImplTest {
         verify(assignOnUpdateService, never()).assignToCurrentLogin(any(DigitalResponse.class),
             anyString());
         verify(summonsReplyMergeService, never()).mergeDigitalResponse(any(DigitalResponse.class), anyString());
-        verify(jurorResponseAuditRepository, never()).save(any(JurorResponseAuditMod.class));
     }
 
     @Test
@@ -444,7 +443,6 @@ public class DisqualifyJurorServiceImplTest {
         verify(jurorDigitalResponseRepository, times(1)).findByJurorNumber(anyString());
         verify(assignOnUpdateService, never()).assignToCurrentLogin(any(DigitalResponse.class), anyString());
         verify(summonsReplyMergeService, never()).mergeDigitalResponse(any(DigitalResponse.class), anyString());
-        verify(jurorResponseAuditRepository, never()).save(any(JurorResponseAuditMod.class));
 
         //Paper related
         verify(jurorPaperResponseRepository, never()).findById(anyString());
@@ -498,7 +496,7 @@ public class DisqualifyJurorServiceImplTest {
         response.setConvictions(false);
 
         response.setSigned(true);
-        response.setProcessingStatus(ProcessingStatus.TODO);
+        response.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
 
         return response;
     }
@@ -528,7 +526,7 @@ public class DisqualifyJurorServiceImplTest {
         response.setBail(false);
         response.setConvictions(false);
 
-        response.setProcessingStatus(ProcessingStatus.TODO);
+        response.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
 
         return response;
     }

--- a/src/test/java/uk/gov/hmcts/juror/api/scheduler/UrgentStatusSchedulerTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/scheduler/UrgentStatusSchedulerTest.java
@@ -19,6 +19,7 @@ import uk.gov.hmcts.juror.api.moj.domain.jurorresponse.DigitalResponse;
 import uk.gov.hmcts.juror.api.moj.repository.JurorPoolRepository;
 import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorDigitalResponseRepositoryMod;
 import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorPaperResponseRepositoryMod;
+import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorResponseAuditRepositoryMod;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -33,11 +34,7 @@ import static org.mockito.Mockito.verify;
 public class UrgentStatusSchedulerTest {
 
     private static final String NON_CLOSED_STATUS = ProcessingStatus.TODO.name();
-    private ModJurorDetail jurorBureauDetail;
-    private DigitalResponse jurorResponse;
     private JurorPool poolDetails;
-
-    private LocalDateTime responseReceived;
 
     @Mock
     private JurorDigitalResponseRepositoryMod jurorResponseRepo;
@@ -52,6 +49,8 @@ public class UrgentStatusSchedulerTest {
 
     @Mock
     private UrgencyService urgencyService;
+    @Mock
+    private JurorResponseAuditRepositoryMod jurorResponseAuditRepository;
 
     @InjectMocks
     UrgentStatusScheduler urgentStatusScheduler;
@@ -62,18 +61,18 @@ public class UrgentStatusSchedulerTest {
     @Before
     public void setUp() {
 
-        responseReceived = LocalDateTime.now();
+        LocalDateTime responseReceived = LocalDateTime.now();
 
         //set up some known static dates relative to a start point
         final LocalDate hearingDateValid = LocalDate.now().plusDays(35);
 
-        jurorBureauDetail = new ModJurorDetail();
+        ModJurorDetail jurorBureauDetail = new ModJurorDetail();
         jurorBureauDetail.setProcessingStatus(NON_CLOSED_STATUS);
         jurorBureauDetail.setDateReceived(responseReceived.toLocalDate());
         jurorBureauDetail.setHearingDate(hearingDateValid);
 
-        jurorResponse = new DigitalResponse();
-        jurorResponse.setProcessingStatus(uk.gov.hmcts.juror.api.juror.domain.ProcessingStatus.TODO);
+        DigitalResponse jurorResponse = new DigitalResponse();
+        jurorResponse.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
         jurorResponse.setDateReceived(responseReceived);
 
         poolDetails = new JurorPool();
@@ -87,7 +86,7 @@ public class UrgentStatusSchedulerTest {
         response.setJurorNumber("12345678");
 
         response.setDateReceived(LocalDateTime.now());
-        response.setProcessingStatus(ProcessingStatus.TODO);
+        response.setProcessingStatus(jurorResponseAuditRepository, ProcessingStatus.TODO);
         responseBacklog.add(response);
 
     }


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7703)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=566)


### Change description ###
For the juror_response_aud table we also need to track when paper responses get there processing status updated

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
