### PR TITLE
Wrong error message when adding attendance on absent day

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -281,7 +281,7 @@ pmdTest {
     maxFailures = 298
 }
 pmdMain {
-    maxFailures = 798
+    maxFailures = 794
 }
 pmd {
     maxFailures = 0

--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorManagementControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorManagementControllerITest.java
@@ -175,8 +175,8 @@ class JurorManagementControllerITest extends AbstractIntegrationTest {
 
         // verify attendance record has been added
         Optional<Appearance> appearanceOpt =
-            appearanceRepository.findByJurorNumberAndPoolNumberAndAttendanceDate(requestDto.getJurorNumber(),
-                requestDto.getPoolNumber(), requestDto.getAttendanceDate());
+            appearanceRepository.findByLocCodeAndJurorNumberAndAttendanceDate(
+                "415", requestDto.getJurorNumber(), requestDto.getAttendanceDate());
         assertThat(appearanceOpt).isNotEmpty();
         Appearance appearance = appearanceOpt.get();
         assertThat(appearance.getJurorNumber()).isEqualTo(requestDto.getJurorNumber());
@@ -210,8 +210,8 @@ class JurorManagementControllerITest extends AbstractIntegrationTest {
 
         // verify attendance record has been added
         Optional<Appearance> appearanceOpt =
-            appearanceRepository.findByJurorNumberAndPoolNumberAndAttendanceDate(requestDto.getJurorNumber(),
-                requestDto.getPoolNumber(), requestDto.getAttendanceDate());
+            appearanceRepository.findByLocCodeAndJurorNumberAndAttendanceDate(
+                "415", requestDto.getJurorNumber(), requestDto.getAttendanceDate());
         assertThat(appearanceOpt).isNotEmpty();
         Appearance appearance = appearanceOpt.get();
         assertThat(appearance.getJurorNumber()).isEqualTo(requestDto.getJurorNumber());
@@ -1629,8 +1629,8 @@ class JurorManagementControllerITest extends AbstractIntegrationTest {
 
             // verify non-attendance record has been added
             Optional<Appearance> appearanceOpt =
-                appearanceRepository.findByJurorNumberAndPoolNumberAndAttendanceDate(request.getJurorNumber(),
-                    "415230101", request.getNonAttendanceDate());
+                appearanceRepository.findByLocCodeAndJurorNumberAndAttendanceDate(
+                    "415", request.getJurorNumber(), request.getNonAttendanceDate());
             assertThat(appearanceOpt).isNotEmpty();
             Appearance appearance = appearanceOpt.get();
             assertThat(appearance.getJurorNumber()).isEqualTo(request.getJurorNumber());
@@ -1663,8 +1663,8 @@ class JurorManagementControllerITest extends AbstractIntegrationTest {
 
             // verify non-attendance record has been added
             Optional<Appearance> appearanceOpt =
-                appearanceRepository.findByJurorNumberAndPoolNumberAndAttendanceDate(request.getJurorNumber(),
-                    "415230101", request.getNonAttendanceDate());
+                appearanceRepository.findByLocCodeAndJurorNumberAndAttendanceDate(
+                    "415", request.getJurorNumber(), request.getNonAttendanceDate());
             assertThat(appearanceOpt).isNotEmpty();
             Appearance appearance = appearanceOpt.get();
             assertThat(appearance.getJurorNumber()).isEqualTo(request.getJurorNumber());
@@ -1697,8 +1697,8 @@ class JurorManagementControllerITest extends AbstractIntegrationTest {
 
             // verify non-attendance record has been added
             Optional<Appearance> appearanceOpt =
-                appearanceRepository.findByJurorNumberAndPoolNumberAndAttendanceDate(request.getJurorNumber(),
-                    "415230101", request.getNonAttendanceDate());
+                appearanceRepository.findByLocCodeAndJurorNumberAndAttendanceDate(
+                    "415", request.getJurorNumber(), request.getNonAttendanceDate());
             assertThat(appearanceOpt).isNotEmpty();
             Appearance appearance = appearanceOpt.get();
             assertThat(appearance.getJurorNumber()).isEqualTo(request.getJurorNumber());
@@ -1755,8 +1755,8 @@ class JurorManagementControllerITest extends AbstractIntegrationTest {
 
             // verify non-attendance record has been added
             Optional<Appearance> appearanceOpt =
-                appearanceRepository.findByJurorNumberAndPoolNumberAndAttendanceDate(request.getJurorNumber(),
-                    "415230101", request.getNonAttendanceDate());
+                appearanceRepository.findByLocCodeAndJurorNumberAndAttendanceDate(
+                    "415", request.getJurorNumber(), request.getNonAttendanceDate());
             assertThat(appearanceOpt).isNotEmpty();
             Appearance appearance = appearanceOpt.get();
             assertThat(appearance.getJurorNumber()).isEqualTo(request.getJurorNumber());
@@ -1832,8 +1832,8 @@ class JurorManagementControllerITest extends AbstractIntegrationTest {
             assertThat(response.getStatusCode()).as("HTTP status created expected").isEqualTo(CREATED);
 
             Optional<Appearance> appearanceOpt =
-                appearanceRepository.findByJurorNumberAndPoolNumberAndAttendanceDate(request.getJurorNumber(),
-                    "415230101", request.getNonAttendanceDate());
+                appearanceRepository.findByLocCodeAndJurorNumberAndAttendanceDate(
+                    "415", request.getJurorNumber(), request.getNonAttendanceDate());
             assertThat(appearanceOpt).isNotEmpty();
             Appearance appearance = appearanceOpt.get();
             assertThat(appearance.getJurorNumber()).isEqualTo(request.getJurorNumber());
@@ -1923,8 +1923,8 @@ class JurorManagementControllerITest extends AbstractIntegrationTest {
 
             // verify attendance records have been updated
             Optional<Appearance> appearanceOpt =
-                appearanceRepository.findByJurorNumberAndPoolNumberAndAttendanceDate("222222222",
-                    "415230101", now().minusDays(2));
+                appearanceRepository.findByLocCodeAndJurorNumberAndAttendanceDate(
+                    "415", "222222222", now().minusDays(2));
             assertThat(appearanceOpt).isNotEmpty();
             Appearance appearance = appearanceOpt.get();
             assertThat(appearance.getTimeIn()).isEqualTo(LocalTime.of(9, 30));
@@ -1934,8 +1934,8 @@ class JurorManagementControllerITest extends AbstractIntegrationTest {
             assertThat(appearance.getSatOnJury()).isTrue();
             assertThat(appearance.isAppearanceConfirmed()).isTrue();
 
-            appearanceOpt = appearanceRepository.findByJurorNumberAndPoolNumberAndAttendanceDate(
-                "333333333", "415230101", now().minusDays(2));
+            appearanceOpt = appearanceRepository.findByLocCodeAndJurorNumberAndAttendanceDate(
+                "415", "333333333", now().minusDays(2));
             assertThat(appearanceOpt).isNotEmpty();
             appearance = appearanceOpt.get();
             assertThat(appearance.getTimeIn()).isEqualTo(LocalTime.of(9, 30));

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/AppearanceRepository.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/AppearanceRepository.java
@@ -50,9 +50,6 @@ public interface AppearanceRepository extends IAppearanceRepository, JpaReposito
                                                                                                     LocalDate attendanceDate,
                                                                                                     boolean draftExpense);
 
-    Optional<Appearance> findByJurorNumberAndPoolNumberAndAttendanceDate(String jurorNumber,
-                                                                         String poolNumber, LocalDate attendanceDate);
-
     Optional<Appearance> findByCourtLocationLocCodeAndJurorNumberAndAttendanceDate(String locCode,
                                                                                    String jurorNumber,
                                                                                    LocalDate attendanceDate);
@@ -93,4 +90,6 @@ public interface AppearanceRepository extends IAppearanceRepository, JpaReposito
 
     Optional<Appearance> findFirstByAttendanceAuditNumberEqualsAndLocCodeIn(String auditNumber,
                                                                             Collection<String> locCode);
+
+    Optional<Appearance> findByLocCodeAndJurorNumberAndAttendanceDate(String locCode, String jurorNumber, LocalDate attendanceDate);
 }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceImpl.java
@@ -105,6 +105,10 @@ public class JurorAppearanceServiceImpl implements JurorAppearanceService {
             () -> new MojException.NotFound("Court location not found", null));
 
         JurorAppearanceDto appearanceDto = dto.getJurorAppearanceDto();
+        if (hasAttendance(dto.getLocationCode(), jurorNumber, appearanceDto.getAttendanceDate())) {
+            throw new MojException.BusinessRuleViolation("Attendance record already exists",
+                ATTENDANCE_RECORD_ALREADY_EXISTS);
+        }
         processAppearance(payload, appearanceDto, true, isCompleted);
 
         // Read the newly created appearance record
@@ -125,6 +129,10 @@ public class JurorAppearanceServiceImpl implements JurorAppearanceService {
         appearanceRepository.saveAndFlush(appearance);
     }
 
+    private boolean hasAttendance(String locCode, String jurorNumber, LocalDate attendanceDate) {
+        return appearanceRepository.findByLocCodeAndJurorNumberAndAttendanceDate(locCode, jurorNumber, attendanceDate)
+            .isPresent();
+    }
 
     @Override
     @Transactional
@@ -650,21 +658,19 @@ public class JurorAppearanceServiceImpl implements JurorAppearanceService {
     }
 
     private void checkExistingAttendance(JurorNonAttendanceDto request, LocalDate nonAttendanceDate) {
-        // check if there is already an appearance record for the juror for the non-attendance date
+        final String locCode = request.getLocationCode();
         final String jurorNumber = request.getJurorNumber();
-        appearanceRepository.findByJurorNumberAndPoolNumberAndAttendanceDate(jurorNumber, request.getPoolNumber(),
-                nonAttendanceDate)
+        // check if there is already an appearance record for the juror for the non-attendance date
+        appearanceRepository.findByLocCodeAndJurorNumberAndAttendanceDate(locCode, jurorNumber, nonAttendanceDate)
             .ifPresent(appearance -> {
                 if (appearance.getAppearanceStage() != null) {
                     throw new MojException.BusinessRuleViolation("Juror " + jurorNumber + " already has an "
                         + "attendance record for the date " + nonAttendanceDate, ATTENDANCE_RECORD_ALREADY_EXISTS);
                 }
-
                 if (appearance.getNoShow() != null && appearance.getNoShow()) {
                     // this record will get replaced with the new non-attendance record
                     appearanceRepository.delete(appearance);
-                    log.info("Deleted existing no-show record for juror " + jurorNumber + " on date "
-                        + nonAttendanceDate);
+                    log.info("Deleted existing no-show record for juror {} on date {}", jurorNumber, nonAttendanceDate);
                 }
             });
     }

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceServiceTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.juror.api.TestConstants;
 import uk.gov.hmcts.juror.api.TestUtils;
@@ -294,9 +293,9 @@ class JurorAppearanceServiceTest {
             appearanceDtoCaptor.capture(), eq(true), eq(false));
         verify(courtLocationRepository, times(1)).findByLocCode(LOC_415);
         verify(appearanceRepository, times(1)).findById(appearanceId);
-        verify(jurorHistoryService, times(1)).createPoolAttendanceHistory(Mockito.any(), Mockito.any());
-        verify(jurorExpenseService, times(1)).applyDefaultExpenses(Mockito.anyList());
-        verify(appearanceRepository, times(1)).saveAndFlush(Mockito.any(Appearance.class));
+        verify(jurorHistoryService, times(1)).createPoolAttendanceHistory(any(), any());
+        verify(jurorExpenseService, times(1)).applyDefaultExpenses(anyList());
+        verify(appearanceRepository, times(1)).saveAndFlush(any(Appearance.class));
 
         BureauJwtPayload payload = payloadArgumentCaptor.getValue();
         assertThat(payload.getOwner()).isEqualTo(OWNER_415);
@@ -334,7 +333,8 @@ class JurorAppearanceServiceTest {
             jurorAppearanceService.addAttendanceDay(buildPayload(OWNER_415, List.of("415", "462", "767")),
                 dto)).as("Requested attendance date is in the future.");
 
-        verify(appearanceRepository, never()).findByJurorNumberAndPoolNumberAndAttendanceDate(any(), any(), any());
+        verify(appearanceRepository, never())
+            .findByLocCodeAndJurorNumberAndAttendanceDate(any(), any(), any());
         verify(jurorRepository, never()).findByJurorNumber(any());
         verify(jurorPoolRepository, never()).save(any());
     }
@@ -1512,7 +1512,7 @@ class JurorAppearanceServiceTest {
 
             CourtLocation courtLocation = new CourtLocation();
             courtLocation.setOwner("415");
-            when(courtLocationRepository.findById(Mockito.any())).thenReturn(Optional.of(courtLocation));
+            when(courtLocationRepository.findById(any())).thenReturn(Optional.of(courtLocation));
 
             when(jurorPoolRepository.findJurorsInAttendanceAtCourtLocation(VALID_COURT_LOCATION,
                 pools)).thenReturn(jurorPools);
@@ -1542,8 +1542,8 @@ class JurorAppearanceServiceTest {
             jurorsToDismissTuples.add(t2);
             jurorsToDismissTuples.add(t3);
 
-            when(jurorPoolRepository.getJurorsToDismiss(Mockito.anyList(), Mockito.anyList(),
-                Mockito.anyString()))
+            when(jurorPoolRepository.getJurorsToDismiss(
+                anyList(), anyList(), anyString()))
                 .thenReturn(jurorsToDismissTuples);
 
 
@@ -1594,7 +1594,7 @@ class JurorAppearanceServiceTest {
 
             CourtLocation courtLocation = new CourtLocation();
             courtLocation.setOwner("415");
-            when(courtLocationRepository.findById(Mockito.any())).thenReturn(Optional.of(courtLocation));
+            when(courtLocationRepository.findById(any())).thenReturn(Optional.of(courtLocation));
 
             when(jurorPoolRepository.findJurorsInAttendanceAtCourtLocation(VALID_COURT_LOCATION,
                 pools)).thenReturn(jurorPools);
@@ -1615,8 +1615,8 @@ class JurorAppearanceServiceTest {
             jurorsToDismissTuples.add(t1);
             jurorsToDismissTuples.add(t2);
 
-            when(jurorPoolRepository.getJurorsToDismiss(Mockito.anyList(), Mockito.anyList(),
-                Mockito.anyString()))
+            when(jurorPoolRepository.getJurorsToDismiss(
+                anyList(), anyList(), anyString()))
                 .thenReturn(jurorsToDismissTuples);
 
 
@@ -1667,7 +1667,7 @@ class JurorAppearanceServiceTest {
 
             CourtLocation courtLocation = new CourtLocation();
             courtLocation.setOwner("415");
-            when(courtLocationRepository.findById(Mockito.any())).thenReturn(Optional.of(courtLocation));
+            when(courtLocationRepository.findById(any())).thenReturn(Optional.of(courtLocation));
 
             when(jurorPoolRepository.findJurorsInAttendanceAtCourtLocation(
                 VALID_COURT_LOCATION, pools))
@@ -1691,8 +1691,8 @@ class JurorAppearanceServiceTest {
             jurorsToDismissTuples.add(t1);
             jurorsToDismissTuples.add(t3);
 
-            when(jurorPoolRepository.getJurorsToDismiss(Mockito.anyList(), Mockito.anyList(),
-                Mockito.anyString()))
+            when(jurorPoolRepository.getJurorsToDismiss(
+                anyList(), anyList(), anyString()))
                 .thenReturn(jurorsToDismissTuples);
 
 
@@ -1735,7 +1735,7 @@ class JurorAppearanceServiceTest {
 
             CourtLocation courtLocation = new CourtLocation();
             courtLocation.setOwner("415");
-            when(courtLocationRepository.findById(Mockito.any())).thenReturn(Optional.of(courtLocation));
+            when(courtLocationRepository.findById(any())).thenReturn(Optional.of(courtLocation));
 
             when(jurorPoolRepository.findJurorsInAttendanceAtCourtLocation(VALID_COURT_LOCATION,
                 pools)).thenReturn(jurorPools);
@@ -1748,8 +1748,8 @@ class JurorAppearanceServiceTest {
             List<Tuple> jurorsToDismissTuples = new ArrayList<>();
             jurorsToDismissTuples.add(t1);
 
-            when(jurorPoolRepository.getJurorsToDismiss(Mockito.anyList(), Mockito.anyList(),
-                Mockito.anyString()))
+            when(jurorPoolRepository.getJurorsToDismiss(
+                anyList(), anyList(), anyString()))
                 .thenReturn(jurorsToDismissTuples);
 
 
@@ -1789,7 +1789,7 @@ class JurorAppearanceServiceTest {
 
             CourtLocation courtLocation = new CourtLocation();
             courtLocation.setOwner("415");
-            when(courtLocationRepository.findById(Mockito.any())).thenReturn(Optional.of(courtLocation));
+            when(courtLocationRepository.findById(any())).thenReturn(Optional.of(courtLocation));
 
             when(jurorPoolRepository.findJurorsInAttendanceAtCourtLocation(
                 VALID_COURT_LOCATION, pools))
@@ -2297,15 +2297,15 @@ class JurorAppearanceServiceTest {
         JurorPool jurorPool7 = JurorPool.builder().juror(juror7).pool(poolRequest).build();
 
         doReturn(jurorPool1).when(jurorPoolRepository).findByJurorNumberAndIsActiveAndCourt(eq(JUROR1), eq(true),
-            Mockito.any());
+            any());
         doReturn(jurorPool2).when(jurorPoolRepository).findByJurorNumberAndIsActiveAndCourt(eq(JUROR2), eq(true),
-            Mockito.any());
+            any());
         doReturn(jurorPool3).when(jurorPoolRepository).findByJurorNumberAndIsActiveAndCourt(eq(JUROR3), eq(true),
-            Mockito.any());
+            any());
         doReturn(jurorPool6).when(jurorPoolRepository).findByJurorNumberAndIsActiveAndCourt(eq(JUROR6), eq(true),
-            Mockito.any());
+            any());
         doReturn(jurorPool7).when(jurorPoolRepository).findByJurorNumberAndIsActiveAndCourt(eq(JUROR7), eq(true),
-            Mockito.any());
+            any());
     }
 
 
@@ -2327,7 +2327,7 @@ class JurorAppearanceServiceTest {
             CourtLocation courtLocation = new CourtLocation();
             courtLocation.setOwner(courtOwner);
             when(courtLocationRepository.findByLocCode(courtLocationCode)).thenReturn(Optional.of(courtLocation));
-            when(courtLocationRepository.findById(Mockito.any())).thenReturn(Optional.of(courtLocation));
+            when(courtLocationRepository.findById(any())).thenReturn(Optional.of(courtLocation));
 
             PoolRequest poolRequest = PoolRequest.builder()
                 .poolNumber(poolNumber)
@@ -2355,16 +2355,17 @@ class JurorAppearanceServiceTest {
 
             LocalDate nonAttendanceDate = now();
             doReturn(Optional.empty()).when(appearanceRepository)
-                .findByJurorNumberAndPoolNumberAndAttendanceDate(jurorNumber,
-                    poolNumber, nonAttendanceDate);
+                .findByLocCodeAndJurorNumberAndAttendanceDate(
+                    courtLocationCode, jurorNumber, nonAttendanceDate);
 
             jurorAppearanceService.addNonAttendance(request);
 
             verify(courtLocationRepository, times(1)).findByLocCode(courtLocationCode);
             verify(jurorPoolRepository, times(1))
                 .findByJurorJurorNumberAndPoolPoolNumber(jurorNumber, poolNumber);
-            verify(appearanceRepository, times(1)).findByJurorNumberAndPoolNumberAndAttendanceDate(jurorNumber,
-                poolNumber, nonAttendanceDate);
+            verify(appearanceRepository, times(1))
+                .findByLocCodeAndJurorNumberAndAttendanceDate(
+                    courtLocationCode, jurorNumber, nonAttendanceDate);
             verify(appearanceRepository, times(1)).saveAndFlush(any());
         }
 
@@ -2376,7 +2377,7 @@ class JurorAppearanceServiceTest {
             CourtLocation courtLocation = new CourtLocation();
             courtLocation.setOwner(courtOwner);
             when(courtLocationRepository.findByLocCode(courtLocationCode)).thenReturn(Optional.of(courtLocation));
-            when(courtLocationRepository.findById(Mockito.any())).thenReturn(Optional.of(courtLocation));
+            when(courtLocationRepository.findById(any())).thenReturn(Optional.of(courtLocation));
 
             PoolRequest poolRequest = PoolRequest.builder()
                 .poolNumber(poolNumber)
@@ -2404,7 +2405,8 @@ class JurorAppearanceServiceTest {
 
             LocalDate nonAttendanceDate = now().plusDays(5);
             doReturn(Optional.empty()).when(appearanceRepository)
-                .findByJurorNumberAndPoolNumberAndAttendanceDate(jurorNumber, poolNumber, nonAttendanceDate);
+                .findByLocCodeAndJurorNumberAndAttendanceDate(
+                    courtLocationCode, jurorNumber, nonAttendanceDate);
 
             jurorAppearanceService.addNonAttendance(request);
 
@@ -2412,7 +2414,8 @@ class JurorAppearanceServiceTest {
             verify(jurorPoolRepository, times(1))
                 .findByJurorJurorNumberAndPoolPoolNumber(jurorNumber, poolNumber);
             verify(appearanceRepository, times(1))
-                .findByJurorNumberAndPoolNumberAndAttendanceDate(jurorNumber, poolNumber, nonAttendanceDate);
+                .findByLocCodeAndJurorNumberAndAttendanceDate(
+                    courtLocationCode, jurorNumber, nonAttendanceDate);
             verify(appearanceRepository, times(1)).saveAndFlush(any());
         }
 
@@ -2424,7 +2427,7 @@ class JurorAppearanceServiceTest {
             CourtLocation courtLocation = new CourtLocation();
             courtLocation.setOwner(courtOwner);
             when(courtLocationRepository.findByLocCode(courtLocationCode)).thenReturn(Optional.of(courtLocation));
-            when(courtLocationRepository.findById(Mockito.any())).thenReturn(Optional.of(courtLocation));
+            when(courtLocationRepository.findById(any())).thenReturn(Optional.of(courtLocation));
 
             PoolRequest poolRequest = PoolRequest.builder()
                 .poolNumber(poolNumber)
@@ -2449,8 +2452,8 @@ class JurorAppearanceServiceTest {
 
             LocalDate nonAttendanceDate = now();
             doReturn(Optional.of(appearance)).when(appearanceRepository)
-                .findByJurorNumberAndPoolNumberAndAttendanceDate(jurorNumber,
-                    poolNumber, nonAttendanceDate);
+                .findByLocCodeAndJurorNumberAndAttendanceDate(
+                    courtLocationCode, jurorNumber, nonAttendanceDate);
 
             final JurorNonAttendanceDto request = JurorNonAttendanceDto.builder()
                 .jurorNumber(jurorNumber)
@@ -2466,8 +2469,8 @@ class JurorAppearanceServiceTest {
             verify(jurorPoolRepository, times(1))
                 .findByJurorJurorNumberAndPoolPoolNumber(jurorNumber, poolNumber);
             verify(appearanceRepository, times(1))
-                .findByJurorNumberAndPoolNumberAndAttendanceDate(jurorNumber,
-                    poolNumber, nonAttendanceDate);
+                .findByLocCodeAndJurorNumberAndAttendanceDate(
+                    courtLocationCode, jurorNumber, nonAttendanceDate);
             verify(appearanceRepository, times(1)).delete(appearance);
             //verify(appearanceRepository, times(1)).saveAndFlush(appearanceSaved);
 
@@ -2511,11 +2514,12 @@ class JurorAppearanceServiceTest {
                 .withMessage("Court location " + courtLocationCode + " not found");
 
             verify(courtLocationRepository, times(1)).findByLocCode(courtLocationCode);
-            verify(courtLocationRepository, times(0)).findById(Mockito.anyString());
+            verify(courtLocationRepository, times(0)).findById(anyString());
             verify(jurorPoolRepository, times(0))
-                .findByJurorJurorNumberAndPoolPoolNumber(Mockito.anyString(), Mockito.anyString());
-            verify(appearanceRepository, times(0)).findByJurorNumberAndPoolNumberAndAttendanceDate(Mockito.anyString(),
-                Mockito.anyString(), Mockito.any());
+                .findByJurorJurorNumberAndPoolPoolNumber(anyString(), anyString());
+            verify(appearanceRepository, times(0))
+                .findByLocCodeAndJurorNumberAndAttendanceDate(
+                    anyString(), anyString(), any());
             verify(appearanceRepository, times(0)).saveAndFlush(any());
         }
 
@@ -2543,9 +2547,9 @@ class JurorAppearanceServiceTest {
             verify(courtLocationRepository, times(0)).findByLocCode("416");
             verify(courtLocationRepository, times(0)).findById("416");
             verify(jurorPoolRepository, times(0))
-                .findByJurorJurorNumberAndPoolPoolNumber(Mockito.anyString(), Mockito.anyString());
-            verify(appearanceRepository, times(0)).findByJurorNumberAndPoolNumberAndAttendanceDate(Mockito.anyString(),
-                Mockito.anyString(), Mockito.any());
+                .findByJurorJurorNumberAndPoolPoolNumber(anyString(), anyString());
+            verify(appearanceRepository, times(0))
+                .findByLocCodeAndJurorNumberAndAttendanceDate(anyString(), anyString(), any());
             verify(appearanceRepository, times(0)).saveAndFlush(any());
         }
 
@@ -2557,7 +2561,7 @@ class JurorAppearanceServiceTest {
             CourtLocation courtLocation = new CourtLocation();
             courtLocation.setOwner(courtOwner);
             when(courtLocationRepository.findByLocCode(courtLocationCode)).thenReturn(Optional.of(courtLocation));
-            when(courtLocationRepository.findById(Mockito.any())).thenReturn(Optional.of(courtLocation));
+            when(courtLocationRepository.findById(any())).thenReturn(Optional.of(courtLocation));
 
             doReturn(null).when(jurorPoolRepository)
                 .findByJurorJurorNumberAndPoolPoolNumber(jurorNumber, poolNumber);
@@ -2576,8 +2580,8 @@ class JurorAppearanceServiceTest {
             verify(courtLocationRepository, times(1)).findByLocCode(courtLocationCode);
             verify(jurorPoolRepository, times(1))
                 .findByJurorJurorNumberAndPoolPoolNumber(jurorNumber, poolNumber);
-            verify(appearanceRepository, times(0)).findByJurorNumberAndPoolNumberAndAttendanceDate(Mockito.anyString(),
-                Mockito.anyString(), Mockito.any());
+            verify(appearanceRepository, times(0))
+                .findByLocCodeAndJurorNumberAndAttendanceDate(anyString(), anyString(), any());
             verify(appearanceRepository, times(0)).saveAndFlush(any());
         }
 
@@ -2589,7 +2593,7 @@ class JurorAppearanceServiceTest {
             CourtLocation courtLocation = new CourtLocation();
             courtLocation.setOwner(courtOwner);
             when(courtLocationRepository.findByLocCode(courtLocationCode)).thenReturn(Optional.of(courtLocation));
-            when(courtLocationRepository.findById(Mockito.any())).thenReturn(Optional.of(courtLocation));
+            when(courtLocationRepository.findById(any())).thenReturn(Optional.of(courtLocation));
 
             PoolRequest poolRequest = PoolRequest.builder()
                 .poolNumber(poolNumber)
@@ -2613,8 +2617,8 @@ class JurorAppearanceServiceTest {
 
             LocalDate nonAttendanceDate = now();
             doReturn(Optional.of(appearance)).when(appearanceRepository)
-                .findByJurorNumberAndPoolNumberAndAttendanceDate(jurorNumber,
-                    poolNumber, nonAttendanceDate);
+                .findByLocCodeAndJurorNumberAndAttendanceDate(
+                    courtLocationCode, jurorNumber, nonAttendanceDate);
 
             final JurorNonAttendanceDto request = JurorNonAttendanceDto.builder()
                 .jurorNumber(jurorNumber)
@@ -2635,8 +2639,9 @@ class JurorAppearanceServiceTest {
             verify(courtLocationRepository, times(1)).findByLocCode(courtLocationCode);
             verify(jurorPoolRepository, times(1))
                 .findByJurorJurorNumberAndPoolPoolNumber(jurorNumber, poolNumber);
-            verify(appearanceRepository, times(1)).findByJurorNumberAndPoolNumberAndAttendanceDate(jurorNumber,
-                poolNumber, nonAttendanceDate);
+            verify(appearanceRepository, times(1))
+                .findByLocCodeAndJurorNumberAndAttendanceDate(
+                    courtLocationCode, jurorNumber, nonAttendanceDate);
             verify(appearanceRepository, times(0)).saveAndFlush(any());
         }
     }
@@ -3001,7 +3006,6 @@ class JurorAppearanceServiceTest {
             request.setJuror(Arrays.asList(JUROR1, JUROR2));
 
 
-
             Appearance appearance1 = Appearance.builder()
                 .jurorNumber(JUROR1)
                 .attendanceDate(request.getCommonData().getAttendanceDate())
@@ -3047,7 +3051,7 @@ class JurorAppearanceServiceTest {
 
             verify(appearanceRepository, times(2)).saveAndFlush(appearanceCaptor.capture());
             verify(jurorExpenseService, times(2)).applyDefaultExpenses(
-                appearanceCaptor.capture(), Mockito.any());
+                appearanceCaptor.capture(), any());
 
             Appearance capturedAppearance1 =
                 appearanceCaptor.getAllValues().stream()
@@ -3076,7 +3080,7 @@ class JurorAppearanceServiceTest {
             assertThat(capturedAppearance2.getAttendanceAuditNumber()).isEqualTo("J10123456");
             assertThat(capturedAppearance2.getSatOnJury()).isTrue();
 
-            verify(jurorPoolRepository, times(2)).saveAndFlush(Mockito.any());
+            verify(jurorPoolRepository, times(2)).saveAndFlush(any());
 
             verify(jurorHistoryService, times(1)).createJuryAttendanceHistory(jurorPool1,
                 capturedAppearance1, panel1);


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7904)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=661)


### Change description ###
Adding an attendance on a day a juror was absent outputs this error message

!Screenshot 2024-07-24 at 11.14.53.png|width=1089,height=518,alt="Screenshot 2024-07-24 at 11.14.53.png"!


+*Fix Applied*+
Updated add attendance day to check for pre-existing attendances and if one exists throw an error indicating such

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
