### PR TITLE
Expenses long day flag not updated when a attendance is added in the past (future attendances should get updated)

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceImpl.java
@@ -524,6 +524,7 @@ public class JurorAppearanceServiceImpl implements JurorAppearanceService {
             .isDraftExpense(true)
             .createdBy(payload.getLogin())
             .build();
+        appearanceRepository.save(appearance);
         realignAttendanceType(appearance);
         jurorExpenseService.applyDefaultExpenses(appearance, jurorPool.getJuror());
         appearanceRepository.saveAndFlush(appearance);

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceImpl.java
@@ -524,7 +524,6 @@ public class JurorAppearanceServiceImpl implements JurorAppearanceService {
             .isDraftExpense(true)
             .createdBy(payload.getLogin())
             .build();
-        appearanceRepository.save(appearance);
         realignAttendanceType(appearance);
         jurorExpenseService.applyDefaultExpenses(appearance, jurorPool.getJuror());
         appearanceRepository.saveAndFlush(appearance);
@@ -624,7 +623,6 @@ public class JurorAppearanceServiceImpl implements JurorAppearanceService {
             }
 
             appearance.setAppearanceStage(AppearanceStage.EXPENSE_ENTERED);
-            appearanceRepository.save(appearance);
             realignAttendanceType(appearance);
             appearance.setAppearanceConfirmed(Boolean.TRUE);
 
@@ -1216,6 +1214,7 @@ public class JurorAppearanceServiceImpl implements JurorAppearanceService {
 
     @Override
     public void realignAttendanceType(Appearance appearance) {
+        appearanceRepository.save(appearance);
         realignAttendanceType(appearance.getJurorNumber());
     }
 


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7895)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=640)


### Change description ###


Expenses showing a "£0" Balance - Payment capped at £64.95 after 10 days. Unable to authorise payments

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
