### PR TITLE
Refusing a juror in Def Maintenance If refusing a juror in Def Maint

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/DeferralResponseServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/DeferralResponseServiceImpl.java
@@ -102,7 +102,7 @@ public class DeferralResponseServiceImpl implements DeferralResponseService {
                                              JurorPool jurorPool) {
 
         boolean isInDeferralMaintenance = jurorPool.getStatus().getStatus() == IJurorStatus.DEFERRED;
-
+        final Juror juror = jurorPool.getJuror();
         String username = payload.getLogin();
         //If juror is in deferral maintenance, we should not revert the existing (granted) deferral
         if (!isInDeferralMaintenance) {
@@ -115,13 +115,13 @@ public class DeferralResponseServiceImpl implements DeferralResponseService {
             jurorPool.setNextDate(jurorPool.getPool().getReturnDate());
             jurorPoolRepository.save(jurorPool);
 
-            Juror juror = jurorPool.getJuror();
             juror.setResponded(true);
             juror.setUserEdtq(username);
-            juror.setExcusalRejected(DEFERRAL_REJECTED_CODE);
             juror.setExcusalDate(null);
-            jurorRepository.save(juror);
         }
+        juror.setExcusalRejected(DEFERRAL_REJECTED_CODE);
+        jurorRepository.save(juror);
+
         // update Juror History - create deferral denied status event
         JurorHistory jurorHistory = JurorHistory.builder()
             .jurorNumber(jurorPool.getJurorNumber())

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/DeferralResponseServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/DeferralResponseServiceImpl.java
@@ -116,9 +116,9 @@ public class DeferralResponseServiceImpl implements DeferralResponseService {
             jurorPoolRepository.save(jurorPool);
 
             juror.setResponded(true);
-            juror.setUserEdtq(username);
             juror.setExcusalDate(null);
         }
+        juror.setUserEdtq(username);
         juror.setExcusalRejected(DEFERRAL_REJECTED_CODE);
         jurorRepository.save(juror);
 

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/DeferralResponseServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/DeferralResponseServiceImpl.java
@@ -101,24 +101,27 @@ public class DeferralResponseServiceImpl implements DeferralResponseService {
     private void declineDeferralForJurorPool(BureauJwtPayload payload, DeferralRequestDto deferralRequestDto,
                                              JurorPool jurorPool) {
 
+        boolean isInDeferralMaintenance = jurorPool.getStatus().getStatus() == IJurorStatus.DEFERRED;
+
         String username = payload.getLogin();
+        //If juror is in deferral maintenance, we should not revert the existing (granted) deferral
+        if (!isInDeferralMaintenance) {
+            JurorStatus jurorStatus = new JurorStatus();
+            jurorStatus.setStatus(IJurorStatus.RESPONDED);
+            jurorPool.setStatus(jurorStatus);
+            jurorPool.setUserEdtq(username);
+            jurorPool.setDeferralCode(deferralRequestDto.getDeferralReason());
+            jurorPool.setDeferralDate(null);
+            jurorPool.setNextDate(jurorPool.getPool().getReturnDate());
+            jurorPoolRepository.save(jurorPool);
 
-        JurorStatus jurorStatus = new JurorStatus();
-        jurorStatus.setStatus(IJurorStatus.RESPONDED);
-        jurorPool.setStatus(jurorStatus);
-        jurorPool.setUserEdtq(username);
-        jurorPool.setDeferralCode(deferralRequestDto.getDeferralReason());
-        jurorPool.setDeferralDate(null);
-        jurorPool.setNextDate(jurorPool.getPool().getReturnDate());
-        jurorPoolRepository.save(jurorPool);
-
-        Juror juror = jurorPool.getJuror();
-        juror.setResponded(true);
-        juror.setUserEdtq(username);
-        juror.setExcusalRejected(DEFERRAL_REJECTED_CODE);
-        juror.setExcusalDate(null);
-        jurorRepository.save(juror);
-
+            Juror juror = jurorPool.getJuror();
+            juror.setResponded(true);
+            juror.setUserEdtq(username);
+            juror.setExcusalRejected(DEFERRAL_REJECTED_CODE);
+            juror.setExcusalDate(null);
+            jurorRepository.save(juror);
+        }
         // update Juror History - create deferral denied status event
         JurorHistory jurorHistory = JurorHistory.builder()
             .jurorNumber(jurorPool.getJurorNumber())


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7863)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=638)


### Change description ###
In Deferral maintenance, removing a Juror from a pool that has already been moved to the court puts the Juror in “no mans land”

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
