### PR TITLE
Reasonable adjustment message not displaying on juror record or reports

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/response/JurorDetailsResponseDto.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/response/JurorDetailsResponseDto.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.juror.api.moj.domain.PoliceCheck;
 import uk.gov.hmcts.juror.api.moj.enumeration.jurorresponse.ReasonableAdjustmentsEnum;
 import uk.gov.hmcts.juror.api.moj.repository.JurorStatusRepository;
 import uk.gov.hmcts.juror.api.moj.repository.PendingJurorRepository;
+import uk.gov.hmcts.juror.api.validation.ValidationConstants;
 
 import java.time.LocalDate;
 import java.util.Arrays;
@@ -105,7 +106,7 @@ public class JurorDetailsResponseDto {
     @Schema(description = "Description of Reasonable adjustments")
     private String specialNeedDescription;
 
-    @Length(max = 120)
+    @Length(max = ValidationConstants.REASONABLE_ADJUSTMENT_MESSAGE_LENGTH_MAX)
     @Schema(description = "Reasonable adjustments message")
     private String specialNeedMessage;
 

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/response/JurorDetailsResponseDto.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/response/JurorDetailsResponseDto.java
@@ -105,7 +105,7 @@ public class JurorDetailsResponseDto {
     @Schema(description = "Description of Reasonable adjustments")
     private String specialNeedDescription;
 
-    @Length(max = 60)
+    @Length(max = 120)
     @Schema(description = "Reasonable adjustments message")
     private String specialNeedMessage;
 

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/response/JurorOverviewResponseDto.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/response/JurorOverviewResponseDto.java
@@ -62,7 +62,7 @@ public class JurorOverviewResponseDto {
     @Schema(description = "Description of Reasonable adjustments")
     private String specialNeedDescription;
 
-    @Length(max = 120)
+    @Length(max = ValidationConstants.REASONABLE_ADJUSTMENT_MESSAGE_LENGTH_MAX)
     @Schema(description = "Reasonable adjustments message")
     private String specialNeedMessage;
 

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/response/JurorOverviewResponseDto.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/response/JurorOverviewResponseDto.java
@@ -62,7 +62,7 @@ public class JurorOverviewResponseDto {
     @Schema(description = "Description of Reasonable adjustments")
     private String specialNeedDescription;
 
-    @Length(max = 60)
+    @Length(max = 120)
     @Schema(description = "Reasonable adjustments message")
     private String specialNeedMessage;
 

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/domain/Juror.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/domain/Juror.java
@@ -155,7 +155,7 @@ public class Juror extends Address implements Serializable {
     private String reasonableAdjustmentCode;
 
     @NotAudited
-    @Length(max = 60)
+    @Length(max = 120)
     @Column(name = "reasonable_adj_msg")
     private String reasonableAdjustmentMessage;
 

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/domain/Juror.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/domain/Juror.java
@@ -33,6 +33,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import uk.gov.hmcts.juror.api.moj.domain.jurorresponse.JurorResponseCommon;
+import uk.gov.hmcts.juror.api.validation.ValidationConstants;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
@@ -155,7 +156,7 @@ public class Juror extends Address implements Serializable {
     private String reasonableAdjustmentCode;
 
     @NotAudited
-    @Length(max = 120)
+    @Length(max = ValidationConstants.REASONABLE_ADJUSTMENT_MESSAGE_LENGTH_MAX)
     @Column(name = "reasonable_adj_msg")
     private String reasonableAdjustmentMessage;
 

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceImpl.java
@@ -42,7 +42,6 @@ import uk.gov.hmcts.juror.api.moj.repository.trial.PanelRepository;
 import uk.gov.hmcts.juror.api.moj.repository.trial.TrialRepository;
 import uk.gov.hmcts.juror.api.moj.service.JurorHistoryServiceImpl;
 import uk.gov.hmcts.juror.api.moj.service.JurorPoolService;
-import uk.gov.hmcts.juror.api.moj.service.JurorPoolServiceImpl;
 import uk.gov.hmcts.juror.api.moj.service.expense.JurorExpenseService;
 import uk.gov.hmcts.juror.api.moj.utils.CourtLocationUtils;
 import uk.gov.hmcts.juror.api.moj.utils.JurorPoolUtils;

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceImpl.java
@@ -41,6 +41,8 @@ import uk.gov.hmcts.juror.api.moj.repository.JurorRepository;
 import uk.gov.hmcts.juror.api.moj.repository.trial.PanelRepository;
 import uk.gov.hmcts.juror.api.moj.repository.trial.TrialRepository;
 import uk.gov.hmcts.juror.api.moj.service.JurorHistoryServiceImpl;
+import uk.gov.hmcts.juror.api.moj.service.JurorPoolService;
+import uk.gov.hmcts.juror.api.moj.service.JurorPoolServiceImpl;
 import uk.gov.hmcts.juror.api.moj.service.expense.JurorExpenseService;
 import uk.gov.hmcts.juror.api.moj.utils.CourtLocationUtils;
 import uk.gov.hmcts.juror.api.moj.utils.JurorPoolUtils;
@@ -76,6 +78,7 @@ public class JurorAppearanceServiceImpl implements JurorAppearanceService {
     private final JurorExpenseService jurorExpenseService;
     private final JurorHistoryServiceImpl jurorHistoryService;
     private final PanelRepository panelRepository;
+    private final JurorPoolService jurorPoolService;
 
     @Override
     public void addAttendanceDay(BureauJwtPayload payload, AddAttendanceDayDto dto) {
@@ -1133,8 +1136,7 @@ public class JurorAppearanceServiceImpl implements JurorAppearanceService {
     }
 
     private JurorPool validateJurorStatus(Juror juror, boolean isCompleted) {
-        JurorPool jurorPool = JurorPoolUtils.getLatestActiveJurorPoolRecord(jurorPoolRepository,
-            juror.getJurorNumber());
+        JurorPool jurorPool = jurorPoolService.getJurorPoolFromUser(juror.getJurorNumber());
 
         final int status = jurorPool.getStatus().getStatus();
 

--- a/src/main/java/uk/gov/hmcts/juror/api/validation/ValidationConstants.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/validation/ValidationConstants.java
@@ -32,6 +32,8 @@ public final class ValidationConstants {
     public static final String DATETIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
     public static final String TIME_FORMAT = "HH:mm";
 
+    public static final int REASONABLE_ADJUSTMENT_MESSAGE_LENGTH_MAX = 120;
+
     private ValidationConstants() {
 
     }

--- a/src/main/java/uk/gov/hmcts/juror/api/validation/ValidationConstants.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/validation/ValidationConstants.java
@@ -32,7 +32,7 @@ public final class ValidationConstants {
     public static final String DATETIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
     public static final String TIME_FORMAT = "HH:mm";
 
-    public static final int REASONABLE_ADJUSTMENT_MESSAGE_LENGTH_MAX = 120;
+    public static final int REASONABLE_ADJUSTMENT_MESSAGE_LENGTH_MAX = 2000;
 
     private ValidationConstants() {
 

--- a/src/main/resources/db/migrationv2/V2_2__reasonable_adjustments_message_length_update.sql
+++ b/src/main/resources/db/migrationv2/V2_2__reasonable_adjustments_message_length_update.sql
@@ -1,0 +1,5 @@
+alter table juror_mod.juror
+   alter column reasonable_adj_msg type varchar(2000);
+
+alter table juror_mod.juror_reasonable_adjustment
+    alter column reasonable_adjustment_detail type varchar(2000);


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7766)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=585)


### Change description ###
After a data fix only the reasonable adjustment code is displaying need to also display the message on the juror record and reports

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
