### PR TITLE
Juror history links need updating

### DIFF
--- a/src/main/resources/db/migrationv2/V2_18__update_t_history_code_AJUR_template.sql
+++ b/src/main/resources/db/migrationv2/V2_18__update_t_history_code_AJUR_template.sql
@@ -1,0 +1,5 @@
+UPDATE juror_mod.t_history_code
+SET template = 'Attendance date {other_info_date:d MMM yyyy}
+Trial {other_information}
+Jury attendance audit report {other_info_reference}'
+WHERE history_code = 'AJUR';


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7813)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=660)


### Change description ###
The Juror history screen shows links to trials and attendance audits but the URL points to financial-audit. This needs updating on the FE to point to correct URL.

!image-20240716-170302.png|width=932,height=780,alt="image-20240716-170302.png"!

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
