### PR TITLE
hotfix/JM-7815 Bureau or court are unable to process an excusal

### DIFF
--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/ExcusalResponseControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/ExcusalResponseControllerITest.java
@@ -474,7 +474,7 @@ public class ExcusalResponseControllerITest extends AbstractIntegrationTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 
         JurorPool jurorPool = JurorPoolUtils.getSingleActiveJurorPool(jurorPoolRepository, jurorNumber);
-        validateExcusal(jurorPool, excusalDecisionDto, Ïlogin);
+        validateExcusal(jurorPool, excusalDecisionDto, login);
         validateExcusalLetter(excusalDecisionDto.getExcusalReasonCode());
     }
 

--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/ExcusalResponseControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/ExcusalResponseControllerITest.java
@@ -471,7 +471,11 @@ public class ExcusalResponseControllerITest extends AbstractIntegrationTest {
         RequestEntity<ExcusalDecisionDto> requestEntity = new RequestEntity<>(excusalDecisionDto, httpHeaders,
             HttpMethod.PUT, uri);
         ResponseEntity<String> response = template.exchange(requestEntity, String.class);
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        JurorPool jurorPool = JurorPoolUtils.getSingleActiveJurorPool(jurorPoolRepository, jurorNumber);
+        validateExcusal(jurorPool, excusalDecisionDto, Ïlogin);
+        validateExcusalLetter(excusalDecisionDto.getExcusalReasonCode());
     }
 
     private void validatePaperResponseExcusal(PaperResponse jurorPaperResponse, String login) {

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/ExcusalResponseServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/ExcusalResponseServiceImpl.java
@@ -89,7 +89,14 @@ public class ExcusalResponseServiceImpl implements ExcusalResponseService {
 
         if (excusalDecisionDto.getReplyMethod() != null) {
             if (excusalDecisionDto.getReplyMethod().equals(ReplyMethod.PAPER)) {
-                setPaperResponseProcessingStatusToClosed(payload, jurorNumber);
+                if (null == jurorPaperResponseRepository.findByJurorNumber(jurorNumber)) {
+                    // There are scenarios where a juror may not have a paper response when excused from the juror
+                    // record
+                    log.info(String.format("No Paper response found for Juror %s when processing excusal request",
+                        jurorNumber));
+                } else {
+                    setPaperResponseProcessingStatusToClosed(payload, jurorNumber);
+                }
             } else {
                 setDigitalResponseProcessingStatusToClosed(payload, jurorNumber);
             }

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/ExcusalResponseServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/ExcusalResponseServiceImplTest.java
@@ -325,7 +325,12 @@ public class ExcusalResponseServiceImplTest {
         Mockito.verify(jurorPoolRepository, Mockito.times(1))
             .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(any(), Mockito.anyBoolean());
 
-        verifyHappyPaperPath(payload, JUROR_NUMBER);
+        Mockito.verify(jurorPaperResponseRepository, Mockito.times(2)).findByJurorNumber(JUROR_NUMBER);
+        Mockito.verify(jurorResponseRepository, Mockito.never()).findById(JUROR_NUMBER);
+        Mockito.verify(userRepository, Mockito.times(1)).findByUsername(payload.getLogin());
+        Mockito.verify(mergeService, Mockito.times(1))
+            .mergePaperResponse(any(), any());
+        Mockito.verify(mergeService, Mockito.never()).mergeDigitalResponse(any(), any());
         verifyHappyGrantJurorPoolPathNoLetter(); // deceased jurors don't get letters
         verifyHappyExcusalLetter(jurorPool, excusalDecisionDto);
     }
@@ -396,7 +401,7 @@ public class ExcusalResponseServiceImplTest {
         Mockito.verify(jurorPoolRepository, Mockito.times(1))
             .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(any(), Mockito.anyBoolean());
 
-        Mockito.verify(jurorPaperResponseRepository, Mockito.times(1)).findByJurorNumber(JUROR_NUMBER);
+        Mockito.verify(jurorPaperResponseRepository, Mockito.times(2)).findByJurorNumber(JUROR_NUMBER);
         Mockito.verify(jurorResponseRepository, Mockito.never()).findByJurorNumber(JUROR_NUMBER);
         verifyHappyExcusalLetter(jurorPool, excusalDecisionDto);
     }
@@ -496,9 +501,7 @@ public class ExcusalResponseServiceImplTest {
 
         Mockito.doReturn(null).when(jurorPaperResponseRepository).findByJurorNumber(JUROR_NUMBER);
 
-        Assertions.assertThatExceptionOfType(MojException.NotFound.class)
-            .isThrownBy(() -> excusalResponseService.respondToExcusalRequest(payload, excusalDecisionDto,
-                JUROR_NUMBER));
+        excusalResponseService.respondToExcusalRequest(payload, excusalDecisionDto, JUROR_NUMBER);
 
         Mockito.verify(jurorPoolRepository, Mockito.times(1))
             .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(any(), Mockito.anyBoolean());
@@ -652,7 +655,7 @@ public class ExcusalResponseServiceImplTest {
     }
 
     private void verifyHappyPaperPath(BureauJwtPayload payload, String jurorNumber) {
-        Mockito.verify(jurorPaperResponseRepository, Mockito.times(1)).findByJurorNumber(jurorNumber);
+        Mockito.verify(jurorPaperResponseRepository, Mockito.times(2)).findByJurorNumber(jurorNumber);
         Mockito.verify(jurorResponseRepository, Mockito.never()).findById(jurorNumber);
         Mockito.verify(userRepository, Mockito.times(1)).findByUsername(payload.getLogin());
         Mockito.verify(mergeService, Mockito.times(1))
@@ -694,9 +697,6 @@ public class ExcusalResponseServiceImplTest {
         Mockito.verify(userRepository, Mockito.never()).findByUsername(payload.getLogin());
         Mockito.verify(mergeService, Mockito.never()).mergePaperResponse(any(), any());
         Mockito.verify(mergeService, Mockito.never()).mergeDigitalResponse(any(), any());
-        Mockito.verify(jurorPoolRepository, Mockito.never()).save(any());
-        Mockito.verify(jurorHistoryRepository, Mockito.never()).save(any());
-        Mockito.verify(printDataService, Mockito.never()).printExcusalDeniedLetter(any());
     }
 
     private void verifyFailedInitialChecksPath(BureauJwtPayload payload, String jurorNumber) {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://centralgovernmentcgi.atlassian.net/browse/JM-7815

### Change description ###

Update to allow juror to be excused when marked as having a paper response but it no longer is in the database or has never been entered

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
