### PR TITLE
Pool request received after go live, however wont create it

### DIFF
--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/CreatePoolControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/CreatePoolControllerITest.java
@@ -1588,7 +1588,7 @@ public class CreatePoolControllerITest extends AbstractIntegrationTest {
         RequestEntity<PoolCreateRequestDto> requestEntity = new RequestEntity<>(poolCreateRequest, httpHeaders,
             HttpMethod.POST, uri);
         ResponseEntity<String> response = template.exchange(requestEntity, String.class);
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     private void confirmCoronerPoolRecordAsExpected(CoronerPoolItemDto coronerPoolItemDto) {

--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/domain/PoolCreateITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/domain/PoolCreateITest.java
@@ -46,7 +46,7 @@ public class PoolCreateITest extends ContainerTest {
                 "CH1,CH2,CH3",
                 "N");
             assertThat(resultSet).isNotEmpty();
-            assertThat(resultSet.size()).isEqualTo(6); // should be 5 * 1.2 = 6
+            assertThat(resultSet.size()).isEqualTo(7); // should be 5 * 1.4 = 7
         } catch (SQLException e) {
             log.error("Unexpected error", e);
             fail("Unexpected error", e);

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/JurorManagementController.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/JurorManagementController.java
@@ -41,7 +41,6 @@ import uk.gov.hmcts.juror.api.moj.controller.response.jurormanagement.Attendance
 import uk.gov.hmcts.juror.api.moj.enumeration.jurormanagement.JurorStatusGroup;
 import uk.gov.hmcts.juror.api.moj.exception.MojException;
 import uk.gov.hmcts.juror.api.moj.service.jurormanagement.JurorAppearanceService;
-import uk.gov.hmcts.juror.api.moj.utils.DataUtils;
 import uk.gov.hmcts.juror.api.validation.CourtLocationCode;
 
 import java.time.LocalDate;

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/JurorManagementController.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/JurorManagementController.java
@@ -41,6 +41,7 @@ import uk.gov.hmcts.juror.api.moj.controller.response.jurormanagement.Attendance
 import uk.gov.hmcts.juror.api.moj.enumeration.jurormanagement.JurorStatusGroup;
 import uk.gov.hmcts.juror.api.moj.exception.MojException;
 import uk.gov.hmcts.juror.api.moj.service.jurormanagement.JurorAppearanceService;
+import uk.gov.hmcts.juror.api.moj.utils.DataUtils;
 import uk.gov.hmcts.juror.api.validation.CourtLocationCode;
 
 import java.time.LocalDate;

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/exception/MojException.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/exception/MojException.java
@@ -91,7 +91,9 @@ public class MojException extends RuntimeException {
             JUROR_DATE_OF_BIRTH_REQUIRED,
             INVALID_APPEARANCES_STATUS,
             DATA_IS_OUT_OF_DATE,
-            JUROR_HAS_BEEN_DEFERRED_BEFORE
+            JUROR_HAS_BEEN_DEFERRED_BEFORE,
+            COULD_NOT_FIND_ENOUGH_VOTERS,
+            COULD_NOT_FIND_ENOUGH_ELIGIBLE_VOTERS
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/PoolCreateServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/PoolCreateServiceImpl.java
@@ -400,7 +400,9 @@ public class PoolCreateServiceImpl implements PoolCreateService {
 
             // throw an exception if we couldn't find the required number of voters
             if (size < poolCreateRequestDto.getCitizensToSummon()) {
-                throw new RuntimeException();
+                throw new MojException.BusinessRuleViolation(
+                    "Not enough voters found to create a pool",
+                    MojException.BusinessRuleViolation.ErrorCode.COULD_NOT_FIND_ENOUGH_VOTERS);
             }
 
             int sequenceNumber =
@@ -435,7 +437,9 @@ public class PoolCreateServiceImpl implements PoolCreateService {
             }
 
             if (jurorsFound < poolCreateRequestDto.getCitizensToSummon()) {
-                throw new RuntimeException(); // we were unable to find the required number of jurors who can serve.
+                throw new MojException.BusinessRuleViolation(
+                    "Not enough eligible voters found to create a pool",
+                    MojException.BusinessRuleViolation.ErrorCode.COULD_NOT_FIND_ENOUGH_ELIGIBLE_VOTERS);
             }
 
             // Saving records (bulk)

--- a/src/main/resources/db/migrationv2/V2_13__summoning_updates.sql
+++ b/src/main/resources/db/migrationv2/V2_13__summoning_updates.sql
@@ -4,7 +4,6 @@ alter table juror_mod.voters
     drop column postcode_start,
     add column postcode_start VARCHAR(10) generated always as (split_part(zip, ' ', 1)) stored;
 
-DROP INDEX juror_mod.voters_postcode_start_idx;
 CREATE INDEX voters_postcode_start_idx ON juror_mod.voters (postcode_start,loc_code,perm_disqual,flags,dob);
 
 

--- a/src/main/resources/db/migrationv2/V2_13__summoning_updates.sql
+++ b/src/main/resources/db/migrationv2/V2_13__summoning_updates.sql
@@ -1,0 +1,30 @@
+drop function juror_mod.get_voters(bigint,text, text, text, text, text);
+
+alter table juror_mod.voters
+    drop column postcode_start,
+    add column postcode_start VARCHAR(10) generated always as (split_part(zip, ' ', 1)) stored;
+
+DROP INDEX juror_mod.voters_postcode_start_idx;
+CREATE INDEX voters_postcode_start_idx ON juror_mod.voters (postcode_start,loc_code,perm_disqual,flags,dob);
+
+
+
+CREATE OR REPLACE FUNCTION juror_mod.get_voters(p_required bigint, p_mindate date, p_maxdate date, p_loccode text, p_areacode_list text, p_pool_type text)
+ RETURNS TABLE(part_number character varying, juror_flags character varying)
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+AS $function$
+DECLARE
+begin
+    return query select part_no, flags from juror_mod.voters
+                 where loc_code=p_LocCode and date_selected1 is null
+                   and ((dob is null) or dob > p_minDate and dob < p_maxDate)
+                   and perm_disqual is null
+                   and (postcode_start in (select unnest(string_to_array(p_areacode_list, ',')))) -- specified postcode areas
+                   and (flags is null or p_pool_type = 'N') -- only coroner pools check flag
+                 order by random()
+                 limit p_required*1.4; -- grab 40% more than requested to allow for jurors with flags
+
+END;
+$function$
+;


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7860)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=641)


### Change description ###
Its put a pool flag on there because it thinks someone else is using this data. How do we remove this as we used to do it locally?
Pools effected
479240903
424240903



CW I checked the voters_lock on the court location table @ 22:50,  court 411 is locked, all other courts are unlocked. I suggest ask the Bureau to try again.

UPDATE 18/07 - This has not worked

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
