### PR TITLE
When there is lines missing from an address we need to be able to shuffle the address lines so there is no gaps in the bulk print

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -278,7 +278,7 @@ checkstyle {
 }
 
 pmdTest {
-    maxFailures = 304
+    maxFailures = 298
 }
 pmdMain {
     maxFailures = 799

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/LetterBase.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/LetterBase.java
@@ -150,7 +150,11 @@ public class LetterBase {
 
         @Override
         public String getValue() {
-            return Optional.ofNullable(type.getValue(letterContext)).orElse("");
+            String text = Optional.ofNullable(type.getValue(letterContext)).orElse("");
+            if (text.length() > length) {
+                return text.substring(0, length);
+            }
+            return text;
         }
 
         @Override
@@ -158,7 +162,6 @@ public class LetterBase {
             return length;
         }
     }
-
 
 
     @EqualsAndHashCode
@@ -327,6 +330,54 @@ public class LetterBase {
         private final CourtLocation bureauLocation;
         private final WelshCourtLocation welshCourtLocation;
         private final String additionalInformation;
+    }
+
+    protected void addBureauAddress() {
+        addDataShuffle(
+            new DataShuffle(LetterDataType.BUREAU_ADDRESS1, 35),
+            new DataShuffle(LetterDataType.BUREAU_ADDRESS2, 35),
+            new DataShuffle(LetterDataType.BUREAU_ADDRESS3, 35),
+            new DataShuffle(LetterDataType.BUREAU_ADDRESS4, 35),
+            new DataShuffle(LetterDataType.BUREAU_ADDRESS5, 35),
+            new DataShuffle(LetterDataType.BUREAU_ADDRESS6, 35),
+            new DataShuffle(LetterDataType.BUREAU_POSTCODE, 10)
+        );
+    }
+
+    protected void addJurorAddress() {
+        addData(LetterDataType.JUROR_ADDRESS1, 35);
+        addDataShuffle(
+            new DataShuffle(LetterDataType.JUROR_ADDRESS2, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS3, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS4, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS5, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS6, 35),
+            new DataShuffle(LetterDataType.JUROR_POSTCODE, 10)
+        );
+    }
+
+    protected void addWelshCourtAddress() {
+        addDataShuffle(
+            new DataShuffle(LetterDataType.WELSH_COURT_ADDRESS1, 35),
+            new DataShuffle(LetterDataType.WELSH_COURT_ADDRESS2, 35),
+            new DataShuffle(LetterDataType.WELSH_COURT_ADDRESS3, 35),
+            new DataShuffle(LetterDataType.WELSH_COURT_ADDRESS4, 35),
+            new DataShuffle(LetterDataType.WELSH_COURT_ADDRESS5, 35),
+            new DataShuffle(LetterDataType.WELSH_COURT_ADDRESS6, 35),
+            new DataShuffle(LetterDataType.COURT_POSTCODE, 10)
+        );
+    }
+
+    protected void addEnglishCourtAddress() {
+        addDataShuffle(
+            new DataShuffle(LetterDataType.COURT_ADDRESS1, 35),
+            new DataShuffle(LetterDataType.COURT_ADDRESS2, 35),
+            new DataShuffle(LetterDataType.COURT_ADDRESS3, 35),
+            new DataShuffle(LetterDataType.COURT_ADDRESS4, 35),
+            new DataShuffle(LetterDataType.COURT_ADDRESS5, 35),
+            new DataShuffle(LetterDataType.COURT_ADDRESS6, 35),
+            new DataShuffle(LetterDataType.COURT_POSTCODE, 10)
+        );
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/ConfirmLetter.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/ConfirmLetter.java
@@ -36,14 +36,13 @@ public class ConfirmLetter extends LetterBase {
         addData(LetterDataType.DATE_OF_LETTER, 18);
         addData(LetterDataType.COURT_LOCATION_CODE, 3);
         addData(LetterDataType.WELSH_COURT_NAME, 40);
-        addData(LetterDataType.COURT_NAME, 40);
-        addData(LetterDataType.BUREAU_NAME, 35);
-        sharedBureauSetup();
-        addData(LetterDataType.BUREAU_POSTCODE, 10);
+        addData(LetterDataType.BUREAU_NAME, 40);
+        addBureauAddress();
         addData(LetterDataType.BUREAU_PHONE, 12);
         addData(LetterDataType.BUREAU_FAX, 12);
         addData(LetterDataType.WELSH_DATE_OF_ATTENDANCE, 32);
         sharedSetup();
+        addData(LetterDataType.BUREAU_SIGNATORY, 30);
     }
 
     @Override
@@ -53,9 +52,7 @@ public class ConfirmLetter extends LetterBase {
         addData(LetterDataType.COURT_LOCATION_CODE, 3);
         addData(LetterDataType.COURT_NAME, 59);
         addData(LetterDataType.BUREAU_NAME, 40);
-        sharedBureauSetup();
-        addData(LetterDataType.BUREAU_ADDRESS6, 35);
-        addData(LetterDataType.BUREAU_POSTCODE, 10);
+        addBureauAddress();
         addData(LetterDataType.BUREAU_PHONE, 12);
         addData(LetterDataType.BUREAU_FAX, 12);
         addData(LetterDataType.DATE_OF_ATTENDANCE, 32);
@@ -63,28 +60,12 @@ public class ConfirmLetter extends LetterBase {
         addData(LetterDataType.BUREAU_SIGNATORY, 30);
     }
 
-    private void sharedBureauSetup() {
-        addData(LetterDataType.BUREAU_ADDRESS1, 35);
-        addData(LetterDataType.BUREAU_ADDRESS2, 35);
-        addData(LetterDataType.BUREAU_ADDRESS3, 35);
-        addData(LetterDataType.BUREAU_ADDRESS4, 35);
-        addData(LetterDataType.BUREAU_ADDRESS5, 35);
-    }
-
     private void sharedSetup() {
         addData(LetterDataType.TIME_OF_ATTENDANCE, 8);
         addData(LetterDataType.JUROR_TITLE, 10);
         addData(LetterDataType.JUROR_FIRST_NAME, 20);
         addData(LetterDataType.JUROR_LAST_NAME, 20);
-        addData(LetterDataType.JUROR_ADDRESS1, 35);
-        addDataShuffle(
-            new DataShuffle(LetterDataType.JUROR_ADDRESS2, 35),
-            new DataShuffle(LetterDataType.JUROR_ADDRESS3, 35),
-            new DataShuffle(LetterDataType.JUROR_ADDRESS4, 35),
-            new DataShuffle(LetterDataType.JUROR_ADDRESS5, 35),
-            new DataShuffle(LetterDataType.JUROR_ADDRESS6, 35),
-            new DataShuffle(LetterDataType.JUROR_POSTCODE, 10)
-        );
+        addJurorAddress();
         addData(LetterDataType.JUROR_NUMBER, 9);
     }
 }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/ConfirmLetter.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/ConfirmLetter.java
@@ -77,12 +77,14 @@ public class ConfirmLetter extends LetterBase {
         addData(LetterDataType.JUROR_FIRST_NAME, 20);
         addData(LetterDataType.JUROR_LAST_NAME, 20);
         addData(LetterDataType.JUROR_ADDRESS1, 35);
-        addData(LetterDataType.JUROR_ADDRESS2, 35);
-        addData(LetterDataType.JUROR_ADDRESS3, 35);
-        addData(LetterDataType.JUROR_ADDRESS4, 35);
-        addData(LetterDataType.JUROR_ADDRESS5, 35);
-        addData(LetterDataType.JUROR_ADDRESS6, 35);
-        addData(LetterDataType.JUROR_POSTCODE, 10);
+        addDataShuffle(
+            new DataShuffle(LetterDataType.JUROR_ADDRESS2, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS3, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS4, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS5, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS6, 35),
+            new DataShuffle(LetterDataType.JUROR_POSTCODE, 10)
+        );
         addData(LetterDataType.JUROR_NUMBER, 9);
     }
 }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/DeferralDeniedLetter.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/DeferralDeniedLetter.java
@@ -34,9 +34,11 @@ public class DeferralDeniedLetter extends LetterBase {
         setFormCode(FormCode.BI_DEFERRALDENIED);
         addData(LetterDataType.DATE_OF_LETTER, 18);
         addData(LetterDataType.WELSH_COURT_NAME, 40);
-        addData(LetterDataType.COURT_NAME, 40);
-        addData(LetterDataType.BUREAU_NAME, 35);
-        sharedBureauSetup();
+        addData(LetterDataType.BUREAU_NAME, 40);
+        addBureauAddress();
+        addData(LetterDataType.BUREAU_PHONE, 12);
+        addData(LetterDataType.BUREAU_FAX, 12);
+        addWelshCourtAddress();
         sharedSetup();
     }
 
@@ -46,42 +48,20 @@ public class DeferralDeniedLetter extends LetterBase {
         addData(LetterDataType.DATE_OF_LETTER, 18);
         addData(LetterDataType.COURT_NAME, 59);
         addData(LetterDataType.BUREAU_NAME, 40);
-        sharedBureauSetup();
-        addData(LetterDataType.BUREAU_ADDRESS6, 35);
+        addBureauAddress();
+        addData(LetterDataType.BUREAU_PHONE, 12);
+        addData(LetterDataType.BUREAU_FAX, 12);
+        addEnglishCourtAddress();
         sharedSetup();
     }
 
-    private void sharedBureauSetup() {
-        addData(LetterDataType.BUREAU_ADDRESS1, 35);
-        addData(LetterDataType.BUREAU_ADDRESS2, 35);
-        addData(LetterDataType.BUREAU_ADDRESS3, 35);
-        addData(LetterDataType.BUREAU_ADDRESS4, 35);
-        addData(LetterDataType.BUREAU_ADDRESS5, 35);
-    }
+
 
     private void sharedSetup() {
-        addData(LetterDataType.BUREAU_POSTCODE, 10);
-        addData(LetterDataType.BUREAU_PHONE, 12);
-        addData(LetterDataType.BUREAU_FAX, 12);
-        addData(LetterDataType.COURT_ADDRESS1, 35);
-        addData(LetterDataType.COURT_ADDRESS2, 35);
-        addData(LetterDataType.COURT_ADDRESS3, 35);
-        addData(LetterDataType.COURT_ADDRESS4, 35);
-        addData(LetterDataType.COURT_ADDRESS5, 35);
-        addData(LetterDataType.COURT_ADDRESS6, 35);
-        addData(LetterDataType.COURT_POSTCODE, 10);
         addData(LetterDataType.JUROR_TITLE, 10);
         addData(LetterDataType.JUROR_FIRST_NAME, 20);
         addData(LetterDataType.JUROR_LAST_NAME, 20);
-        addData(LetterDataType.JUROR_ADDRESS1, 35);
-        addDataShuffle(
-            new DataShuffle(LetterDataType.JUROR_ADDRESS2, 35),
-            new DataShuffle(LetterDataType.JUROR_ADDRESS3, 35),
-            new DataShuffle(LetterDataType.JUROR_ADDRESS4, 35),
-            new DataShuffle(LetterDataType.JUROR_ADDRESS5, 35),
-            new DataShuffle(LetterDataType.JUROR_ADDRESS6, 35),
-            new DataShuffle(LetterDataType.JUROR_POSTCODE, 10)
-        );
+        addJurorAddress();
         addData(LetterDataType.JUROR_NUMBER, 9);
         addData(LetterDataType.BUREAU_SIGNATORY, 30);
     }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/DeferralDeniedLetter.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/DeferralDeniedLetter.java
@@ -74,12 +74,14 @@ public class DeferralDeniedLetter extends LetterBase {
         addData(LetterDataType.JUROR_FIRST_NAME, 20);
         addData(LetterDataType.JUROR_LAST_NAME, 20);
         addData(LetterDataType.JUROR_ADDRESS1, 35);
-        addData(LetterDataType.JUROR_ADDRESS2, 35);
-        addData(LetterDataType.JUROR_ADDRESS3, 35);
-        addData(LetterDataType.JUROR_ADDRESS4, 35);
-        addData(LetterDataType.JUROR_ADDRESS5, 35);
-        addData(LetterDataType.JUROR_ADDRESS6, 35);
-        addData(LetterDataType.JUROR_POSTCODE, 10);
+        addDataShuffle(
+            new DataShuffle(LetterDataType.JUROR_ADDRESS2, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS3, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS4, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS5, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS6, 35),
+            new DataShuffle(LetterDataType.JUROR_POSTCODE, 10)
+        );
         addData(LetterDataType.JUROR_NUMBER, 9);
         addData(LetterDataType.BUREAU_SIGNATORY, 30);
     }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/DeferralLetter.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/DeferralLetter.java
@@ -7,6 +7,7 @@ import uk.gov.hmcts.juror.api.moj.domain.JurorPool;
 import uk.gov.hmcts.juror.api.moj.xerox.LetterBase;
 
 public class DeferralLetter extends LetterBase {
+
     public DeferralLetter(JurorPool jurorPool,
                           CourtLocation courtLocation,
                           CourtLocation bureauLocation) {
@@ -34,14 +35,8 @@ public class DeferralLetter extends LetterBase {
         setFormCode(FormCode.BI_DEFERRAL);
         addData(LetterDataType.DATE_OF_LETTER, 18);
         addData(LetterDataType.WELSH_COURT_NAME, 40);
-        addData(LetterDataType.COURT_NAME, 40);
-        addData(LetterDataType.BUREAU_NAME, 35);
-        addData(LetterDataType.BUREAU_ADDRESS1, 35);
-        addData(LetterDataType.BUREAU_ADDRESS2, 35);
-        addData(LetterDataType.BUREAU_ADDRESS3, 35);
-        addData(LetterDataType.BUREAU_ADDRESS4, 35);
-        addData(LetterDataType.BUREAU_ADDRESS5, 35);
-        addData(LetterDataType.BUREAU_POSTCODE, 10);
+        addData(LetterDataType.BUREAU_NAME, 40);
+        addBureauAddress();
         addData(LetterDataType.BUREAU_PHONE, 12);
         addData(LetterDataType.BUREAU_FAX, 12);
         addData(LetterDataType.WELSH_DEFERRAL_DATE, 32);
@@ -54,13 +49,7 @@ public class DeferralLetter extends LetterBase {
         addData(LetterDataType.DATE_OF_LETTER, 18);
         addData(LetterDataType.COURT_NAME, 59);
         addData(LetterDataType.BUREAU_NAME, 40);
-        addData(LetterDataType.BUREAU_ADDRESS1, 35);
-        addData(LetterDataType.BUREAU_ADDRESS2, 35);
-        addData(LetterDataType.BUREAU_ADDRESS3, 35);
-        addData(LetterDataType.BUREAU_ADDRESS4, 35);
-        addData(LetterDataType.BUREAU_ADDRESS5, 35);
-        addData(LetterDataType.BUREAU_ADDRESS6, 35);
-        addData(LetterDataType.BUREAU_POSTCODE, 10);
+        addBureauAddress();
         addData(LetterDataType.BUREAU_PHONE, 12);
         addData(LetterDataType.BUREAU_FAX, 12);
         addData(LetterDataType.DEFERRAL_DATE, 32);
@@ -72,15 +61,7 @@ public class DeferralLetter extends LetterBase {
         addData(LetterDataType.JUROR_TITLE, 10);
         addData(LetterDataType.JUROR_FIRST_NAME, 20);
         addData(LetterDataType.JUROR_LAST_NAME, 20);
-        addData(LetterDataType.JUROR_ADDRESS1, 35);
-        addDataShuffle(
-            new DataShuffle(LetterDataType.JUROR_ADDRESS2, 35),
-            new DataShuffle(LetterDataType.JUROR_ADDRESS3, 35),
-            new DataShuffle(LetterDataType.JUROR_ADDRESS4, 35),
-            new DataShuffle(LetterDataType.JUROR_ADDRESS5, 35),
-            new DataShuffle(LetterDataType.JUROR_ADDRESS6, 35),
-            new DataShuffle(LetterDataType.JUROR_POSTCODE, 10)
-        );
+        addJurorAddress();
         addData(LetterDataType.JUROR_NUMBER, 9);
         addData(LetterDataType.BUREAU_SIGNATORY, 30);
 

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/DeferralLetter.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/DeferralLetter.java
@@ -73,12 +73,14 @@ public class DeferralLetter extends LetterBase {
         addData(LetterDataType.JUROR_FIRST_NAME, 20);
         addData(LetterDataType.JUROR_LAST_NAME, 20);
         addData(LetterDataType.JUROR_ADDRESS1, 35);
-        addData(LetterDataType.JUROR_ADDRESS2, 35);
-        addData(LetterDataType.JUROR_ADDRESS3, 35);
-        addData(LetterDataType.JUROR_ADDRESS4, 35);
-        addData(LetterDataType.JUROR_ADDRESS5, 35);
-        addData(LetterDataType.JUROR_ADDRESS6, 35);
-        addData(LetterDataType.JUROR_POSTCODE, 10);
+        addDataShuffle(
+            new DataShuffle(LetterDataType.JUROR_ADDRESS2, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS3, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS4, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS5, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS6, 35),
+            new DataShuffle(LetterDataType.JUROR_POSTCODE, 10)
+        );
         addData(LetterDataType.JUROR_NUMBER, 9);
         addData(LetterDataType.BUREAU_SIGNATORY, 30);
 

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/ExcusalDeniedLetter.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/ExcusalDeniedLetter.java
@@ -35,9 +35,11 @@ public class ExcusalDeniedLetter extends LetterBase {
         setFormCode(FormCode.BI_EXCUSALDENIED);
         addData(LetterDataType.DATE_OF_LETTER, 18);
         addData(LetterDataType.WELSH_COURT_NAME, 40);
-        addData(LetterDataType.COURT_NAME, 40);
-        addData(LetterDataType.BUREAU_NAME, 35);
-        sharedBureauSetup();
+        addData(LetterDataType.BUREAU_NAME, 40);
+        addBureauAddress();
+        addData(LetterDataType.BUREAU_PHONE, 12);
+        addData(LetterDataType.BUREAU_FAX, 12);
+        addWelshCourtAddress();
         sharedSetup();
     }
 
@@ -47,42 +49,18 @@ public class ExcusalDeniedLetter extends LetterBase {
         addData(LetterDataType.DATE_OF_LETTER, 18);
         addData(LetterDataType.COURT_NAME, 59);
         addData(LetterDataType.BUREAU_NAME, 40);
-        sharedBureauSetup();
-        addData(LetterDataType.BUREAU_ADDRESS6, 35);
+        addBureauAddress();
+        addData(LetterDataType.BUREAU_PHONE, 12);
+        addData(LetterDataType.BUREAU_FAX, 12);
+        addEnglishCourtAddress();
         sharedSetup();
     }
 
-    private void sharedBureauSetup() {
-        addData(LetterDataType.BUREAU_ADDRESS1, 35);
-        addData(LetterDataType.BUREAU_ADDRESS2, 35);
-        addData(LetterDataType.BUREAU_ADDRESS3, 35);
-        addData(LetterDataType.BUREAU_ADDRESS4, 35);
-        addData(LetterDataType.BUREAU_ADDRESS5, 35);
-    }
-
     private void sharedSetup() {
-        addData(LetterDataType.BUREAU_POSTCODE, 10);
-        addData(LetterDataType.BUREAU_PHONE, 12);
-        addData(LetterDataType.BUREAU_FAX, 12);
-        addData(LetterDataType.COURT_ADDRESS1, 35);
-        addData(LetterDataType.COURT_ADDRESS2, 35);
-        addData(LetterDataType.COURT_ADDRESS3, 35);
-        addData(LetterDataType.COURT_ADDRESS4, 35);
-        addData(LetterDataType.COURT_ADDRESS5, 35);
-        addData(LetterDataType.COURT_ADDRESS6, 35);
-        addData(LetterDataType.COURT_POSTCODE, 10);
         addData(LetterDataType.JUROR_TITLE, 10);
         addData(LetterDataType.JUROR_FIRST_NAME, 20);
         addData(LetterDataType.JUROR_LAST_NAME, 20);
-        addData(LetterDataType.JUROR_ADDRESS1, 35);
-        addDataShuffle(
-            new DataShuffle(LetterDataType.JUROR_ADDRESS2, 35),
-            new DataShuffle(LetterDataType.JUROR_ADDRESS3, 35),
-            new DataShuffle(LetterDataType.JUROR_ADDRESS4, 35),
-            new DataShuffle(LetterDataType.JUROR_ADDRESS5, 35),
-            new DataShuffle(LetterDataType.JUROR_ADDRESS6, 35),
-            new DataShuffle(LetterDataType.JUROR_POSTCODE, 10)
-        );
+        addJurorAddress();
         addData(LetterDataType.JUROR_NUMBER, 9);
         addData(LetterDataType.COURT_SIGNATORY, 30);
     }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/ExcusalDeniedLetter.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/ExcusalDeniedLetter.java
@@ -75,12 +75,14 @@ public class ExcusalDeniedLetter extends LetterBase {
         addData(LetterDataType.JUROR_FIRST_NAME, 20);
         addData(LetterDataType.JUROR_LAST_NAME, 20);
         addData(LetterDataType.JUROR_ADDRESS1, 35);
-        addData(LetterDataType.JUROR_ADDRESS2, 35);
-        addData(LetterDataType.JUROR_ADDRESS3, 35);
-        addData(LetterDataType.JUROR_ADDRESS4, 35);
-        addData(LetterDataType.JUROR_ADDRESS5, 35);
-        addData(LetterDataType.JUROR_ADDRESS6, 35);
-        addData(LetterDataType.JUROR_POSTCODE, 10);
+        addDataShuffle(
+            new DataShuffle(LetterDataType.JUROR_ADDRESS2, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS3, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS4, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS5, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS6, 35),
+            new DataShuffle(LetterDataType.JUROR_POSTCODE, 10)
+        );
         addData(LetterDataType.JUROR_NUMBER, 9);
         addData(LetterDataType.COURT_SIGNATORY, 30);
     }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/ExcusalLetter.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/ExcusalLetter.java
@@ -73,12 +73,14 @@ public class ExcusalLetter extends LetterBase {
         addData(LetterDataType.JUROR_FIRST_NAME, 20);
         addData(LetterDataType.JUROR_LAST_NAME, 20);
         addData(LetterDataType.JUROR_ADDRESS1, 35);
-        addData(LetterDataType.JUROR_ADDRESS2, 35);
-        addData(LetterDataType.JUROR_ADDRESS3, 35);
-        addData(LetterDataType.JUROR_ADDRESS4, 35);
-        addData(LetterDataType.JUROR_ADDRESS5, 35);
-        addData(LetterDataType.JUROR_ADDRESS6, 35);
-        addData(LetterDataType.JUROR_POSTCODE, 10);
+        addDataShuffle(
+            new DataShuffle(LetterDataType.JUROR_ADDRESS2, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS3, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS4, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS5, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS6, 35),
+            new DataShuffle(LetterDataType.JUROR_POSTCODE, 10)
+        );
         addData(LetterDataType.JUROR_NUMBER, 9);
     }
 }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/ExcusalLetter.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/ExcusalLetter.java
@@ -35,10 +35,8 @@ public class ExcusalLetter extends LetterBase {
         setFormCode(FormCode.BI_EXCUSAL);
         addData(LetterDataType.DATE_OF_LETTER, 18);
         addData(LetterDataType.WELSH_COURT_NAME, 40);
-        addData(LetterDataType.COURT_NAME, 40);
-        addData(LetterDataType.BUREAU_NAME, 35);
-        sharedBureauSetup();
-        addData(LetterDataType.BUREAU_POSTCODE, 10);
+        addData(LetterDataType.BUREAU_NAME, 40);
+        addBureauAddress();
         addData(LetterDataType.BUREAU_PHONE, 12);
         addData(LetterDataType.BUREAU_FAX, 12);
         sharedSetup();
@@ -51,36 +49,18 @@ public class ExcusalLetter extends LetterBase {
         addData(LetterDataType.DATE_OF_LETTER, 18);
         addData(LetterDataType.COURT_NAME, 59);
         addData(LetterDataType.BUREAU_NAME, 40);
-        sharedBureauSetup();
-        addData(LetterDataType.BUREAU_ADDRESS6, 35);
-        addData(LetterDataType.BUREAU_POSTCODE, 10);
+        addBureauAddress();
         addData(LetterDataType.BUREAU_PHONE, 12);
         addData(LetterDataType.BUREAU_FAX, 12);
         sharedSetup();
         addData(LetterDataType.BUREAU_SIGNATORY, 30);
     }
 
-    private void sharedBureauSetup() {
-        addData(LetterDataType.BUREAU_ADDRESS1, 35);
-        addData(LetterDataType.BUREAU_ADDRESS2, 35);
-        addData(LetterDataType.BUREAU_ADDRESS3, 35);
-        addData(LetterDataType.BUREAU_ADDRESS4, 35);
-        addData(LetterDataType.BUREAU_ADDRESS5, 35);
-    }
-
     private void sharedSetup() {
         addData(LetterDataType.JUROR_TITLE, 10);
         addData(LetterDataType.JUROR_FIRST_NAME, 20);
         addData(LetterDataType.JUROR_LAST_NAME, 20);
-        addData(LetterDataType.JUROR_ADDRESS1, 35);
-        addDataShuffle(
-            new DataShuffle(LetterDataType.JUROR_ADDRESS2, 35),
-            new DataShuffle(LetterDataType.JUROR_ADDRESS3, 35),
-            new DataShuffle(LetterDataType.JUROR_ADDRESS4, 35),
-            new DataShuffle(LetterDataType.JUROR_ADDRESS5, 35),
-            new DataShuffle(LetterDataType.JUROR_ADDRESS6, 35),
-            new DataShuffle(LetterDataType.JUROR_POSTCODE, 10)
-        );
+        addJurorAddress();
         addData(LetterDataType.JUROR_NUMBER, 9);
     }
 }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/PostponeLetter.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/PostponeLetter.java
@@ -72,12 +72,14 @@ public class PostponeLetter extends LetterBase {
         addData(LetterDataType.JUROR_FIRST_NAME, 20);
         addData(LetterDataType.JUROR_LAST_NAME, 20);
         addData(LetterDataType.JUROR_ADDRESS1, 35);
-        addData(LetterDataType.JUROR_ADDRESS2, 35);
-        addData(LetterDataType.JUROR_ADDRESS3, 35);
-        addData(LetterDataType.JUROR_ADDRESS4, 35);
-        addData(LetterDataType.JUROR_ADDRESS5, 35);
-        addData(LetterDataType.JUROR_ADDRESS6, 35);
-        addData(LetterDataType.JUROR_POSTCODE, 10);
+        addDataShuffle(
+            new DataShuffle(LetterDataType.JUROR_ADDRESS2, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS3, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS4, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS5, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS6, 35),
+            new DataShuffle(LetterDataType.JUROR_POSTCODE, 10)
+        );
         addData(LetterDataType.JUROR_NUMBER, 9);
         addData(LetterDataType.BUREAU_SIGNATORY, 30);
     }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/PostponeLetter.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/PostponeLetter.java
@@ -35,13 +35,8 @@ public class PostponeLetter extends LetterBase {
         setFormCode(FormCode.BI_POSTPONE);
         addData(LetterDataType.DATE_OF_LETTER, 18);
         addData(LetterDataType.WELSH_COURT_NAME, 40);
-        addData(LetterDataType.COURT_NAME, 40);
-        addData(LetterDataType.BUREAU_NAME, 35);
-        addData(LetterDataType.BUREAU_ADDRESS1, 35);
-        addData(LetterDataType.BUREAU_ADDRESS2, 35);
-        addData(LetterDataType.BUREAU_ADDRESS3, 35);
-        addData(LetterDataType.BUREAU_ADDRESS4, 35);
-        addData(LetterDataType.BUREAU_ADDRESS5, 35);
+        addData(LetterDataType.BUREAU_NAME, 40);
+        addBureauAddress();
         sharedSetup();
         addData(LetterDataType.WELSH_DEFERRAL_DATE, 32);
         addData(LetterDataType.DEFERRAL_TIME, 8);
@@ -53,33 +48,19 @@ public class PostponeLetter extends LetterBase {
         addData(LetterDataType.DATE_OF_LETTER, 18);
         addData(LetterDataType.COURT_NAME, 59);
         addData(LetterDataType.BUREAU_NAME, 40);
-        addData(LetterDataType.BUREAU_ADDRESS1, 35);
-        addData(LetterDataType.BUREAU_ADDRESS2, 35);
-        addData(LetterDataType.BUREAU_ADDRESS3, 35);
-        addData(LetterDataType.BUREAU_ADDRESS4, 35);
-        addData(LetterDataType.BUREAU_ADDRESS5, 35);
-        addData(LetterDataType.BUREAU_ADDRESS6, 35);
+        addBureauAddress();
         sharedSetup();
         addData(LetterDataType.DEFERRAL_DATE, 32);
         addData(LetterDataType.DEFERRAL_TIME, 8);
     }
 
     private void sharedSetup() {
-        addData(LetterDataType.BUREAU_POSTCODE, 10);
         addData(LetterDataType.BUREAU_PHONE, 12);
         addData(LetterDataType.BUREAU_FAX, 12);
         addData(LetterDataType.JUROR_TITLE, 10);
         addData(LetterDataType.JUROR_FIRST_NAME, 20);
         addData(LetterDataType.JUROR_LAST_NAME, 20);
-        addData(LetterDataType.JUROR_ADDRESS1, 35);
-        addDataShuffle(
-            new DataShuffle(LetterDataType.JUROR_ADDRESS2, 35),
-            new DataShuffle(LetterDataType.JUROR_ADDRESS3, 35),
-            new DataShuffle(LetterDataType.JUROR_ADDRESS4, 35),
-            new DataShuffle(LetterDataType.JUROR_ADDRESS5, 35),
-            new DataShuffle(LetterDataType.JUROR_ADDRESS6, 35),
-            new DataShuffle(LetterDataType.JUROR_POSTCODE, 10)
-        );
+        addJurorAddress();
         addData(LetterDataType.JUROR_NUMBER, 9);
         addData(LetterDataType.BUREAU_SIGNATORY, 30);
     }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/RequestInfoLetter.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/RequestInfoLetter.java
@@ -39,9 +39,8 @@ public class RequestInfoLetter extends LetterBase {
         setFormCode(FormCode.BI_REQUESTINFO);
         addData(LetterDataType.DATE_OF_LETTER, 18);
         addData(LetterDataType.WELSH_COURT_NAME, 40);
-        addData(LetterDataType.COURT_NAME, 40);
-        addData(LetterDataType.BUREAU_NAME, 35);
-        sharedBureauSetup();
+        addData(LetterDataType.BUREAU_NAME, 40);
+        addBureauAddress();
         sharedSetup();
     }
 
@@ -51,36 +50,19 @@ public class RequestInfoLetter extends LetterBase {
         addData(LetterDataType.DATE_OF_LETTER, 18);
         addData(LetterDataType.COURT_NAME, 59);
         addData(LetterDataType.BUREAU_NAME, 40);
-        sharedBureauSetup();
-        addData(LetterDataType.BUREAU_ADDRESS6, 35);
+        addBureauAddress();
         sharedSetup();
     }
 
-    private void sharedBureauSetup() {
-        addData(LetterDataType.BUREAU_ADDRESS1, 35);
-        addData(LetterDataType.BUREAU_ADDRESS2, 35);
-        addData(LetterDataType.BUREAU_ADDRESS3, 35);
-        addData(LetterDataType.BUREAU_ADDRESS4, 35);
-        addData(LetterDataType.BUREAU_ADDRESS5, 35);
-    }
 
     private void sharedSetup() {
-        addData(LetterDataType.BUREAU_POSTCODE, 10);
         addData(LetterDataType.BUREAU_PHONE, 12);
         addData(LetterDataType.BUREAU_FAX, 12);
         addData(LetterDataType.ADDITIONAL_INFORMATION, 210);
         addData(LetterDataType.JUROR_TITLE, 10);
         addData(LetterDataType.JUROR_FIRST_NAME, 20);
         addData(LetterDataType.JUROR_LAST_NAME, 20);
-        addData(LetterDataType.JUROR_ADDRESS1, 35);
-        addDataShuffle(
-            new DataShuffle(LetterDataType.JUROR_ADDRESS2, 35),
-            new DataShuffle(LetterDataType.JUROR_ADDRESS3, 35),
-            new DataShuffle(LetterDataType.JUROR_ADDRESS4, 35),
-            new DataShuffle(LetterDataType.JUROR_ADDRESS5, 35),
-            new DataShuffle(LetterDataType.JUROR_ADDRESS6, 35),
-            new DataShuffle(LetterDataType.JUROR_POSTCODE, 10)
-        );
+        addJurorAddress();
         addData(LetterDataType.JUROR_NUMBER, 9);
         addData(LetterDataType.BUREAU_SIGNATORY, 30);
     }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/RequestInfoLetter.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/RequestInfoLetter.java
@@ -73,12 +73,14 @@ public class RequestInfoLetter extends LetterBase {
         addData(LetterDataType.JUROR_FIRST_NAME, 20);
         addData(LetterDataType.JUROR_LAST_NAME, 20);
         addData(LetterDataType.JUROR_ADDRESS1, 35);
-        addData(LetterDataType.JUROR_ADDRESS2, 35);
-        addData(LetterDataType.JUROR_ADDRESS3, 35);
-        addData(LetterDataType.JUROR_ADDRESS4, 35);
-        addData(LetterDataType.JUROR_ADDRESS5, 35);
-        addData(LetterDataType.JUROR_ADDRESS6, 35);
-        addData(LetterDataType.JUROR_POSTCODE, 10);
+        addDataShuffle(
+            new DataShuffle(LetterDataType.JUROR_ADDRESS2, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS3, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS4, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS5, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS6, 35),
+            new DataShuffle(LetterDataType.JUROR_POSTCODE, 10)
+        );
         addData(LetterDataType.JUROR_NUMBER, 9);
         addData(LetterDataType.BUREAU_SIGNATORY, 30);
     }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/SummonsLetter.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/SummonsLetter.java
@@ -84,12 +84,14 @@ public class SummonsLetter extends LetterBase {
         addData(LetterDataType.JUROR_FIRST_NAME, 20);
         addData(LetterDataType.JUROR_LAST_NAME, 20);
         addData(LetterDataType.JUROR_ADDRESS1, 35);
-        addData(LetterDataType.JUROR_ADDRESS2, 35);
-        addData(LetterDataType.JUROR_ADDRESS3, 35);
-        addData(LetterDataType.JUROR_ADDRESS4, 35);
-        addData(LetterDataType.JUROR_ADDRESS5, 35);
-        addData(LetterDataType.JUROR_ADDRESS6, 35);
-        addData(LetterDataType.JUROR_POSTCODE, 10);
+        addDataShuffle(
+            new DataShuffle(LetterDataType.JUROR_ADDRESS2, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS3, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS4, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS5, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS6, 35),
+            new DataShuffle(LetterDataType.JUROR_POSTCODE, 10)
+        );
         addData(LetterDataType.JUROR_NUMBER, 9);
     }
 
@@ -115,5 +117,4 @@ public class SummonsLetter extends LetterBase {
         addData(LetterDataType.BUREAU_PHONE, 12);
         addData(LetterDataType.BUREAU_FAX, 12);
     }
-
 }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/SummonsLetter.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/SummonsLetter.java
@@ -53,12 +53,15 @@ public class SummonsLetter extends LetterBase {
         addData(LetterDataType.COURT_NAME, 40);
         sharedCourtSetup();
         addData(LetterDataType.WELSH_COURT_NAME, 40);
-        addData(LetterDataType.WELSH_COURT_ADDRESS1, 35);
-        addData(LetterDataType.WELSH_COURT_ADDRESS2, 35);
-        addData(LetterDataType.WELSH_COURT_ADDRESS3, 35);
-        addData(LetterDataType.WELSH_COURT_ADDRESS4, 35);
-        addData(LetterDataType.WELSH_COURT_ADDRESS5, 35);
-        addData(LetterDataType.WELSH_COURT_ADDRESS6, 35);
+        addDataShuffle(
+            new DataShuffle(LetterDataType.WELSH_COURT_ADDRESS1, 35),
+            new DataShuffle(LetterDataType.WELSH_COURT_ADDRESS2, 35),
+            new DataShuffle(LetterDataType.WELSH_COURT_ADDRESS3, 35),
+            new DataShuffle(LetterDataType.WELSH_COURT_ADDRESS4, 35),
+            new DataShuffle(LetterDataType.WELSH_COURT_ADDRESS5, 35),
+            new DataShuffle(LetterDataType.COURT_POSTCODE, 35)
+        );
+
         // repeated field
         addData(LetterDataType.JUROR_NUMBER, 9);
     }
@@ -83,37 +86,17 @@ public class SummonsLetter extends LetterBase {
         addData(LetterDataType.JUROR_TITLE, 10);
         addData(LetterDataType.JUROR_FIRST_NAME, 20);
         addData(LetterDataType.JUROR_LAST_NAME, 20);
-        addData(LetterDataType.JUROR_ADDRESS1, 35);
-        addDataShuffle(
-            new DataShuffle(LetterDataType.JUROR_ADDRESS2, 35),
-            new DataShuffle(LetterDataType.JUROR_ADDRESS3, 35),
-            new DataShuffle(LetterDataType.JUROR_ADDRESS4, 35),
-            new DataShuffle(LetterDataType.JUROR_ADDRESS5, 35),
-            new DataShuffle(LetterDataType.JUROR_ADDRESS6, 35),
-            new DataShuffle(LetterDataType.JUROR_POSTCODE, 10)
-        );
+        addJurorAddress();
         addData(LetterDataType.JUROR_NUMBER, 9);
     }
 
     private void sharedCourtSetup() {
-        addData(LetterDataType.COURT_ADDRESS1, 35);
-        addData(LetterDataType.COURT_ADDRESS2, 35);
-        addData(LetterDataType.COURT_ADDRESS3, 35);
-        addData(LetterDataType.COURT_ADDRESS4, 35);
-        addData(LetterDataType.COURT_ADDRESS5, 35);
-        addData(LetterDataType.COURT_ADDRESS6, 35);
-        addData(LetterDataType.COURT_POSTCODE, 10);
+        addEnglishCourtAddress();
         addData(LetterDataType.COURT_PHONE, 12);
         addData(LetterDataType.COURT_FAX, 12);
         addData(LetterDataType.COURT_SIGNATORY, 30);
         addData(LetterDataType.BUREAU_NAME, 40);
-        addData(LetterDataType.BUREAU_ADDRESS1, 35);
-        addData(LetterDataType.BUREAU_ADDRESS2, 35);
-        addData(LetterDataType.BUREAU_ADDRESS3, 35);
-        addData(LetterDataType.BUREAU_ADDRESS4, 35);
-        addData(LetterDataType.BUREAU_ADDRESS5, 35);
-        addData(LetterDataType.BUREAU_ADDRESS6, 35);
-        addData(LetterDataType.BUREAU_POSTCODE, 10);
+        addBureauAddress();
         addData(LetterDataType.BUREAU_PHONE, 12);
         addData(LetterDataType.BUREAU_FAX, 12);
     }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/SummonsReminderLetter.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/SummonsReminderLetter.java
@@ -61,12 +61,14 @@ public class SummonsReminderLetter extends LetterBase {
         addData(LetterDataType.JUROR_FIRST_NAME, 20);
         addData(LetterDataType.JUROR_LAST_NAME, 20);
         addData(LetterDataType.JUROR_ADDRESS1, 35);
-        addData(LetterDataType.JUROR_ADDRESS2, 35);
-        addData(LetterDataType.JUROR_ADDRESS3, 35);
-        addData(LetterDataType.JUROR_ADDRESS4, 35);
-        addData(LetterDataType.JUROR_ADDRESS5, 35);
-        addData(LetterDataType.JUROR_ADDRESS6, 35);
-        addData(LetterDataType.JUROR_POSTCODE, 10);
+        addDataShuffle(
+            new DataShuffle(LetterDataType.JUROR_ADDRESS2, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS3, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS4, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS5, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS6, 35),
+            new DataShuffle(LetterDataType.JUROR_POSTCODE, 10)
+        );
         addData(LetterDataType.JUROR_NUMBER, 9);
         addData(LetterDataType.BUREAU_SIGNATORY, 30);
 

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/SummonsReminderLetter.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/SummonsReminderLetter.java
@@ -48,27 +48,13 @@ public class SummonsReminderLetter extends LetterBase {
 
     private void sharedSetup() {
         addData(LetterDataType.BUREAU_NAME, 40);
-        addData(LetterDataType.BUREAU_ADDRESS1, 35);
-        addData(LetterDataType.BUREAU_ADDRESS2, 35);
-        addData(LetterDataType.BUREAU_ADDRESS3, 35);
-        addData(LetterDataType.BUREAU_ADDRESS4, 35);
-        addData(LetterDataType.BUREAU_ADDRESS5, 35);
-        addData(LetterDataType.BUREAU_ADDRESS6, 35);
-        addData(LetterDataType.BUREAU_POSTCODE, 10);
+        addBureauAddress();
         addData(LetterDataType.BUREAU_PHONE, 12);
         addData(LetterDataType.BUREAU_FAX, 12);
         addData(LetterDataType.JUROR_TITLE, 10);
         addData(LetterDataType.JUROR_FIRST_NAME, 20);
         addData(LetterDataType.JUROR_LAST_NAME, 20);
-        addData(LetterDataType.JUROR_ADDRESS1, 35);
-        addDataShuffle(
-            new DataShuffle(LetterDataType.JUROR_ADDRESS2, 35),
-            new DataShuffle(LetterDataType.JUROR_ADDRESS3, 35),
-            new DataShuffle(LetterDataType.JUROR_ADDRESS4, 35),
-            new DataShuffle(LetterDataType.JUROR_ADDRESS5, 35),
-            new DataShuffle(LetterDataType.JUROR_ADDRESS6, 35),
-            new DataShuffle(LetterDataType.JUROR_POSTCODE, 10)
-        );
+        addJurorAddress();
         addData(LetterDataType.JUROR_NUMBER, 9);
         addData(LetterDataType.BUREAU_SIGNATORY, 30);
 

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/WithdrawalLetter.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/WithdrawalLetter.java
@@ -35,10 +35,8 @@ public class WithdrawalLetter extends LetterBase {
         setFormCode(FormCode.BI_WITHDRAWAL);
         addData(LetterDataType.DATE_OF_LETTER, 18);
         addData(LetterDataType.WELSH_COURT_NAME, 40);
-        addData(LetterDataType.COURT_NAME, 40);
-        addData(LetterDataType.BUREAU_NAME, 35);
-        sharedBureauSetup();
-        addData(LetterDataType.BUREAU_POSTCODE, 10);
+        addData(LetterDataType.BUREAU_NAME, 40);
+        addBureauAddress();
         addData(LetterDataType.BUREAU_PHONE, 12);
         addData(LetterDataType.BUREAU_FAX, 12);
         sharedSetup();
@@ -51,36 +49,19 @@ public class WithdrawalLetter extends LetterBase {
         addData(LetterDataType.DATE_OF_LETTER, 18);
         addData(LetterDataType.COURT_NAME, 59);
         addData(LetterDataType.BUREAU_NAME, 40);
-        sharedBureauSetup();
-        addData(LetterDataType.BUREAU_ADDRESS6, 35);
-        addData(LetterDataType.BUREAU_POSTCODE, 10);
+        addBureauAddress();
         addData(LetterDataType.BUREAU_PHONE, 12);
         addData(LetterDataType.BUREAU_FAX, 12);
         sharedSetup();
         addData(LetterDataType.BUREAU_SIGNATORY, 30);
     }
 
-    private void sharedBureauSetup() {
-        addData(LetterDataType.BUREAU_ADDRESS1, 35);
-        addData(LetterDataType.BUREAU_ADDRESS2, 35);
-        addData(LetterDataType.BUREAU_ADDRESS3, 35);
-        addData(LetterDataType.BUREAU_ADDRESS4, 35);
-        addData(LetterDataType.BUREAU_ADDRESS5, 35);
-    }
 
     private void sharedSetup() {
         addData(LetterDataType.JUROR_TITLE, 10);
         addData(LetterDataType.JUROR_FIRST_NAME, 20);
         addData(LetterDataType.JUROR_LAST_NAME, 20);
-        addData(LetterDataType.JUROR_ADDRESS1, 35);
-        addDataShuffle(
-            new DataShuffle(LetterDataType.JUROR_ADDRESS2, 35),
-            new DataShuffle(LetterDataType.JUROR_ADDRESS3, 35),
-            new DataShuffle(LetterDataType.JUROR_ADDRESS4, 35),
-            new DataShuffle(LetterDataType.JUROR_ADDRESS5, 35),
-            new DataShuffle(LetterDataType.JUROR_ADDRESS6, 35),
-            new DataShuffle(LetterDataType.JUROR_POSTCODE, 10)
-        );
+        addJurorAddress();
         addData(LetterDataType.JUROR_NUMBER, 9);
     }
 }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/WithdrawalLetter.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/WithdrawalLetter.java
@@ -73,12 +73,14 @@ public class WithdrawalLetter extends LetterBase {
         addData(LetterDataType.JUROR_FIRST_NAME, 20);
         addData(LetterDataType.JUROR_LAST_NAME, 20);
         addData(LetterDataType.JUROR_ADDRESS1, 35);
-        addData(LetterDataType.JUROR_ADDRESS2, 35);
-        addData(LetterDataType.JUROR_ADDRESS3, 35);
-        addData(LetterDataType.JUROR_ADDRESS4, 35);
-        addData(LetterDataType.JUROR_ADDRESS5, 35);
-        addData(LetterDataType.JUROR_ADDRESS6, 35);
-        addData(LetterDataType.JUROR_POSTCODE, 10);
+        addDataShuffle(
+            new DataShuffle(LetterDataType.JUROR_ADDRESS2, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS3, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS4, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS5, 35),
+            new DataShuffle(LetterDataType.JUROR_ADDRESS6, 35),
+            new DataShuffle(LetterDataType.JUROR_POSTCODE, 10)
+        );
         addData(LetterDataType.JUROR_NUMBER, 9);
     }
 }

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/ConfirmLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/ConfirmLetterTest.java
@@ -38,8 +38,8 @@ class ConfirmLetterTest extends AbstractLetterTest {
         addEnglishField("JUROR_ADDRESS_3", 35);
         addEnglishField("JUROR_ADDRESS_4", 35);
         addEnglishField("JUROR_ADDRESS_5", 35);
-        addEnglishField("", 35);
-        addEnglishField("SY2 6LU", 10);
+        addEnglishField("SY2 6LU", 35);
+        addEnglishField("", 10);
         addEnglishField("641500541", 9);
         addEnglishField("JURY MANAGER", 30);
     }
@@ -69,8 +69,8 @@ class ConfirmLetterTest extends AbstractLetterTest {
         addWelshField("JUROR_ADDRESS_3", 35);
         addWelshField("JUROR_ADDRESS_4", 35);
         addWelshField("JUROR_ADDRESS_5", 35);
-        addWelshField("", 35);
-        addWelshField("SY2 6LU", 10);
+        addWelshField("SY2 6LU", 35);
+        addWelshField("", 10);
         addWelshField("641500541", 9);
     }
 
@@ -90,8 +90,6 @@ class ConfirmLetterTest extends AbstractLetterTest {
 
         // Fax number is always empty
         assertThat(confirmLetter.getData().get(12).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
-        // Juror address 6 is always empty
-        assertThat(confirmLetter.getData().get(23).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(35));
 
     }
 
@@ -111,8 +109,6 @@ class ConfirmLetterTest extends AbstractLetterTest {
 
         // Fax number is always empty
         assertThat(confirmLetter.getData().get(12).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
-        // Juror address 6 is always empty
-        assertThat(confirmLetter.getData().get(23).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(35));
 
     }
 

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/ConfirmLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/ConfirmLetterTest.java
@@ -49,13 +49,13 @@ class ConfirmLetterTest extends AbstractLetterTest {
         addWelshLetterDate();
         addWelshField("457", 3);
         addWelshField("ABERTAWE", 40);
-        addWelshField("SWANSEA CROWN COURT", 40);
-        addWelshField("JURY CENTRAL SUMMONING BUREAU", 35);
+        addWelshField("JURY CENTRAL SUMMONING BUREAU", 40);
         addWelshField("THE COURT SERVICE", 35);
         addWelshField("FREEPOST LON 19669", 35);
         addWelshField("POCOCK STREET", 35);
         addWelshField("LONDON", 35);
         addWelshField("BUREAU_ADDRESS_5", 35);
+        addWelshField("BUREAU_ADDRESS_6", 35);
         addWelshField("SE1 0YG", 10);
         addWelshField("0845 3555567", 12);
         addWelshField("", 12);
@@ -72,6 +72,7 @@ class ConfirmLetterTest extends AbstractLetterTest {
         addWelshField("SY2 6LU", 35);
         addWelshField("", 10);
         addWelshField("641500541", 9);
+        addWelshField("JURY MANAGER", 30);
     }
 
 
@@ -89,7 +90,7 @@ class ConfirmLetterTest extends AbstractLetterTest {
         assertThat(confirmLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testJuror().getJurorNumber());
 
         // Fax number is always empty
-        assertThat(confirmLetter.getData().get(12).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
+        assertThat(confirmLetter.getData().get(6).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
 
     }
 
@@ -108,7 +109,7 @@ class ConfirmLetterTest extends AbstractLetterTest {
         assertThat(confirmLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testWelshJuror().getJurorNumber());
 
         // Fax number is always empty
-        assertThat(confirmLetter.getData().get(12).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
+        assertThat(confirmLetter.getData().get(6).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
 
     }
 

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/DeferralDeniedLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/DeferralDeniedLetterTest.java
@@ -42,8 +42,8 @@ class DeferralDeniedLetterTest extends AbstractLetterTest {
         addEnglishField("JUROR_ADDRESS_3", 35);
         addEnglishField("JUROR_ADDRESS_4", 35);
         addEnglishField("JUROR_ADDRESS_5", 35);
-        addEnglishField("", 35);
-        addEnglishField("SY2 6LU", 10);
+        addEnglishField("SY2 6LU", 35);
+        addEnglishField("", 10);
         addEnglishField("641500541", 9);
         addEnglishField("JURY MANAGER", 30);
     }
@@ -77,8 +77,8 @@ class DeferralDeniedLetterTest extends AbstractLetterTest {
         addWelshField("JUROR_ADDRESS_3", 35);
         addWelshField("JUROR_ADDRESS_4", 35);
         addWelshField("JUROR_ADDRESS_5", 35);
-        addWelshField("", 35);
-        addWelshField("SY2 6LU", 10);
+        addWelshField("SY2 6LU", 35);
+        addWelshField("", 10);
         addWelshField("641500541", 9);
         addWelshField("JURY MANAGER", 30);
     }
@@ -100,10 +100,6 @@ class DeferralDeniedLetterTest extends AbstractLetterTest {
         // Fax number is always empty
         assertThat(deferralDeniedLetter.getData().get(11).getFormattedString())
             .isEqualTo(LetterTestUtils.emptyField(12));
-        // Juror address 6 is always empty
-        assertThat(deferralDeniedLetter.getData().get(27).getFormattedString())
-            .isEqualTo(LetterTestUtils.emptyField(35));
-
     }
 
     @Test
@@ -124,10 +120,6 @@ class DeferralDeniedLetterTest extends AbstractLetterTest {
         // Fax number is always empty
         assertThat(deferralDeniedLetter.getData().get(11).getFormattedString())
             .isEqualTo(LetterTestUtils.emptyField(12));
-        // Juror address 6 is always empty
-        assertThat(deferralDeniedLetter.getData().get(27).getFormattedString())
-            .isEqualTo(LetterTestUtils.emptyField(35));
-
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/DeferralDeniedLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/DeferralDeniedLetterTest.java
@@ -52,22 +52,22 @@ class DeferralDeniedLetterTest extends AbstractLetterTest {
     protected void setupWelshExpectedResult() {
         addWelshLetterDate();
         addWelshField("ABERTAWE", 40);
-        addWelshField("SWANSEA CROWN COURT", 40);
-        addWelshField("JURY CENTRAL SUMMONING BUREAU", 35);
+        addWelshField("JURY CENTRAL SUMMONING BUREAU", 40);
         addWelshField("THE COURT SERVICE", 35);
         addWelshField("FREEPOST LON 19669", 35);
         addWelshField("POCOCK STREET", 35);
         addWelshField("LONDON", 35);
         addWelshField("BUREAU_ADDRESS_5", 35);
+        addWelshField("BUREAU_ADDRESS_6", 35);
         addWelshField("SE1 0YG", 10);
         addWelshField("0845 3555567", 12);
         addWelshField("", 12);
-        addWelshField("THE LAW COURTS", 35);
-        addWelshField("ST HELENS ROAD", 35);
-        addWelshField("SWANSEA", 35);
-        addWelshField("SHREWSBURY", 35);
-        addWelshField("COURT_ADDRESS_5", 35);
-        addWelshField("COURT_ADDRESS_6", 35);
+        addWelshField("Y LLYSOEDD BARN", 35);
+        addWelshField("LON SAN HELEN", 35);
+        addWelshField("ABERTAWE", 35);
+        addWelshField("WELSH_COURT_ADDRESS_4", 35);
+        addWelshField("WELSH_COURT_ADDRESS_5", 35);
+        addWelshField("WELSH_COURT_ADDRESS_6", 35);
         addWelshField("SY2 6LU", 10);
         addWelshField("MR", 10);
         addWelshField("FNAMEEIGHTTHREEONE", 20);
@@ -98,7 +98,7 @@ class DeferralDeniedLetterTest extends AbstractLetterTest {
         assertThat(deferralDeniedLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testJuror().getJurorNumber());
 
         // Fax number is always empty
-        assertThat(deferralDeniedLetter.getData().get(11).getFormattedString())
+        assertThat(deferralDeniedLetter.getData().get(5).getFormattedString())
             .isEqualTo(LetterTestUtils.emptyField(12));
     }
 
@@ -118,7 +118,7 @@ class DeferralDeniedLetterTest extends AbstractLetterTest {
             .isEqualTo(LetterTestUtils.testWelshJuror().getJurorNumber());
 
         // Fax number is always empty
-        assertThat(deferralDeniedLetter.getData().get(11).getFormattedString())
+        assertThat(deferralDeniedLetter.getData().get(5).getFormattedString())
             .isEqualTo(LetterTestUtils.emptyField(12));
     }
 

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/DeferralLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/DeferralLetterTest.java
@@ -47,13 +47,13 @@ class DeferralLetterTest extends AbstractLetterTest {
     protected void setupWelshExpectedResult() {
         addWelshLetterDate();
         addWelshField("ABERTAWE", 40);
-        addWelshField("SWANSEA CROWN COURT", 40);
-        addWelshField("JURY CENTRAL SUMMONING BUREAU", 35);
+        addWelshField("JURY CENTRAL SUMMONING BUREAU", 40);
         addWelshField("THE COURT SERVICE", 35);
         addWelshField("FREEPOST LON 19669", 35);
         addWelshField("POCOCK STREET", 35);
         addWelshField("LONDON", 35);
         addWelshField("BUREAU_ADDRESS_5", 35);
+        addWelshField("BUREAU_ADDRESS_6", 35);
         addWelshField("SE1 0YG", 10);
         addWelshField("0845 3555567", 12);
         addWelshField("", 12);
@@ -89,7 +89,7 @@ class DeferralLetterTest extends AbstractLetterTest {
         assertThat(deferralLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testJuror().getJurorNumber());
 
         // Fax number is always empty
-        assertThat(deferralLetter.getData().get(11).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
+        assertThat(deferralLetter.getData().get(5).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
     }
 
     @Test
@@ -107,7 +107,7 @@ class DeferralLetterTest extends AbstractLetterTest {
         assertThat(deferralLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testWelshJuror().getJurorNumber());
 
         // Fax number is always empty
-        assertThat(deferralLetter.getData().get(11).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
+        assertThat(deferralLetter.getData().get(5).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/DeferralLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/DeferralLetterTest.java
@@ -37,8 +37,8 @@ class DeferralLetterTest extends AbstractLetterTest {
         addEnglishField("JUROR_ADDRESS_3", 35);
         addEnglishField("JUROR_ADDRESS_4", 35);
         addEnglishField("JUROR_ADDRESS_5", 35);
-        addEnglishField("", 35);
-        addEnglishField("SY2 6LU", 10);
+        addEnglishField("SY2 6LU", 35);
+        addEnglishField("", 10);
         addEnglishField("641500541", 9);
         addEnglishField("JURY MANAGER", 30);
     }
@@ -67,8 +67,8 @@ class DeferralLetterTest extends AbstractLetterTest {
         addWelshField("JUROR_ADDRESS_3", 35);
         addWelshField("JUROR_ADDRESS_4", 35);
         addWelshField("JUROR_ADDRESS_5", 35);
-        addWelshField("", 35);
-        addWelshField("SY2 6LU", 10);
+        addWelshField("SY2 6LU", 35);
+        addWelshField("", 10);
         addWelshField("641500541", 9);
         addWelshField("JURY MANAGER", 30);
 
@@ -90,8 +90,6 @@ class DeferralLetterTest extends AbstractLetterTest {
 
         // Fax number is always empty
         assertThat(deferralLetter.getData().get(11).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
-        // Juror address 6 is always empty
-        assertThat(deferralLetter.getData().get(22).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(35));
     }
 
     @Test
@@ -110,8 +108,6 @@ class DeferralLetterTest extends AbstractLetterTest {
 
         // Fax number is always empty
         assertThat(deferralLetter.getData().get(11).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
-        // Juror address 6 is always empty
-        assertThat(deferralLetter.getData().get(22).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(35));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/ExcusalDeniedLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/ExcusalDeniedLetterTest.java
@@ -52,22 +52,22 @@ class ExcusalDeniedLetterTest extends AbstractLetterTest {
     protected void setupWelshExpectedResult() {
         addWelshLetterDate();
         addWelshField("ABERTAWE", 40);
-        addWelshField("SWANSEA CROWN COURT", 40);
-        addWelshField("JURY CENTRAL SUMMONING BUREAU", 35);
+        addWelshField("JURY CENTRAL SUMMONING BUREAU", 40);
         addWelshField("THE COURT SERVICE", 35);
         addWelshField("FREEPOST LON 19669", 35);
         addWelshField("POCOCK STREET", 35);
         addWelshField("LONDON", 35);
         addWelshField("BUREAU_ADDRESS_5", 35);
+        addWelshField("BUREAU_ADDRESS_6", 35);
         addWelshField("SE1 0YG", 10);
         addWelshField("0845 3555567", 12);
         addWelshField("", 12);
-        addWelshField("THE LAW COURTS", 35);
-        addWelshField("ST HELENS ROAD", 35);
-        addWelshField("SWANSEA", 35);
-        addWelshField("SHREWSBURY", 35);
-        addWelshField("COURT_ADDRESS_5", 35);
-        addWelshField("COURT_ADDRESS_6", 35);
+        addWelshField("Y LLYSOEDD BARN", 35);
+        addWelshField("LON SAN HELEN", 35);
+        addWelshField("ABERTAWE", 35);
+        addWelshField("WELSH_COURT_ADDRESS_4", 35);
+        addWelshField("WELSH_COURT_ADDRESS_5", 35);
+        addWelshField("WELSH_COURT_ADDRESS_6", 35);
         addWelshField("SY2 6LU", 10);
         addWelshField("MR", 10);
         addWelshField("FNAMEEIGHTTHREEONE", 20);
@@ -98,7 +98,7 @@ class ExcusalDeniedLetterTest extends AbstractLetterTest {
         assertThat(excusalDeniedLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testJuror().getJurorNumber());
 
         // Fax number is always empty
-        assertThat(excusalDeniedLetter.getData().get(11).getFormattedString())
+        assertThat(excusalDeniedLetter.getData().get(5).getFormattedString())
             .isEqualTo(LetterTestUtils.emptyField(12));
     }
 
@@ -118,7 +118,7 @@ class ExcusalDeniedLetterTest extends AbstractLetterTest {
             .isEqualTo(LetterTestUtils.testWelshJuror().getJurorNumber());
 
         // Fax number is always empty
-        assertThat(excusalDeniedLetter.getData().get(11).getFormattedString())
+        assertThat(excusalDeniedLetter.getData().get(5).getFormattedString())
             .isEqualTo(LetterTestUtils.emptyField(12));
     }
 

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/ExcusalDeniedLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/ExcusalDeniedLetterTest.java
@@ -42,8 +42,8 @@ class ExcusalDeniedLetterTest extends AbstractLetterTest {
         addEnglishField("JUROR_ADDRESS_3", 35);
         addEnglishField("JUROR_ADDRESS_4", 35);
         addEnglishField("JUROR_ADDRESS_5", 35);
-        addEnglishField("", 35);
-        addEnglishField("SY2 6LU", 10);
+        addEnglishField("SY2 6LU", 35);
+        addEnglishField("", 10);
         addEnglishField("641500541", 9);
         addEnglishField("JURY MANAGER", 30);
     }
@@ -77,8 +77,8 @@ class ExcusalDeniedLetterTest extends AbstractLetterTest {
         addWelshField("JUROR_ADDRESS_3", 35);
         addWelshField("JUROR_ADDRESS_4", 35);
         addWelshField("JUROR_ADDRESS_5", 35);
-        addWelshField("", 35);
-        addWelshField("SY2 6LU", 10);
+        addWelshField("SY2 6LU", 35);
+        addWelshField("", 10);
         addWelshField("641500541", 9);
         addWelshField("JURY MANAGER", 30);
     }
@@ -100,10 +100,6 @@ class ExcusalDeniedLetterTest extends AbstractLetterTest {
         // Fax number is always empty
         assertThat(excusalDeniedLetter.getData().get(11).getFormattedString())
             .isEqualTo(LetterTestUtils.emptyField(12));
-        // Juror address 6 is always empty
-        assertThat(excusalDeniedLetter.getData().get(27).getFormattedString())
-            .isEqualTo(LetterTestUtils.emptyField(35));
-
     }
 
     @Test
@@ -124,9 +120,6 @@ class ExcusalDeniedLetterTest extends AbstractLetterTest {
         // Fax number is always empty
         assertThat(excusalDeniedLetter.getData().get(11).getFormattedString())
             .isEqualTo(LetterTestUtils.emptyField(12));
-        // Juror address 6 is always empty
-        assertThat(excusalDeniedLetter.getData().get(27).getFormattedString())
-            .isEqualTo(LetterTestUtils.emptyField(35));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/ExcusalLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/ExcusalLetterTest.java
@@ -35,8 +35,8 @@ public class ExcusalLetterTest extends AbstractLetterTest {
         addEnglishField("JUROR_ADDRESS_3", 35);
         addEnglishField("JUROR_ADDRESS_4", 35);
         addEnglishField("JUROR_ADDRESS_5", 35);
-        addEnglishField("", 35);
-        addEnglishField("SY2 6LU", 10);
+        addEnglishField("SY2 6LU", 35);
+        addEnglishField("", 10);
         addEnglishField("641500541", 9);
         addEnglishField("JURY MANAGER", 30);
     }
@@ -63,8 +63,8 @@ public class ExcusalLetterTest extends AbstractLetterTest {
         addWelshField("JUROR_ADDRESS_3", 35);
         addWelshField("JUROR_ADDRESS_4", 35);
         addWelshField("JUROR_ADDRESS_5", 35);
-        addWelshField("", 35);
-        addWelshField("SY2 6LU", 10);
+        addWelshField("SY2 6LU", 35);
+        addWelshField("", 10);
         addWelshField("641500541", 9);
         addWelshField("JURY MANAGER", 30);
 
@@ -87,9 +87,6 @@ public class ExcusalLetterTest extends AbstractLetterTest {
         // Fax number is always empty
         assertThat(excusalLetter.getData().get(11).getFormattedString())
             .isEqualTo(LetterTestUtils.emptyField(12));
-        // Juror address 6 is always empty
-        assertThat(excusalLetter.getData().get(20).getFormattedString())
-            .isEqualTo(LetterTestUtils.emptyField(35));
 
     }
 
@@ -112,9 +109,6 @@ public class ExcusalLetterTest extends AbstractLetterTest {
         // Fax number is always empty
         assertThat(excusalLetter.getData().get(11).getFormattedString())
             .isEqualTo(LetterTestUtils.emptyField(12));
-        // Juror address 6 is always empty
-        assertThat(excusalLetter.getData().get(20).getFormattedString())
-            .isEqualTo(LetterTestUtils.emptyField(35));
 
     }
 

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/ExcusalLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/ExcusalLetterTest.java
@@ -45,13 +45,13 @@ public class ExcusalLetterTest extends AbstractLetterTest {
     protected void setupWelshExpectedResult() {
         addWelshLetterDate();
         addWelshField("ABERTAWE", 40);
-        addWelshField("SWANSEA CROWN COURT", 40);
-        addWelshField("JURY CENTRAL SUMMONING BUREAU", 35);
+        addWelshField("JURY CENTRAL SUMMONING BUREAU", 40);
         addWelshField("THE COURT SERVICE", 35);
         addWelshField("FREEPOST LON 19669", 35);
         addWelshField("POCOCK STREET", 35);
         addWelshField("LONDON", 35);
         addWelshField("BUREAU_ADDRESS_5", 35);
+        addWelshField("BUREAU_ADDRESS_6", 35);
         addWelshField("SE1 0YG", 10);
         addWelshField("0845 3555567", 12);
         addWelshField("", 12);
@@ -85,7 +85,7 @@ public class ExcusalLetterTest extends AbstractLetterTest {
         assertThat(excusalLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testJuror().getJurorNumber());
 
         // Fax number is always empty
-        assertThat(excusalLetter.getData().get(11).getFormattedString())
+        assertThat(excusalLetter.getData().get(5).getFormattedString())
             .isEqualTo(LetterTestUtils.emptyField(12));
 
     }
@@ -107,7 +107,7 @@ public class ExcusalLetterTest extends AbstractLetterTest {
             .isEqualTo(LetterTestUtils.testWelshJuror().getJurorNumber());
 
         // Fax number is always empty
-        assertThat(excusalLetter.getData().get(11).getFormattedString())
+        assertThat(excusalLetter.getData().get(5).getFormattedString())
             .isEqualTo(LetterTestUtils.emptyField(12));
 
     }

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/LetterBaseTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/LetterBaseTest.java
@@ -120,9 +120,20 @@ class LetterBaseTest {
         LetterBase testLetter = new LetterBase(testContextBuilder()
             .courtLocation(LetterTestUtils.testCourtLocation())
             .build());
-        testLetter.addData(LetterBase.LetterDataType.COURT_NAME, 15);
+        testLetter.addData(LetterBase.LetterDataType.COURT_NAME, 19);
         assertThat(testLetter.getLetterString()).isEqualTo(LetterTestUtils.pad(
-            "SWANSEA CROWN COURT", 15
+            "SWANSEA CROWN COURT", 19
+        ));
+    }
+
+    @Test
+    void fieldLengthIsLimitedIsCorrect() {
+        LetterBase testLetter = new LetterBase(testContextBuilder()
+            .courtLocation(LetterTestUtils.testCourtLocation())
+            .build());
+        testLetter.addData(LetterBase.LetterDataType.COURT_NAME, 10);
+        assertThat(testLetter.getLetterString()).isEqualTo(LetterTestUtils.pad(
+            "SWANSEA CR", 10
         ));
     }
 

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/LetterBaseTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/LetterBaseTest.java
@@ -21,7 +21,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -609,6 +611,187 @@ class LetterBaseTest {
 
         testLetter.addData(LetterBase.LetterDataType.WELSH_COURT_ADDRESS6, 40);
         assertThat(testLetter.getLetterString()).isEqualTo(LetterTestUtils.pad("WELSH_COURT_ADDRESS_6", 40));
+    }
+
+
+    @Test
+    void positiveAddDataShuffleSingle() {
+        LetterBase.LetterContext context = testContextBuilder().build();
+        LetterBase letterBase = spy(new LetterBase(context));
+
+        LetterBase.LetterDataType letterDataType = mock(LetterBase.LetterDataType.class);
+        doReturn("test").when(letterDataType).getValue(context);
+
+        LetterBase.DataShuffle dataShuffle = new LetterBase.DataShuffle(letterDataType, 10);
+
+        letterBase.addDataShuffle(dataShuffle);
+
+        verify(letterDataType, times(1)).validateContext(eq(context));
+
+        assertThat(letterBase.getData()).hasSize(1);
+        LetterBase.ILetterData actualLetterDataShuffle = letterBase.getData().get(0);
+
+        assertThat(actualLetterDataShuffle).isNotNull();
+        assertThat(actualLetterDataShuffle.getLength()).isEqualTo(10);
+        assertThat(actualLetterDataShuffle.getFormattedString()).isEqualTo("test      ");
+    }
+
+    @Test
+    void positiveAddDataShuffleMultiple() {
+        LetterBase.LetterContext context = testContextBuilder().build();
+
+        LetterBase.LetterDataType letterDataType1 = mock(LetterBase.LetterDataType.class);
+        doReturn("test 123").when(letterDataType1).getValue(context);
+        LetterBase.DataShuffle dataShuffle1 = new LetterBase.DataShuffle(letterDataType1, 20);
+
+        LetterBase.LetterDataType letterDataType2 = mock(LetterBase.LetterDataType.class);
+        doReturn("some value 2345").when(letterDataType2).getValue(context);
+        LetterBase.DataShuffle dataShuffle2 = new LetterBase.DataShuffle(letterDataType2, 15);
+
+        LetterBase.LetterDataType letterDataType3 = mock(LetterBase.LetterDataType.class);
+        doReturn("value 22 ").when(letterDataType3).getValue(context);
+        LetterBase.DataShuffle dataShuffle3 = new LetterBase.DataShuffle(letterDataType3, 10);
+
+        LetterBase letterBase = spy(new LetterBase(context));
+        letterBase.addDataShuffle(dataShuffle1, dataShuffle2, dataShuffle3);
+
+        verify(letterDataType1, times(1)).validateContext(eq(context));
+        verify(letterDataType2, times(1)).validateContext(eq(context));
+        verify(letterDataType3, times(1)).validateContext(eq(context));
+
+        assertThat(letterBase.getData()).hasSize(1);
+        LetterBase.ILetterData actualLetterDataShuffle = letterBase.getData().get(0);
+
+        assertThat(actualLetterDataShuffle).isNotNull();
+        assertThat(actualLetterDataShuffle.getLength()).isEqualTo(45);
+        assertThat(actualLetterDataShuffle.getFormattedString())
+            .isEqualTo("test 123            some value 2345value 22  ");
+    }
+
+    @Test
+    void positiveAddDataShuffleMultipleMissingFirstNull() {
+        LetterBase.LetterContext context = testContextBuilder().build();
+        LetterBase.LetterDataType letterDataType1 = mock(LetterBase.LetterDataType.class);
+        doReturn(null).when(letterDataType1).getValue(context);
+        LetterBase.DataShuffle dataShuffle1 = new LetterBase.DataShuffle(letterDataType1, 20);
+
+        LetterBase.LetterDataType letterDataType2 = mock(LetterBase.LetterDataType.class);
+        doReturn("some value 2345").when(letterDataType2).getValue(context);
+        LetterBase.DataShuffle dataShuffle2 = new LetterBase.DataShuffle(letterDataType2, 15);
+
+        LetterBase.LetterDataType letterDataType3 = mock(LetterBase.LetterDataType.class);
+        doReturn("value 22 ").when(letterDataType3).getValue(context);
+        LetterBase.DataShuffle dataShuffle3 = new LetterBase.DataShuffle(letterDataType3, 10);
+
+        LetterBase letterBase = spy(new LetterBase(context));
+        letterBase.addDataShuffle(dataShuffle1, dataShuffle2, dataShuffle3);
+
+        verify(letterDataType1, times(1)).validateContext(eq(context));
+        verify(letterDataType2, times(1)).validateContext(eq(context));
+        verify(letterDataType3, times(1)).validateContext(eq(context));
+
+        assertThat(letterBase.getData()).hasSize(1);
+        LetterBase.ILetterData actualLetterDataShuffle = letterBase.getData().get(0);
+
+        assertThat(actualLetterDataShuffle).isNotNull();
+        assertThat(actualLetterDataShuffle.getLength()).isEqualTo(45);
+        assertThat(actualLetterDataShuffle.getFormattedString())
+            .isEqualTo("some value 2345value 22                      ");
+    }
+
+    @Test
+    void positiveAddDataShuffleMultipleMissingFirstEmpty() {
+        LetterBase.LetterContext context = testContextBuilder().build();
+        LetterBase.LetterDataType letterDataType1 = mock(LetterBase.LetterDataType.class);
+        doReturn("").when(letterDataType1).getValue(context);
+        LetterBase.DataShuffle dataShuffle1 = new LetterBase.DataShuffle(letterDataType1, 20);
+
+        LetterBase.LetterDataType letterDataType2 = mock(LetterBase.LetterDataType.class);
+        doReturn("some value 2345").when(letterDataType2).getValue(context);
+        LetterBase.DataShuffle dataShuffle2 = new LetterBase.DataShuffle(letterDataType2, 15);
+
+        LetterBase.LetterDataType letterDataType3 = mock(LetterBase.LetterDataType.class);
+        doReturn("value 22 ").when(letterDataType3).getValue(context);
+        LetterBase.DataShuffle dataShuffle3 = new LetterBase.DataShuffle(letterDataType3, 10);
+
+        LetterBase letterBase = spy(new LetterBase(context));
+        letterBase.addDataShuffle(dataShuffle1, dataShuffle2, dataShuffle3);
+
+        verify(letterDataType1, times(1)).validateContext(eq(context));
+        verify(letterDataType2, times(1)).validateContext(eq(context));
+        verify(letterDataType3, times(1)).validateContext(eq(context));
+
+        assertThat(letterBase.getData()).hasSize(1);
+        LetterBase.ILetterData actualLetterDataShuffle = letterBase.getData().get(0);
+
+        assertThat(actualLetterDataShuffle).isNotNull();
+        assertThat(actualLetterDataShuffle.getLength()).isEqualTo(45);
+        assertThat(actualLetterDataShuffle.getFormattedString())
+            .isEqualTo("some value 2345value 22                      ");
+    }
+
+    @Test
+    void positiveAddDataShuffleMultipleMissingSecond() {
+        LetterBase.LetterContext context = testContextBuilder().build();
+
+        LetterBase.LetterDataType letterDataType1 = mock(LetterBase.LetterDataType.class);
+        doReturn("test 123").when(letterDataType1).getValue(context);
+        LetterBase.DataShuffle dataShuffle1 = new LetterBase.DataShuffle(letterDataType1, 20);
+
+        LetterBase.LetterDataType letterDataType2 = mock(LetterBase.LetterDataType.class);
+        doReturn(null).when(letterDataType2).getValue(context);
+        LetterBase.DataShuffle dataShuffle2 = new LetterBase.DataShuffle(letterDataType2, 15);
+
+        LetterBase.LetterDataType letterDataType3 = mock(LetterBase.LetterDataType.class);
+        doReturn("value 22 ").when(letterDataType3).getValue(context);
+        LetterBase.DataShuffle dataShuffle3 = new LetterBase.DataShuffle(letterDataType3, 10);
+
+        LetterBase letterBase = spy(new LetterBase(context));
+        letterBase.addDataShuffle(dataShuffle1, dataShuffle2, dataShuffle3);
+
+        verify(letterDataType1, times(1)).validateContext(eq(context));
+        verify(letterDataType2, times(1)).validateContext(eq(context));
+        verify(letterDataType3, times(1)).validateContext(eq(context));
+
+        assertThat(letterBase.getData()).hasSize(1);
+        LetterBase.ILetterData actualLetterDataShuffle = letterBase.getData().get(0);
+
+        assertThat(actualLetterDataShuffle).isNotNull();
+        assertThat(actualLetterDataShuffle.getLength()).isEqualTo(45);
+        assertThat(actualLetterDataShuffle.getFormattedString())
+            .isEqualTo("test 123            value 22                 ");
+    }
+
+    @Test
+    void positiveAddDataShuffleMultipleMissingFirstAndSecond() {
+        LetterBase.LetterContext context = testContextBuilder().build();
+
+        LetterBase.LetterDataType letterDataType1 = mock(LetterBase.LetterDataType.class);
+        doReturn(null).when(letterDataType1).getValue(context);
+        LetterBase.DataShuffle dataShuffle1 = new LetterBase.DataShuffle(letterDataType1, 20);
+
+        LetterBase.LetterDataType letterDataType2 = mock(LetterBase.LetterDataType.class);
+        doReturn(null).when(letterDataType2).getValue(context);
+        LetterBase.DataShuffle dataShuffle2 = new LetterBase.DataShuffle(letterDataType2, 15);
+
+        LetterBase.LetterDataType letterDataType3 = mock(LetterBase.LetterDataType.class);
+        doReturn("value 22 ").when(letterDataType3).getValue(context);
+        LetterBase.DataShuffle dataShuffle3 = new LetterBase.DataShuffle(letterDataType3, 10);
+
+        LetterBase letterBase = spy(new LetterBase(context));
+        letterBase.addDataShuffle(dataShuffle1, dataShuffle2, dataShuffle3);
+
+        verify(letterDataType1, times(1)).validateContext(eq(context));
+        verify(letterDataType2, times(1)).validateContext(eq(context));
+        verify(letterDataType3, times(1)).validateContext(eq(context));
+
+        assertThat(letterBase.getData()).hasSize(1);
+        LetterBase.ILetterData actualLetterDataShuffle = letterBase.getData().get(0);
+
+        assertThat(actualLetterDataShuffle).isNotNull();
+        assertThat(actualLetterDataShuffle.getLength()).isEqualTo(45);
+        assertThat(actualLetterDataShuffle.getFormattedString())
+            .isEqualTo("value 22                                     ");
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/LetterTestUtils.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/LetterTestUtils.java
@@ -9,14 +9,13 @@ import uk.gov.hmcts.juror.api.moj.domain.JurorPool;
 import uk.gov.hmcts.juror.api.moj.domain.JurorStatus;
 import uk.gov.hmcts.juror.api.moj.domain.PoolRequest;
 
-import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.Month;
-import java.util.Calendar;
-import java.util.Locale;
 
+//False positive this class is used to set up test data instead of running tests
+@SuppressWarnings("PMD.JUnit4TestShouldUseTestAnnotation")
 public final class LetterTestUtils {
 
     private LetterTestUtils() {
@@ -25,27 +24,6 @@ public final class LetterTestUtils {
 
     static String pad(String data, Integer width) {
         return StringUtils.rightPad(data, width, " ");
-    }
-
-    static String generateLetterDate() {
-        SimpleDateFormat formatter = new SimpleDateFormat("dd MMMM yyyy", Locale.ENGLISH);
-        Calendar cal = Calendar.getInstance();
-
-        switch (cal.get(Calendar.DAY_OF_WEEK)) {
-            case Calendar.MONDAY:
-            case Calendar.TUESDAY:
-            case Calendar.WEDNESDAY:
-                cal.add(Calendar.DAY_OF_MONTH, 2);
-                break;
-            case Calendar.THURSDAY:
-            case Calendar.FRIDAY:
-                cal.add(Calendar.DAY_OF_MONTH, 4);
-                break;
-            default:
-                break;
-        }
-
-        return formatter.format(cal.getTime()).toUpperCase();
     }
 
     static String emptyField(Integer width) {

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/PostponeLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/PostponeLetterTest.java
@@ -12,7 +12,7 @@ import java.time.Month;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(SpringExtension.class)
-public class PostponeLetterTest extends AbstractLetterTest {
+class PostponeLetterTest extends AbstractLetterTest {
     @Override
     protected void setupEnglishExpectedResult() {
         addEnglishLetterDate();
@@ -35,8 +35,8 @@ public class PostponeLetterTest extends AbstractLetterTest {
         addEnglishField("JUROR_ADDRESS_3", 35);
         addEnglishField("JUROR_ADDRESS_4", 35);
         addEnglishField("JUROR_ADDRESS_5", 35);
-        addEnglishField("", 35);
-        addEnglishField("SY2 6LU", 10);
+        addEnglishField("SY2 6LU", 35);
+        addEnglishField("", 10);
         addEnglishField("641500541", 9);
         addEnglishField("JURY MANAGER", 30);
         addEnglishField("MONDAY 6 FEBRUARY, 2017", 32);
@@ -65,8 +65,8 @@ public class PostponeLetterTest extends AbstractLetterTest {
         addWelshField("JUROR_ADDRESS_3", 35);
         addWelshField("JUROR_ADDRESS_4", 35);
         addWelshField("JUROR_ADDRESS_5", 35);
-        addWelshField("", 35);
-        addWelshField("SY2 6LU", 10);
+        addWelshField("SY2 6LU", 35);
+        addWelshField("", 10);
         addWelshField("641500541", 9);
         addWelshField("JURY MANAGER", 30);
         addWelshField("DYDD LLUN 6 CHWEFROR, 2017", 32);
@@ -90,8 +90,6 @@ public class PostponeLetterTest extends AbstractLetterTest {
 
         // Fax number is always empty
         assertThat(postponeLetter.getData().get(11).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
-        // Juror address 6 is always empty
-        assertThat(postponeLetter.getData().get(20).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(35));
     }
 
     @Test
@@ -111,8 +109,6 @@ public class PostponeLetterTest extends AbstractLetterTest {
 
         // Fax number is always empty
         assertThat(postponeLetter.getData().get(11).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
-        // Juror address 6 is always empty
-        assertThat(postponeLetter.getData().get(20).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(35));
 
     }
 

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/PostponeLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/PostponeLetterTest.java
@@ -47,13 +47,13 @@ class PostponeLetterTest extends AbstractLetterTest {
     protected void setupWelshExpectedResult() {
         addWelshLetterDate();
         addWelshField("ABERTAWE", 40);
-        addWelshField("SWANSEA CROWN COURT", 40);
-        addWelshField("JURY CENTRAL SUMMONING BUREAU", 35);
+        addWelshField("JURY CENTRAL SUMMONING BUREAU", 40);
         addWelshField("THE COURT SERVICE", 35);
         addWelshField("FREEPOST LON 19669", 35);
         addWelshField("POCOCK STREET", 35);
         addWelshField("LONDON", 35);
         addWelshField("BUREAU_ADDRESS_5", 35);
+        addWelshField("BUREAU_ADDRESS_6", 35);
         addWelshField("SE1 0YG", 10);
         addWelshField("0845 3555567", 12);
         addWelshField("", 12);
@@ -89,7 +89,7 @@ class PostponeLetterTest extends AbstractLetterTest {
         assertThat(postponeLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testJuror().getJurorNumber());
 
         // Fax number is always empty
-        assertThat(postponeLetter.getData().get(11).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
+        assertThat(postponeLetter.getData().get(5).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
     }
 
     @Test
@@ -108,7 +108,7 @@ class PostponeLetterTest extends AbstractLetterTest {
         assertThat(postponeLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testWelshJuror().getJurorNumber());
 
         // Fax number is always empty
-        assertThat(postponeLetter.getData().get(11).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
+        assertThat(postponeLetter.getData().get(5).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
 
     }
 

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/RequestInfoLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/RequestInfoLetterTest.java
@@ -49,13 +49,13 @@ class RequestInfoLetterTest extends AbstractLetterTest {
     protected void setupWelshExpectedResult() {
         addWelshLetterDate();
         addWelshField("ABERTAWE", 40);
-        addWelshField("SWANSEA CROWN COURT", 40);
-        addWelshField("JURY CENTRAL SUMMONING BUREAU", 35);
+        addWelshField("JURY CENTRAL SUMMONING BUREAU", 40);
         addWelshField("THE COURT SERVICE", 35);
         addWelshField("FREEPOST LON 19669", 35);
         addWelshField("POCOCK STREET", 35);
         addWelshField("LONDON", 35);
         addWelshField("BUREAU_ADDRESS_5", 35);
+        addWelshField("BUREAU_ADDRESS_6", 35);
         addWelshField("SE1 0YG", 10);
         addWelshField("0845 3555567", 12);
         addWelshField("", 12);
@@ -91,7 +91,7 @@ class RequestInfoLetterTest extends AbstractLetterTest {
         assertThat(requestInfoLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testJuror().getJurorNumber());
 
         // Fax number is always empty
-        assertThat(requestInfoLetter.getData().get(11).getFormattedString())
+        assertThat(requestInfoLetter.getData().get(5).getFormattedString())
             .isEqualTo(LetterTestUtils.emptyField(12));
     }
 
@@ -111,7 +111,7 @@ class RequestInfoLetterTest extends AbstractLetterTest {
         assertThat(requestInfoLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testWelshJuror().getJurorNumber());
 
         // Fax number is always empty
-        assertThat(requestInfoLetter.getData().get(11).getFormattedString())
+        assertThat(requestInfoLetter.getData().get(5).getFormattedString())
             .isEqualTo(LetterTestUtils.emptyField(12));
     }
 

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/RequestInfoLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/RequestInfoLetterTest.java
@@ -39,8 +39,8 @@ class RequestInfoLetterTest extends AbstractLetterTest {
         addEnglishField("JUROR_ADDRESS_3", 35);
         addEnglishField("JUROR_ADDRESS_4", 35);
         addEnglishField("JUROR_ADDRESS_5", 35);
-        addEnglishField("", 35);
-        addEnglishField("SY2 6LU", 10);
+        addEnglishField("SY2 6LU", 35);
+        addEnglishField("", 10);
         addEnglishField("641500541", 9);
         addEnglishField("JURY MANAGER", 30);
     }
@@ -68,8 +68,8 @@ class RequestInfoLetterTest extends AbstractLetterTest {
         addWelshField("JUROR_ADDRESS_3", 35);
         addWelshField("JUROR_ADDRESS_4", 35);
         addWelshField("JUROR_ADDRESS_5", 35);
-        addWelshField("", 35);
-        addWelshField("SY2 6LU", 10);
+        addWelshField("SY2 6LU", 35);
+        addWelshField("", 10);
         addWelshField("641500541", 9);
         addWelshField("JURY MANAGER", 30);
     }
@@ -93,9 +93,6 @@ class RequestInfoLetterTest extends AbstractLetterTest {
         // Fax number is always empty
         assertThat(requestInfoLetter.getData().get(11).getFormattedString())
             .isEqualTo(LetterTestUtils.emptyField(12));
-        // Juror address 6 is always empty
-        assertThat(requestInfoLetter.getData().get(21).getFormattedString())
-            .isEqualTo(LetterTestUtils.emptyField(35));
     }
 
     @Test
@@ -116,9 +113,6 @@ class RequestInfoLetterTest extends AbstractLetterTest {
         // Fax number is always empty
         assertThat(requestInfoLetter.getData().get(11).getFormattedString())
             .isEqualTo(LetterTestUtils.emptyField(12));
-        // Juror address 6 is always empty
-        assertThat(requestInfoLetter.getData().get(21).getFormattedString())
-            .isEqualTo(LetterTestUtils.emptyField(35));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/SummonsLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/SummonsLetterTest.java
@@ -24,8 +24,8 @@ class SummonsLetterTest extends AbstractLetterTest {
         addEnglishField("JUROR_ADDRESS_3", 35);
         addEnglishField("JUROR_ADDRESS_4", 35);
         addEnglishField("JUROR_ADDRESS_5", 35);
-        addEnglishField("", 35);
-        addEnglishField("SY2 6LU", 10);
+        addEnglishField("SY2 6LU", 35);
+        addEnglishField("", 10);
         addEnglishField("641500541", 9);
         addEnglishField("641500541", 9);
         addEnglishLetterDate();
@@ -67,8 +67,8 @@ class SummonsLetterTest extends AbstractLetterTest {
         addWelshField("JUROR_ADDRESS_3", 35);
         addWelshField("JUROR_ADDRESS_4", 35);
         addWelshField("JUROR_ADDRESS_5", 35);
-        addWelshField("", 35);
-        addWelshField("SY2 6LU", 10);
+        addWelshField("SY2 6LU", 35);
+        addWelshField("", 10);
         addWelshField("641500541", 9);
         addWelshLetterDate();
         addWelshField("MONDAY 6 FEBRUARY, 2017", 32);
@@ -123,11 +123,9 @@ class SummonsLetterTest extends AbstractLetterTest {
         assertThat(summonsLetter.getFormCode()).isEqualTo(FormCode.ENG_SUMMONS.getCode());
         assertThat(summonsLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testJuror().getJurorNumber());
 
-        // Juror address 6 is always empty
-        assertThat(summonsLetter.getData().get(9).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(35));
         // Fax number is always empty
-        assertThat(summonsLetter.getData().get(27).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
-        assertThat(summonsLetter.getData().get(38).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
+        assertThat(summonsLetter.getData().get(22).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
+        assertThat(summonsLetter.getData().get(33).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
 
     }
 
@@ -145,11 +143,9 @@ class SummonsLetterTest extends AbstractLetterTest {
         assertThat(summonsLetter.getFormCode()).isEqualTo(FormCode.BI_SUMMONS.getCode());
         assertThat(summonsLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testWelshJuror().getJurorNumber());
 
-        // Juror address 6 is always empty
-        assertThat(summonsLetter.getData().get(9).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(35));
         // Fax number is always empty
-        assertThat(summonsLetter.getData().get(27).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
-        assertThat(summonsLetter.getData().get(38).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
+        assertThat(summonsLetter.getData().get(22).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
+        assertThat(summonsLetter.getData().get(33).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
 
     }
 

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/SummonsLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/SummonsLetterTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(SpringExtension.class)
 class SummonsLetterTest extends AbstractLetterTest {
+
     @Override
     protected void setupEnglishExpectedResult() {
         addEnglishField("415221201", 9);
@@ -103,7 +104,7 @@ class SummonsLetterTest extends AbstractLetterTest {
         addWelshField("ABERTAWE", 35);
         addWelshField("WELSH_COURT_ADDRESS_4", 35);
         addWelshField("WELSH_COURT_ADDRESS_5", 35);
-        addWelshField("WELSH_COURT_ADDRESS_6", 35);
+        addWelshField("SY2 6LU", 35);
         // repeated field
         addWelshField("641500541", 9);
     }
@@ -124,8 +125,8 @@ class SummonsLetterTest extends AbstractLetterTest {
         assertThat(summonsLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testJuror().getJurorNumber());
 
         // Fax number is always empty
-        assertThat(summonsLetter.getData().get(22).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
-        assertThat(summonsLetter.getData().get(33).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
+        assertThat(summonsLetter.getData().get(16).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
+        assertThat(summonsLetter.getData().get(21).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
 
     }
 
@@ -144,9 +145,8 @@ class SummonsLetterTest extends AbstractLetterTest {
         assertThat(summonsLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testWelshJuror().getJurorNumber());
 
         // Fax number is always empty
-        assertThat(summonsLetter.getData().get(22).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
-        assertThat(summonsLetter.getData().get(33).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
-
+        assertThat(summonsLetter.getData().get(16).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
+        assertThat(summonsLetter.getData().get(21).getFormattedString()).isEqualTo(LetterTestUtils.emptyField(12));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/SummonsReminderLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/SummonsReminderLetterTest.java
@@ -36,8 +36,8 @@ class SummonsReminderLetterTest extends AbstractLetterTest {
         addEnglishField("JUROR_ADDRESS_3", 35);
         addEnglishField("JUROR_ADDRESS_4", 35);
         addEnglishField("JUROR_ADDRESS_5", 35);
-        addEnglishField("", 35);
-        addEnglishField("SY2 6LU", 10);
+        addEnglishField("SY2 6LU", 35);
+        addEnglishField("", 10);
         addEnglishField("641500541", 9);
         addEnglishField("JURY MANAGER", 30);
     }
@@ -65,8 +65,8 @@ class SummonsReminderLetterTest extends AbstractLetterTest {
         addWelshField("JUROR_ADDRESS_3", 35);
         addWelshField("JUROR_ADDRESS_4", 35);
         addWelshField("JUROR_ADDRESS_5", 35);
-        addWelshField("", 35);
-        addWelshField("SY2 6LU", 10);
+        addWelshField("SY2 6LU", 35);
+        addWelshField("", 10);
         addWelshField("641500541", 9);
         addWelshField("JURY MANAGER", 30);
     }
@@ -85,12 +85,9 @@ class SummonsReminderLetterTest extends AbstractLetterTest {
         assertThat(summonsReminderLetter.getFormCode()).isEqualTo(FormCode.ENG_SUMMONS_REMINDER.getCode());
         assertThat(summonsReminderLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testJuror().getJurorNumber());
 
-        // Juror address 6 is always empty
+        // Fax number is always empty
         assertThat(summonsReminderLetter.getData().get(11).getFormattedString())
             .isEqualTo(LetterTestUtils.emptyField(12));
-        // Fax number is always empty
-        assertThat(summonsReminderLetter.getData().get(20).getFormattedString())
-            .isEqualTo(LetterTestUtils.emptyField(35));
     }
 
     @Test
@@ -109,12 +106,9 @@ class SummonsReminderLetterTest extends AbstractLetterTest {
         assertThat(summonsReminderLetter.getJurorNumber()).isEqualTo(
             LetterTestUtils.testWelshJuror().getJurorNumber());
 
-        // Juror address 6 is always empty
+        // Fax number is always empty
         assertThat(summonsReminderLetter.getData().get(12).getFormattedString()).isEqualTo(
             LetterTestUtils.emptyField(12));
-        // Fax number is always empty
-        assertThat(summonsReminderLetter.getData().get(21).getFormattedString()).isEqualTo(
-            LetterTestUtils.emptyField(35));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/SummonsReminderLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/SummonsReminderLetterTest.java
@@ -86,7 +86,7 @@ class SummonsReminderLetterTest extends AbstractLetterTest {
         assertThat(summonsReminderLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testJuror().getJurorNumber());
 
         // Fax number is always empty
-        assertThat(summonsReminderLetter.getData().get(11).getFormattedString())
+        assertThat(summonsReminderLetter.getData().get(5).getFormattedString())
             .isEqualTo(LetterTestUtils.emptyField(12));
     }
 
@@ -107,7 +107,7 @@ class SummonsReminderLetterTest extends AbstractLetterTest {
             LetterTestUtils.testWelshJuror().getJurorNumber());
 
         // Fax number is always empty
-        assertThat(summonsReminderLetter.getData().get(12).getFormattedString()).isEqualTo(
+        assertThat(summonsReminderLetter.getData().get(6).getFormattedString()).isEqualTo(
             LetterTestUtils.emptyField(12));
     }
 

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/WithdrawalLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/WithdrawalLetterTest.java
@@ -35,8 +35,8 @@ public class WithdrawalLetterTest extends AbstractLetterTest {
         addEnglishField("JUROR_ADDRESS_3", 35);
         addEnglishField("JUROR_ADDRESS_4", 35);
         addEnglishField("JUROR_ADDRESS_5", 35);
-        addEnglishField("", 35);
-        addEnglishField("SY2 6LU", 10);
+        addEnglishField("SY2 6LU", 35);
+        addEnglishField("", 10);
         addEnglishField("641500541", 9);
         addEnglishField("JURY MANAGER", 30);
     }
@@ -63,8 +63,8 @@ public class WithdrawalLetterTest extends AbstractLetterTest {
         addWelshField("JUROR_ADDRESS_3", 35);
         addWelshField("JUROR_ADDRESS_4", 35);
         addWelshField("JUROR_ADDRESS_5", 35);
-        addWelshField("", 35);
-        addWelshField("SY2 6LU", 10);
+        addWelshField("SY2 6LU", 35);
+        addWelshField("", 10);
         addWelshField("641500541", 9);
         addWelshField("JURY MANAGER", 30);
 
@@ -87,9 +87,6 @@ public class WithdrawalLetterTest extends AbstractLetterTest {
         // Fax number is always empty
         assertThat(withdrawalLetter.getData().get(11).getFormattedString())
             .isEqualTo(LetterTestUtils.emptyField(12));
-        // Juror address 6 is always empty
-        assertThat(withdrawalLetter.getData().get(20).getFormattedString())
-            .isEqualTo(LetterTestUtils.emptyField(35));
 
     }
 
@@ -111,9 +108,6 @@ public class WithdrawalLetterTest extends AbstractLetterTest {
         // Fax number is always empty
         assertThat(withdrawalLetter.getData().get(11).getFormattedString())
             .isEqualTo(LetterTestUtils.emptyField(12));
-        // Juror address 6 is always empty
-        assertThat(withdrawalLetter.getData().get(20).getFormattedString())
-            .isEqualTo(LetterTestUtils.emptyField(35));
 
     }
 

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/WithdrawalLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/WithdrawalLetterTest.java
@@ -45,13 +45,13 @@ public class WithdrawalLetterTest extends AbstractLetterTest {
     protected void setupWelshExpectedResult() {
         addWelshLetterDate();
         addWelshField("ABERTAWE", 40);
-        addWelshField("SWANSEA CROWN COURT", 40);
-        addWelshField("JURY CENTRAL SUMMONING BUREAU", 35);
+        addWelshField("JURY CENTRAL SUMMONING BUREAU", 40);
         addWelshField("THE COURT SERVICE", 35);
         addWelshField("FREEPOST LON 19669", 35);
         addWelshField("POCOCK STREET", 35);
         addWelshField("LONDON", 35);
         addWelshField("BUREAU_ADDRESS_5", 35);
+        addWelshField("BUREAU_ADDRESS_6", 35);
         addWelshField("SE1 0YG", 10);
         addWelshField("0845 3555567", 12);
         addWelshField("", 12);
@@ -85,7 +85,7 @@ public class WithdrawalLetterTest extends AbstractLetterTest {
         assertThat(withdrawalLetter.getJurorNumber()).isEqualTo(LetterTestUtils.testJuror().getJurorNumber());
 
         // Fax number is always empty
-        assertThat(withdrawalLetter.getData().get(11).getFormattedString())
+        assertThat(withdrawalLetter.getData().get(5).getFormattedString())
             .isEqualTo(LetterTestUtils.emptyField(12));
 
     }
@@ -106,7 +106,7 @@ public class WithdrawalLetterTest extends AbstractLetterTest {
             .isEqualTo(LetterTestUtils.testWelshJuror().getJurorNumber());
 
         // Fax number is always empty
-        assertThat(withdrawalLetter.getData().get(11).getFormattedString())
+        assertThat(withdrawalLetter.getData().get(5).getFormattedString())
             .isEqualTo(LetterTestUtils.emptyField(12));
 
     }


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7736)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=577)


### Change description ###
On the addresses on the bulk print letters from the Bureau in the new modernised app there is a difference in the spacing, this is because we are populating the bulk print data as per the spec for the Xerox interface but that spec didn't cover the shuffling of the address/postcode data that was introduced into Heritage in 2019 as a result of an issue in Juror Digital that required address4 (town) to be not null.

 

This means that in a worst case scenario where the address has rows missing the address field will look like the below:

 

e.g.

 

!file:///C:/Users/LIAM~1.MUR/AppData/Local/Temp/msohtmlclip1/01/clip_image002.gif|thumbnail!

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
