### PR TITLE
Confirming the day for a primary court marks satellite court jurors as absent if they are not checked in  

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/IAppearanceRepositoryImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/IAppearanceRepositoryImpl.java
@@ -112,7 +112,7 @@ public class IAppearanceRepositoryImpl implements IAppearanceRepository {
             .from(JUROR)
             .join(JUROR_POOL)
             .on(JUROR.jurorNumber.eq(JUROR_POOL.juror.jurorNumber))
-            .where(JUROR_POOL.owner.eq(commonData.getLocationCode()))
+            .where(JUROR_POOL.pool.courtLocation.locationAddress.eq(commonData.getLocationCode()))
             .where(JUROR_POOL.nextDate.eq(commonData.getAttendanceDate()))
             .where(JUROR_POOL.status.status.eq(IJurorStatus.RESPONDED))
             .where(JUROR.jurorNumber.notIn(


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7887)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=%pullRequestNumber%)


### Change description ###
Data fix needed for today.
Code fix needed for next release.
Second dada fix for after release.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
