### PR TITLE
hotfix/JM-7783 Duplicate bureau users showing in assign response list

### DIFF
--- a/src/integration-test/java/uk/gov/hmcts/juror/api/bureau/controller/BureauOfficerAllocatedRepliesControllerTest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/bureau/controller/BureauOfficerAllocatedRepliesControllerTest.java
@@ -125,5 +125,11 @@ public class BureauOfficerAllocatedRepliesControllerTest extends AbstractIntegra
                 assertThat(bureauOfficerAllocatedData.getUrgent()).isEqualTo(0);
                 assertThat(bureauOfficerAllocatedData.getNonUrgent()).isEqualTo(0);
             });
+
+        List<BureauOfficerAllocatedData> inactiveUser =
+            exchange.getBody().getData().stream().filter(r -> "inactiveuser".equals(r.getLogin()))
+                .toList();
+        assertThat(inactiveUser.size()).as("Inactive user should not be included").isEqualTo(0);
+
     }
 }

--- a/src/integration-test/resources/db/BureauOfficerAllocateRepliesService_BacklogData.sql
+++ b/src/integration-test/resources/db/BureauOfficerAllocateRepliesService_BacklogData.sql
@@ -5,7 +5,8 @@ VALUES ('carneson','carneson','carneson','BUREAU','carneson@email.gov.uk','Chad 
        ('carneson','carneson','mruby','BUREAU','mruby@email.gov.uk','Martin Ruby',true,3),
        ('carneson','carneson','cbeasley','BUREAU','cbeasley@email.gov.uk','Charles Beasley',true,1),
        ('carneson','carneson','tgarrett','BUREAU','tgarrett@email.gov.uk','Timothy Garrett',true,2),
-       ('carneson','carneson','ksalazar','BUREAU','ksalazar@email.gov.uk','Kris Salazar',true,3);
+       ('carneson','carneson','ksalazar','BUREAU','ksalazar@email.gov.uk','Kris Salazar',true,3),
+       ('carneson','carneson','inactiveuser','BUREAU','inactiveuser@email.gov.uk','Inactive User',false,3);
 
 insert into juror_mod.user_courts (username, loc_code)
 values ('carneson', '400'),
@@ -13,7 +14,8 @@ values ('carneson', '400'),
        ('mruby', '400'),
        ('cbeasley', '400'),
        ('tgarrett', '400'),
-       ('ksalazar', '400');
+       ('ksalazar', '400'),
+       ('inactiveuser', '400');
 
 
 INSERT INTO juror_mod.user_roles (username, role)

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/jurorresponse/JurorDigitalResponseRepositoryModImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/jurorresponse/JurorDigitalResponseRepositoryModImpl.java
@@ -49,6 +49,7 @@ public class JurorDigitalResponseRepositoryModImpl implements IJurorDigitalRespo
                 digitalResponse.count().as("allReplies")
             ).from(user)
             .where(user.userType.eq(UserType.BUREAU))
+            .where(user.active.isTrue())
             .leftJoin(digitalResponse)
             .on(user.eq(digitalResponse.staff).and(digitalResponse.processingStatus.eq(ProcessingStatus.TODO)))
             .groupBy(user.username, user.name);


### PR DESCRIPTION

### JIRA link (if applicable) ###
https://centralgovernmentcgi.atlassian.net/browse/JM-7783


### Change description ###

Updated to filter out  inactive users for the assign replies screen


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
