### PR TITLE
Remove the in in-front of the welsh court name for bi lingual summons

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/juror/domain/WelshCourtLocation.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/juror/domain/WelshCourtLocation.java
@@ -39,7 +39,7 @@ public class WelshCourtLocation implements Serializable, ICourtLocation {
     private String locCourtName;
 
     /**
-     * Court name.
+     * Correspondence name used for letters.
      */
     @Column(name = "correspondence_name")
     private String correspondenceName;

--- a/src/main/java/uk/gov/hmcts/juror/api/juror/domain/WelshCourtLocation.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/juror/domain/WelshCourtLocation.java
@@ -39,6 +39,12 @@ public class WelshCourtLocation implements Serializable, ICourtLocation {
     private String locCourtName;
 
     /**
+     * Court name.
+     */
+    @Column(name = "correspondence_name")
+    private String correspondenceName;
+
+    /**
      * Court address line 1.
      */
     @Column(name = "loc_address1")

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/LetterBase.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/LetterBase.java
@@ -272,6 +272,8 @@ public class LetterBase {
         JUROR_NUMBER(context -> context.getJurorPool().getJuror().getJurorNumber(), ContextType.JUROR_POOL),
         POOL_NUMBER(context -> context.getJurorPool().getPoolNumber(), ContextType.JUROR_POOL),
         ADDITIONAL_INFORMATION(LetterContext::getAdditionalInformation, ContextType.ADDITIONAL_INFORMATION),
+        WELSH_CORRESPONDENCE_NAME(context -> context.getWelshCourtLocation().getCorrespondenceName(),
+            ContextType.WELSH_COURT_LOCATION),
         WELSH_COURT_NAME(context -> context.getWelshCourtLocation().getLocCourtName(),
             ContextType.WELSH_COURT_LOCATION),
         WELSH_COURT_ADDRESS1(context -> context.getWelshCourtLocation().getAddress1(),

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/ConfirmLetter.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/ConfirmLetter.java
@@ -35,7 +35,7 @@ public class ConfirmLetter extends LetterBase {
         setFormCode(FormCode.BI_CONFIRMATION);
         addData(LetterDataType.DATE_OF_LETTER, 18);
         addData(LetterDataType.COURT_LOCATION_CODE, 3);
-        addData(LetterDataType.WELSH_COURT_NAME, 40);
+        addData(LetterDataType.WELSH_CORRESPONDENCE_NAME, 40);
         addData(LetterDataType.BUREAU_NAME, 40);
         addBureauAddress();
         addData(LetterDataType.BUREAU_PHONE, 12);

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/DeferralDeniedLetter.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/DeferralDeniedLetter.java
@@ -33,7 +33,7 @@ public class DeferralDeniedLetter extends LetterBase {
     protected void setupWelsh() {
         setFormCode(FormCode.BI_DEFERRALDENIED);
         addData(LetterDataType.DATE_OF_LETTER, 18);
-        addData(LetterDataType.WELSH_COURT_NAME, 40);
+        addData(LetterDataType.WELSH_CORRESPONDENCE_NAME, 40);
         addData(LetterDataType.BUREAU_NAME, 40);
         addBureauAddress();
         addData(LetterDataType.BUREAU_PHONE, 12);

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/DeferralLetter.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/DeferralLetter.java
@@ -34,7 +34,7 @@ public class DeferralLetter extends LetterBase {
     protected void setupWelsh() {
         setFormCode(FormCode.BI_DEFERRAL);
         addData(LetterDataType.DATE_OF_LETTER, 18);
-        addData(LetterDataType.WELSH_COURT_NAME, 40);
+        addData(LetterDataType.WELSH_CORRESPONDENCE_NAME, 40);
         addData(LetterDataType.BUREAU_NAME, 40);
         addBureauAddress();
         addData(LetterDataType.BUREAU_PHONE, 12);

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/ExcusalDeniedLetter.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/ExcusalDeniedLetter.java
@@ -34,7 +34,7 @@ public class ExcusalDeniedLetter extends LetterBase {
     protected void setupWelsh() {
         setFormCode(FormCode.BI_EXCUSALDENIED);
         addData(LetterDataType.DATE_OF_LETTER, 18);
-        addData(LetterDataType.WELSH_COURT_NAME, 40);
+        addData(LetterDataType.WELSH_CORRESPONDENCE_NAME, 40);
         addData(LetterDataType.BUREAU_NAME, 40);
         addBureauAddress();
         addData(LetterDataType.BUREAU_PHONE, 12);

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/ExcusalLetter.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/ExcusalLetter.java
@@ -34,7 +34,7 @@ public class ExcusalLetter extends LetterBase {
     protected void setupWelsh() {
         setFormCode(FormCode.BI_EXCUSAL);
         addData(LetterDataType.DATE_OF_LETTER, 18);
-        addData(LetterDataType.WELSH_COURT_NAME, 40);
+        addData(LetterDataType.WELSH_CORRESPONDENCE_NAME, 40);
         addData(LetterDataType.BUREAU_NAME, 40);
         addBureauAddress();
         addData(LetterDataType.BUREAU_PHONE, 12);

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/PostponeLetter.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/PostponeLetter.java
@@ -34,7 +34,7 @@ public class PostponeLetter extends LetterBase {
     protected void setupWelsh() {
         setFormCode(FormCode.BI_POSTPONE);
         addData(LetterDataType.DATE_OF_LETTER, 18);
-        addData(LetterDataType.WELSH_COURT_NAME, 40);
+        addData(LetterDataType.WELSH_CORRESPONDENCE_NAME, 40);
         addData(LetterDataType.BUREAU_NAME, 40);
         addBureauAddress();
         sharedSetup();

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/RequestInfoLetter.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/RequestInfoLetter.java
@@ -38,7 +38,7 @@ public class RequestInfoLetter extends LetterBase {
     protected void setupWelsh() {
         setFormCode(FormCode.BI_REQUESTINFO);
         addData(LetterDataType.DATE_OF_LETTER, 18);
-        addData(LetterDataType.WELSH_COURT_NAME, 40);
+        addData(LetterDataType.WELSH_CORRESPONDENCE_NAME, 40);
         addData(LetterDataType.BUREAU_NAME, 40);
         addBureauAddress();
         sharedSetup();

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/SummonsReminderLetter.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/SummonsReminderLetter.java
@@ -33,7 +33,7 @@ public class SummonsReminderLetter extends LetterBase {
     protected void setupWelsh() {
         setFormCode(FormCode.BI_SUMMONS_REMINDER);
         addData(LetterDataType.DATE_OF_LETTER, 18);
-        addData(LetterDataType.WELSH_COURT_NAME, 40);
+        addData(LetterDataType.WELSH_CORRESPONDENCE_NAME, 40);
         addData(LetterDataType.COURT_NAME, 40);
         sharedSetup();
     }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/WithdrawalLetter.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/xerox/letters/WithdrawalLetter.java
@@ -34,7 +34,7 @@ public class WithdrawalLetter extends LetterBase {
     protected void setupWelsh() {
         setFormCode(FormCode.BI_WITHDRAWAL);
         addData(LetterDataType.DATE_OF_LETTER, 18);
-        addData(LetterDataType.WELSH_COURT_NAME, 40);
+        addData(LetterDataType.WELSH_CORRESPONDENCE_NAME, 40);
         addData(LetterDataType.BUREAU_NAME, 40);
         addBureauAddress();
         addData(LetterDataType.BUREAU_PHONE, 12);

--- a/src/main/resources/db/migration/V1_161__update_welsh_court_court_name.sql
+++ b/src/main/resources/db/migration/V1_161__update_welsh_court_court_name.sql
@@ -1,0 +1,42 @@
+alter table juror_mod.welsh_court_location
+    add column correspondence_name varchar(40);
+
+update juror_mod.welsh_court_location
+    set correspondence_name = loc_name;
+
+update juror_mod.welsh_court_location
+set loc_name = 'CAERDYDD'
+where loc_code='411';
+update juror_mod.welsh_court_location
+set loc_name = 'MERTHYR TUDFUL'
+where loc_code='437';
+update juror_mod.welsh_court_location
+set loc_name = 'CASNEWYDD DE CYMRU'
+where loc_code='441';
+update juror_mod.welsh_court_location
+set loc_name = 'ABERTAWE'
+where loc_code='457';
+update juror_mod.welsh_court_location
+set loc_name = 'CAERNARFON'
+where loc_code='755';
+update juror_mod.welsh_court_location
+set loc_name = 'CAERFYRDDIN'
+where loc_code='756';
+update juror_mod.welsh_court_location
+set loc_name = 'DOLGELLAU'
+where loc_code='758';
+update juror_mod.welsh_court_location
+set loc_name = 'HWLFFORDD'
+where loc_code='761';
+update juror_mod.welsh_court_location
+set loc_name = 'YR WYDDGRUG'
+where loc_code='769';
+update juror_mod.welsh_court_location
+set loc_name = 'Y TRALLWNG'
+where loc_code='774';
+
+
+
+
+
+

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/ConfirmLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/ConfirmLetterTest.java
@@ -48,7 +48,7 @@ class ConfirmLetterTest extends AbstractLetterTest {
     protected void setupWelshExpectedResult() {
         addWelshLetterDate();
         addWelshField("457", 3);
-        addWelshField("ABERTAWE", 40);
+        addWelshField("YN ABERTAWE", 40);
         addWelshField("JURY CENTRAL SUMMONING BUREAU", 40);
         addWelshField("THE COURT SERVICE", 35);
         addWelshField("FREEPOST LON 19669", 35);

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/DeferralDeniedLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/DeferralDeniedLetterTest.java
@@ -51,7 +51,7 @@ class DeferralDeniedLetterTest extends AbstractLetterTest {
     @Override
     protected void setupWelshExpectedResult() {
         addWelshLetterDate();
-        addWelshField("ABERTAWE", 40);
+        addWelshField("YN ABERTAWE", 40);
         addWelshField("JURY CENTRAL SUMMONING BUREAU", 40);
         addWelshField("THE COURT SERVICE", 35);
         addWelshField("FREEPOST LON 19669", 35);

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/DeferralLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/DeferralLetterTest.java
@@ -46,7 +46,7 @@ class DeferralLetterTest extends AbstractLetterTest {
     @Override
     protected void setupWelshExpectedResult() {
         addWelshLetterDate();
-        addWelshField("ABERTAWE", 40);
+        addWelshField("YN ABERTAWE", 40);
         addWelshField("JURY CENTRAL SUMMONING BUREAU", 40);
         addWelshField("THE COURT SERVICE", 35);
         addWelshField("FREEPOST LON 19669", 35);

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/ExcusalDeniedLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/ExcusalDeniedLetterTest.java
@@ -51,7 +51,7 @@ class ExcusalDeniedLetterTest extends AbstractLetterTest {
     @Override
     protected void setupWelshExpectedResult() {
         addWelshLetterDate();
-        addWelshField("ABERTAWE", 40);
+        addWelshField("YN ABERTAWE", 40);
         addWelshField("JURY CENTRAL SUMMONING BUREAU", 40);
         addWelshField("THE COURT SERVICE", 35);
         addWelshField("FREEPOST LON 19669", 35);

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/ExcusalLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/ExcusalLetterTest.java
@@ -44,7 +44,7 @@ public class ExcusalLetterTest extends AbstractLetterTest {
     @Override
     protected void setupWelshExpectedResult() {
         addWelshLetterDate();
-        addWelshField("ABERTAWE", 40);
+        addWelshField("YN ABERTAWE", 40);
         addWelshField("JURY CENTRAL SUMMONING BUREAU", 40);
         addWelshField("THE COURT SERVICE", 35);
         addWelshField("FREEPOST LON 19669", 35);

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/LetterTestUtils.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/LetterTestUtils.java
@@ -154,6 +154,7 @@ public final class LetterTestUtils {
     public static WelshCourtLocation testWelshCourtLocation() {
         WelshCourtLocation courtLocationWelsh = new WelshCourtLocation();
         courtLocationWelsh.setLocCourtName("ABERTAWE");
+        courtLocationWelsh.setCorrespondenceName("YN ABERTAWE");
         courtLocationWelsh.setAddress1("Y LLYSOEDD BARN");
         courtLocationWelsh.setAddress2("LON SAN HELEN");
         courtLocationWelsh.setAddress3("ABERTAWE");

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/PostponeLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/PostponeLetterTest.java
@@ -46,7 +46,7 @@ class PostponeLetterTest extends AbstractLetterTest {
     @Override
     protected void setupWelshExpectedResult() {
         addWelshLetterDate();
-        addWelshField("ABERTAWE", 40);
+        addWelshField("YN ABERTAWE", 40);
         addWelshField("JURY CENTRAL SUMMONING BUREAU", 40);
         addWelshField("THE COURT SERVICE", 35);
         addWelshField("FREEPOST LON 19669", 35);

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/RequestInfoLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/RequestInfoLetterTest.java
@@ -48,7 +48,7 @@ class RequestInfoLetterTest extends AbstractLetterTest {
     @Override
     protected void setupWelshExpectedResult() {
         addWelshLetterDate();
-        addWelshField("ABERTAWE", 40);
+        addWelshField("YN ABERTAWE", 40);
         addWelshField("JURY CENTRAL SUMMONING BUREAU", 40);
         addWelshField("THE COURT SERVICE", 35);
         addWelshField("FREEPOST LON 19669", 35);

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/SummonsReminderLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/SummonsReminderLetterTest.java
@@ -45,7 +45,7 @@ class SummonsReminderLetterTest extends AbstractLetterTest {
     @Override
     protected void setupWelshExpectedResult() {
         addWelshLetterDate();
-        addWelshField("ABERTAWE", 40);
+        addWelshField("YN ABERTAWE", 40);
         addWelshField("THE CROWN COURT AT SWANSEA", 40);
         addWelshField("JURY CENTRAL SUMMONING BUREAU", 40);
         addWelshField("THE COURT SERVICE", 35);

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/WithdrawalLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/xerox/WithdrawalLetterTest.java
@@ -44,7 +44,7 @@ public class WithdrawalLetterTest extends AbstractLetterTest {
     @Override
     protected void setupWelshExpectedResult() {
         addWelshLetterDate();
-        addWelshField("ABERTAWE", 40);
+        addWelshField("YN ABERTAWE", 40);
         addWelshField("JURY CENTRAL SUMMONING BUREAU", 40);
         addWelshField("THE COURT SERVICE", 35);
         addWelshField("FREEPOST LON 19669", 35);


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7751)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=586)


### Change description ###
In welsh language we say in Cardiff in the court name we need to change this to just the welsh court name for the bi lingual summons and summons reminders.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
