### PR TITLE
Existing trials not accessible post migration

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/request/trial/TrialDto.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/request/trial/TrialDto.java
@@ -35,7 +35,7 @@ public class TrialDto {
     @JsonProperty("defendant")
     @Schema(description = "Depending on the trial type, a defendant is one of two types, Defendant or Respondent.  "
         + "The data captured for either is the same, free text", requiredMode = Schema.RequiredMode.REQUIRED)
-    @Size(max = 16, message = "Defendant must have at least 1 alphanumeric value and maximum of 16")
+    @Size(max = 50, message = "Defendant must have at least 1 alphanumeric value and maximum of 50")
     @NotBlank
     private String defendant;
 


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7792)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=592)


### Change description ###
Trials created before go-live weekend that are now not accessible - T20210487/0490 for Croydon. " issues;
1 - when you click on the trial is says page not found
2 - although the name was input in heritage on Friday, it is now saying that the defendant name is exceeding 16 characters


Heritage database supported up to 30 chars for trial.description

Modernised database supports 50 chars for trial.description

Backend API  supports 50 chars for Trial entity, description property

Front end is restricting to 16 chars - please update to match DB/BE

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
