### PR TITLE
hotfix/JM-7806 returning jury creates multiple audit numbers

### DIFF
--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/TrialControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/TrialControllerITest.java
@@ -50,7 +50,9 @@ import java.net.URI;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
@@ -703,6 +705,8 @@ class TrialControllerITest extends AbstractIntegrationTest {
         List<Panel> panelList = panelRepository.findByTrialTrialNumberAndTrialCourtLocationLocCode(
             "T10000001", "415");
 
+        Map<String, Integer> auditNumberMap = new HashMap<>();
+
         for (Panel panel : panelList) {
             assertThat(panel.getResult()).as("Expect result to be Returned")
                 .isEqualTo(PanelResult.RETURNED);
@@ -725,6 +729,9 @@ class TrialControllerITest extends AbstractIntegrationTest {
 
             assertThat(appearance.getAttendanceAuditNumber()).isNotNull();
 
+            auditNumberMap.putIfAbsent(appearance.getAttendanceAuditNumber(), 0);
+            auditNumberMap.computeIfPresent(appearance.getAttendanceAuditNumber(), (k, v) -> v + 1);
+
             assertThat(appearance.getTimeIn()).as("Expect time in to not be null").isNotNull();
             assertThat(appearance.getTimeIn()).as("Expect time in to be 09:00").isEqualTo(LocalTime.parse(
                 "09:00"));
@@ -742,6 +749,9 @@ class TrialControllerITest extends AbstractIntegrationTest {
                 .as("Expect attendance type to be HALF_DAY")
                 .isEqualTo(AttendanceType.HALF_DAY);
         }
+
+        // check we have the same audit number for all the jurors
+        assertThat(auditNumberMap.values().stream().findFirst().orElse(0)).isEqualTo(4);
     }
 
     @Test

--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/TrialControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/TrialControllerITest.java
@@ -50,9 +50,9 @@ import java.net.URI;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
@@ -705,7 +705,7 @@ class TrialControllerITest extends AbstractIntegrationTest {
         List<Panel> panelList = panelRepository.findByTrialTrialNumberAndTrialCourtLocationLocCode(
             "T10000001", "415");
 
-        Map<String, Integer> auditNumberMap = new HashMap<>();
+        Map<String, Integer> auditNumberMap = new ConcurrentHashMap<>();
 
         for (Panel panel : panelList) {
             assertThat(panel.getResult()).as("Expect result to be Returned")

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/trial/TrialServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/trial/TrialServiceImpl.java
@@ -247,14 +247,16 @@ public class TrialServiceImpl implements TrialService {
         JurorStatus jurorStatus = new JurorStatus();
         jurorStatus.setStatus(IJurorStatus.RESPONDED);
 
+        // get the next available attendance number from the database sequence
+        final long attendanceAuditNumber = appearanceRepository.getNextAttendanceAuditNumber();
+
         for (Panel panel : juryMembersToBeReturned) {
 
             final String jurorNumber = panel.getJurorNumber();
             JurorPool jurorPool = PanelUtils.getAssociatedJurorPool(jurorPoolRepository, panel);
 
             if (StringUtils.isNotEmpty(returnJuryDto.getCheckIn())) {
-                // get the next available attendance number from the database sequence
-                final long attendanceAuditNumber = appearanceRepository.getNextAttendanceAuditNumber();
+
                 Appearance appearance = getJurorAppearanceForDate(jurorPool, returnJuryDto.getAttendanceDate());
 
                 // only apply check in time for those that have not been checked in yet


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://centralgovernmentcgi.atlassian.net/browse/JM-7806

### Change description ###

Update to just create one audit reference when returning a number of jurors from a trial

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
