### PR TITLE
Digital responses - Reasonable adjustments detail only displaying code on JUROR DETAILS and REASONABLE ADJ REPORT

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/bureau/service/ResponseStatusUpdateServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/bureau/service/ResponseStatusUpdateServiceImpl.java
@@ -27,9 +27,7 @@ import uk.gov.hmcts.juror.api.moj.repository.JurorStatusRepository;
 import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorDigitalResponseRepositoryMod;
 import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorReasonableAdjustmentRepository;
 import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorResponseAuditRepositoryMod;
-import uk.gov.hmcts.juror.api.moj.utils.DataUtils;
 import uk.gov.hmcts.juror.api.moj.utils.RepositoryUtils;
-import uk.gov.hmcts.juror.api.validation.ValidationConstants;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/src/main/java/uk/gov/hmcts/juror/api/bureau/service/ResponseStatusUpdateServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/bureau/service/ResponseStatusUpdateServiceImpl.java
@@ -45,7 +45,6 @@ import java.util.Objects;
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class ResponseStatusUpdateServiceImpl implements ResponseStatusUpdateService, ResponseMergeService {
     private final JurorDigitalResponseRepositoryMod jurorResponseRepository;
-    private final JurorResponseAuditRepositoryMod auditRepository;
     private final JurorPoolRepository jurorDetailsRepository;
     private final JurorStatusRepository jurorStatusRepository;
     private final JurorHistoryRepository partHistRepository;
@@ -166,27 +165,25 @@ public class ResponseStatusUpdateServiceImpl implements ResponseStatusUpdateServ
             specialNeedsByJurorNumber.size()
         );
 
-        if (specialNeedsByJurorNumber != null) {
-            //if multiple set need to M
-            if (specialNeedsByJurorNumber.size() > 1) {
-                jurorDetails.getJuror().setReasonableAdjustmentCode("M");
-            } else if (specialNeedsByJurorNumber.size() == 1
-                && specialNeedsByJurorNumber.get(0) != null) {
-                jurorDetails.getJuror()
-                    .setReasonableAdjustmentCode(specialNeedsByJurorNumber.get(0).getReasonableAdjustment().getCode());
-            }
+        //if multiple set need to M
+        if (specialNeedsByJurorNumber.size() > 1) {
+            jurorDetails.getJuror().setReasonableAdjustmentCode("M");
+        } else if (specialNeedsByJurorNumber.size() == 1
+            && specialNeedsByJurorNumber.get(0) != null) {
             jurorDetails.getJuror()
-                .setReasonableAdjustmentMessage(jurorDetails.getJuror().getJurorResponse().getReasonableAdjustmentsArrangements());
-
-            log.debug("Merging special need information  for juror {}, Special need {}", jurorDetails.getJurorNumber(),
-                //   poolDetails.getSpecialNeed()
-                jurorDetails.getJuror().getReasonableAdjustmentMessage()
-            );
-
-            jurorDetailsRepository.save(jurorDetails);// save the updated pool table data
-
-            log.debug("Merged special need information  for juror {}", jurorDetails.getJurorNumber());
+                .setReasonableAdjustmentCode(specialNeedsByJurorNumber.get(0).getReasonableAdjustment().getCode());
         }
+        jurorDetails.getJuror()
+            .setReasonableAdjustmentMessage(updatedDetails.getReasonableAdjustmentsArrangements());
+
+        log.debug("Merging special need information  for juror {}, Special need {}", jurorDetails.getJurorNumber(),
+            //   poolDetails.getSpecialNeed()
+            jurorDetails.getJuror().getReasonableAdjustmentMessage()
+        );
+
+        jurorDetailsRepository.save(jurorDetails);// save the updated pool table data
+
+        log.debug("Merged special need information  for juror {}", jurorDetails.getJurorNumber());
 
         if ("deceased".equalsIgnoreCase(originalDetails.getThirdPartyReason())) {
             log.info("Third party deceased flow.");

--- a/src/main/java/uk/gov/hmcts/juror/api/bureau/service/ResponseStatusUpdateServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/bureau/service/ResponseStatusUpdateServiceImpl.java
@@ -170,24 +170,13 @@ public class ResponseStatusUpdateServiceImpl implements ResponseStatusUpdateServ
             //if multiple set need to M
             if (specialNeedsByJurorNumber.size() > 1) {
                 jurorDetails.getJuror().setReasonableAdjustmentCode("M");
-                jurorDetails.getJuror()
-                    .setReasonableAdjustmentMessage(
-                        DataUtils.trimToLength(
-                            specialNeedsByJurorNumber
-                                .stream()
-                                .reduce(
-                                    "",
-                                    (acc, item) -> acc + item.getReasonableAdjustmentDetail() + ", ",
-                                    String::concat
-                                ).trim(),
-                            ValidationConstants.REASONABLE_ADJUSTMENT_MESSAGE_LENGTH_MAX));
             } else if (specialNeedsByJurorNumber.size() == 1
                 && specialNeedsByJurorNumber.get(0) != null) {
                 jurorDetails.getJuror()
                     .setReasonableAdjustmentCode(specialNeedsByJurorNumber.get(0).getReasonableAdjustment().getCode());
-                jurorDetails.getJuror()
-                    .setReasonableAdjustmentMessage(specialNeedsByJurorNumber.get(0).getReasonableAdjustmentDetail());
             }
+            jurorDetails.getJuror()
+                .setReasonableAdjustmentMessage(jurorDetails.getJuror().getJurorResponse().getReasonableAdjustmentsArrangements());
 
             log.debug("Merging special need information  for juror {}, Special need {}", jurorDetails.getJurorNumber(),
                 //   poolDetails.getSpecialNeed()

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/JurorPaperResponseServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/JurorPaperResponseServiceImpl.java
@@ -520,6 +520,7 @@ public class JurorPaperResponseServiceImpl implements JurorPaperResponseService 
                 Juror juror = jurorRepository.findByJurorNumber(jurorNumber);
                 juror.setReasonableAdjustmentCode(type);
                 juror.setReasonableAdjustmentMessage(message);
+                jurorPaperResponse.setReasonableAdjustmentsArrangements(message);
             });
 
 

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/SummonsReplyStatusUpdateServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/SummonsReplyStatusUpdateServiceImpl.java
@@ -431,21 +431,11 @@ public class SummonsReplyStatusUpdateServiceImpl implements SummonsReplyStatusUp
         Juror juror = jurorPool.getJuror();
         if (reasonableAdjustments.size() > 1) {
             juror.setReasonableAdjustmentCode(multipleAdjustmentsCode);
-            juror.setReasonableAdjustmentMessage(
-                DataUtils.trimToLength(
-                    reasonableAdjustments
-                        .stream()
-                        .reduce(
-                            "",
-                            (acc, item) -> acc + item.getReasonableAdjustmentDetail() + ", ",
-                            String::concat
-                        ).trim(),
-                    ValidationConstants.REASONABLE_ADJUSTMENT_MESSAGE_LENGTH_MAX));
         } else if (reasonableAdjustments.size() == 1 && reasonableAdjustments.get(0) != null) {
             juror.setReasonableAdjustmentCode(reasonableAdjustments.get(0).getReasonableAdjustment().getCode());
-            juror.setReasonableAdjustmentMessage(reasonableAdjustments.get(0).getReasonableAdjustmentDetail());
         }
-
+        juror
+            .setReasonableAdjustmentMessage(juror.getJurorResponse().getReasonableAdjustmentsArrangements());
         jurorPoolRepository.save(jurorPool);
         log.trace("Juror: {}. Exit mergeReasonableAdjustments", jurorNumber);
     }

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/SummonsReplyStatusUpdateServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/SummonsReplyStatusUpdateServiceImplTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.juror.api.moj.service;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -34,6 +35,7 @@ import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorPaperResponseRep
 import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorReasonableAdjustmentRepository;
 import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorResponseAuditRepositoryMod;
 import uk.gov.hmcts.juror.api.moj.service.jurormanagement.JurorAuditChangeService;
+import uk.gov.hmcts.juror.api.moj.service.summonsmanagement.JurorResponseService;
 
 import java.text.ParseException;
 import java.time.LocalDate;
@@ -54,6 +56,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 @RunWith(SpringRunner.class)
 @SuppressWarnings({"PMD.ExcessiveImports", "PMD.CouplingBetweenObjects"})
@@ -84,9 +87,18 @@ public class SummonsReplyStatusUpdateServiceImplTest {
     private JurorRecordService jurorRecordService;
     @Mock
     private JurorAuditChangeService jurorAuditChangeService;
+    @Mock
+    private JurorResponseService jurorResponseService;
 
     @InjectMocks
     private SummonsReplyStatusUpdateServiceImpl summonsReplyStatusUpdateService;
+
+    @Before
+    public void setUp() {
+        when(jurorResponseService.getCommonJurorResponseOptional(anyString()))
+            .thenReturn(Optional.empty());
+        summonsReplyStatusUpdateService.jurorResponseService = jurorResponseService;
+    }
 
     //Interface method: updateJurorResponseStatus
     @Test


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7821)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=613)


### Change description ###
Digital responses are not populating reasonable adjustments correctly - only code is displayed on JUROR DETAILS and REASONABLE ADJUSTMENT REPORT. Note - paper responses is fine.

!image-20240717-095546.png|width=1245,height=747,alt="image-20240717-095546.png"!



!image-20240717-095649.png|width=1306,height=739,alt="image-20240717-095649.png"!



!image-20240717-095739.png|width=1339,height=614,alt="image-20240717-095739.png"!

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
