### PR TITLE
Messaging juror hyperlink not always working says juror not found

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/response/messages/JurorToSendMessageBase.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/response/messages/JurorToSendMessageBase.java
@@ -51,4 +51,7 @@ public abstract class JurorToSendMessageBase {
 
     @JsonProperty("welsh_language")
     private boolean welshLanguage;
+
+    @JsonProperty("loc_code")
+    private String locCode;
 }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/MessageTemplateRepositoryImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/MessageTemplateRepositoryImpl.java
@@ -61,6 +61,7 @@ public class MessageTemplateRepositoryImpl implements IMessageTemplateRepository
         returnFields.add(JUROR.email);
         returnFields.add(JUROR.phoneNumber);
         returnFields.add(JUROR.welsh);
+        returnFields.add(JUROR_POOL.pool.courtLocation.locCode);
 
         if (!simpleResponse) {
             returnFields.add(JUROR.firstName);
@@ -123,6 +124,7 @@ public class MessageTemplateRepositoryImpl implements IMessageTemplateRepository
                     .lastName(tuple.get(JUROR.lastName))
                     .status(tuple.get(JUROR_POOL.status) == null ? null : tuple.get(JUROR_POOL.status).getStatusDesc())
                     .dateDeferredTo(tuple.get(JUROR_POOL.deferralDate))
+                    .locCode(tuple.get(JUROR_POOL.pool.courtLocation.locCode))
                     .build();
             },
             maxItems);

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/repository/MessageTemplateRepositoryImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/repository/MessageTemplateRepositoryImplTest.java
@@ -147,7 +147,8 @@ class MessageTemplateRepositoryImplTest {
                 JUROR_POOL.pool.poolNumber,
                 JUROR.email,
                 JUROR.phoneNumber,
-                JUROR.welsh
+                JUROR.welsh,
+                JUROR_POOL.pool.courtLocation.locCode
             );
         verify(messageSearch, times(1))
             .apply(jpaQuery);
@@ -229,6 +230,7 @@ class MessageTemplateRepositoryImplTest {
                 JUROR.email,
                 JUROR.phoneNumber,
                 JUROR.welsh,
+                JUROR_POOL.pool.courtLocation.locCode,
                 JUROR.firstName,
                 JUROR.lastName,
                 JUROR_POOL.status,
@@ -308,7 +310,8 @@ class MessageTemplateRepositoryImplTest {
                 JUROR_POOL.pool.poolNumber,
                 JUROR.email,
                 JUROR.phoneNumber,
-                JUROR.welsh
+                JUROR.welsh,
+                JUROR_POOL.pool.courtLocation.locCode
             );
         verify(messageSearch, times(1))
             .apply(jpaQuery);
@@ -394,6 +397,7 @@ class MessageTemplateRepositoryImplTest {
                 JUROR.email,
                 JUROR.phoneNumber,
                 JUROR.welsh,
+                JUROR_POOL.pool.courtLocation.locCode,
                 JUROR.firstName,
                 JUROR.lastName,
                 JUROR_POOL.status,
@@ -488,7 +492,8 @@ class MessageTemplateRepositoryImplTest {
                 JUROR_POOL.pool.poolNumber,
                 JUROR.email,
                 JUROR.phoneNumber,
-                JUROR.welsh
+                JUROR.welsh,
+                JUROR_POOL.pool.courtLocation.locCode
             );
         verify(messageSearch, times(1))
             .apply(jpaQuery);


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7764)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=591)


### Change description ###


the juror hyperlink is inconsistent some times it works other times it fails and says juror not found:



!image-20240713-141208.png|width=2013,height=609,alt="image-20240713-141208.png"!

 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
