### PR TITLE
when 2 active records exist for one juror at separate courts transferred juror record status can be updated be update by actions from the other active record

### DIFF
--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/DeferralMaintenanceControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/DeferralMaintenanceControllerITest.java
@@ -406,7 +406,7 @@ public class DeferralMaintenanceControllerITest extends AbstractIntegrationTest 
                 httpHeaders, POST, URI.create(URL_PREFIX + JUROR_555555551));
 
             ResponseEntity<DeferralOptionsDto> response = template.exchange(requestEntity, DeferralOptionsDto.class);
-            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+            assertThat(response.getStatusCode()).isEqualTo(NOT_FOUND);
         }
 
         @Test
@@ -896,7 +896,7 @@ public class DeferralMaintenanceControllerITest extends AbstractIntegrationTest 
                 httpHeaders, POST, URI.create(URL_PREFIX + JUROR_555555551));
             ResponseEntity<DeferralReasonRequestDto> response = template.exchange(requestEntity,
                 DeferralReasonRequestDto.class);
-            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
         }
 
         @Test
@@ -1029,7 +1029,7 @@ public class DeferralMaintenanceControllerITest extends AbstractIntegrationTest 
             ResponseEntity<DeferralReasonRequestDto> response = template.exchange(requestEntity,
                 DeferralReasonRequestDto.class);
 
-            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
         }
 
         @Test
@@ -1261,7 +1261,7 @@ public class DeferralMaintenanceControllerITest extends AbstractIntegrationTest 
             RequestEntity<DeferralAllocateRequestDto> requestEntity = new RequestEntity<>(deferralAllocateRequestDto,
                 httpHeaders, POST, URI.create(URL));
             ResponseEntity<Void> response = template.exchange(requestEntity, Void.class);
-            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
         }
 
         private DeferralAllocateRequestDto createDeferralAllocateRequestDto(String poolNumber,
@@ -1412,7 +1412,7 @@ public class DeferralMaintenanceControllerITest extends AbstractIntegrationTest 
                 URI.create(URL_PREFIX + JUROR_123456789));
             ResponseEntity<Void> response = template.exchange(requestEntity, Void.class);
 
-            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
 
             // check to make sure no record was not deleted for the deferral maintenance table
             Optional<CurrentlyDeferred> deferral = currentlyDeferredRepository.findById(JUROR_123456789);
@@ -1679,30 +1679,13 @@ public class DeferralMaintenanceControllerITest extends AbstractIntegrationTest 
         return dto;
     }
 
-    @Override
-    protected String createJwt(String login, String owner, String... courts) {
-        return mintBureauJwt(BureauJwtPayload.builder()
-            .userLevel("1")
-            .login(login)
-            .staff(BureauJwtPayload.Staff.builder()
-                .name("Test User")
-                .active(1)
-                .rank(1)
-                .courts(List.of("415", "400"))
-                .build())
-            .owner(owner)
-            .build());
-    }
-
     protected String createJwt(String login, String owner, UserType userType) {
         return mintBureauJwt(BureauJwtPayload.builder()
-            .userLevel("1")
             .login(login)
             .userType(userType)
             .staff(BureauJwtPayload.Staff.builder()
                 .name("Test User")
                 .active(1)
-                .rank(1)
                 .courts(List.of("415", "400"))
                 .build())
             .owner(owner)

--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/DeferralMaintenanceControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/DeferralMaintenanceControllerITest.java
@@ -896,7 +896,7 @@ public class DeferralMaintenanceControllerITest extends AbstractIntegrationTest 
                 httpHeaders, POST, URI.create(URL_PREFIX + JUROR_555555551));
             ResponseEntity<DeferralReasonRequestDto> response = template.exchange(requestEntity,
                 DeferralReasonRequestDto.class);
-            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+            assertThat(response.getStatusCode()).isEqualTo(NOT_FOUND);
         }
 
         @Test
@@ -1029,7 +1029,7 @@ public class DeferralMaintenanceControllerITest extends AbstractIntegrationTest 
             ResponseEntity<DeferralReasonRequestDto> response = template.exchange(requestEntity,
                 DeferralReasonRequestDto.class);
 
-            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+            assertThat(response.getStatusCode()).isEqualTo(NOT_FOUND);
         }
 
         @Test
@@ -1261,7 +1261,7 @@ public class DeferralMaintenanceControllerITest extends AbstractIntegrationTest 
             RequestEntity<DeferralAllocateRequestDto> requestEntity = new RequestEntity<>(deferralAllocateRequestDto,
                 httpHeaders, POST, URI.create(URL));
             ResponseEntity<Void> response = template.exchange(requestEntity, Void.class);
-            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+            assertThat(response.getStatusCode()).isEqualTo(NOT_FOUND);
         }
 
         private DeferralAllocateRequestDto createDeferralAllocateRequestDto(String poolNumber,
@@ -1412,7 +1412,7 @@ public class DeferralMaintenanceControllerITest extends AbstractIntegrationTest 
                 URI.create(URL_PREFIX + JUROR_123456789));
             ResponseEntity<Void> response = template.exchange(requestEntity, Void.class);
 
-            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+            assertThat(response.getStatusCode()).isEqualTo(NOT_FOUND);
 
             // check to make sure no record was not deleted for the deferral maintenance table
             Optional<CurrentlyDeferred> deferral = currentlyDeferredRepository.findById(JUROR_123456789);

--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/DeferralRequestControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/DeferralRequestControllerITest.java
@@ -15,14 +15,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.hmcts.juror.api.AbstractIntegrationTest;
-import uk.gov.hmcts.juror.api.config.bureau.BureauJwtPayload;
 import uk.gov.hmcts.juror.api.moj.controller.request.DeferralRequestDto;
 import uk.gov.hmcts.juror.api.moj.domain.DeferralDecision;
 
 import java.net.URI;
 import java.time.LocalDate;
 import java.util.Collections;
-import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -53,17 +51,6 @@ public class DeferralRequestControllerITest extends AbstractIntegrationTest {
         httpHeaders.set(HttpHeaders.AUTHORIZATION, bureauJwt);
         httpHeaders.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
     }
-
-    private String initCourtsJwt(String owner, List<String> courts) throws Exception {
-
-        return mintBureauJwt(BureauJwtPayload.builder()
-            .userLevel("99")
-            .login("COURT_USER")
-            .owner(owner)
-            .staff(BureauJwtPayload.Staff.builder().courts(courts).build())
-            .build());
-    }
-
 
     @Test
     @Sql({"/db/mod/truncate.sql", "/db/DeferralRequestController_createInitialPoolRecords.sql"})

--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/ExcusalResponseControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/ExcusalResponseControllerITest.java
@@ -385,7 +385,7 @@ public class ExcusalResponseControllerITest extends AbstractIntegrationTest {
         RequestEntity<ExcusalDecisionDto> requestEntity = new RequestEntity<>(excusalDecisionDto, httpHeaders,
             HttpMethod.PUT, uri);
         ResponseEntity<String> response = template.exchange(requestEntity, String.class);
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
     }
 
     @Test

--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorRecordControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorRecordControllerITest.java
@@ -745,8 +745,8 @@ class JurorRecordControllerITest extends AbstractIntegrationTest {
             URI.create("/api/v1/moj/juror-record/optic-reference/123456789/415220502")), String.class);
 
         assertThat(response.getStatusCode())
-            .as("Expect the HTTP GET request to be FORBIDDEN")
-            .isEqualTo(HttpStatus.FORBIDDEN);
+            .as("Expect the HTTP GET request to be NOT_FOUND")
+            .isEqualTo(HttpStatus.NOT_FOUND);
     }
 
     @Test

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/DeferralResponseServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/DeferralResponseServiceImpl.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.juror.api.moj.service;
 
-import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/DeferralResponseServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/DeferralResponseServiceImpl.java
@@ -45,18 +45,13 @@ public class DeferralResponseServiceImpl implements DeferralResponseService {
     public static final String DEFERRAL_DENIED_INFO = "Deferral Denied - %s";
     public static final String DEFERRAL_GRANTED_INFO = "Add defer - %s";
 
-    @NonNull
     private final ExcusalCodeRepository excusalCodeRepository;
-    @NonNull
     private final JurorRepository jurorRepository;
-    @NonNull
     private final JurorPoolRepository jurorPoolRepository;
-    @NonNull
     private final JurorHistoryRepository jurorHistoryRepository;
-    @NonNull
     private final PrintDataService printDataService;
     private final JurorHistoryService jurorHistoryService;
-
+    private final JurorPoolService jurorPoolService;
 
     @Override
     @Transactional
@@ -65,7 +60,8 @@ public class DeferralResponseServiceImpl implements DeferralResponseService {
         final String jurorNumber = deferralRequestDto.getJurorNumber();
         final String owner = payload.getOwner();
 
-        JurorPool jurorPool = JurorPoolUtils.getLatestActiveJurorPoolRecord(jurorPoolRepository, jurorNumber);
+        JurorPool jurorPool = JurorPoolUtils.getActiveJurorPoolRecord(
+            jurorPoolRepository,jurorPoolService, jurorNumber);
         JurorPoolUtils.checkOwnershipForCurrentUser(jurorPool, owner);
 
         checkExcusalCodeIsValid(deferralRequestDto.getDeferralReason());

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/ExcusalResponseServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/ExcusalResponseServiceImpl.java
@@ -49,29 +49,20 @@ import java.util.List;
 @RequiredArgsConstructor(onConstructor_ = {@Autowired})
 public class ExcusalResponseServiceImpl implements ExcusalResponseService {
 
-    @NonNull
     private final ExcusalCodeRepository excusalCodeRepository;
-    @NonNull
     private final JurorRepository jurorRepository;
-    @NonNull
     private final JurorPoolRepository jurorPoolRepository;
-    @NonNull
     private final JurorPaperResponseRepositoryMod jurorPaperResponseRepository;
-    @NonNull
     private final JurorDigitalResponseRepositoryMod jurorResponseRepository;
-    @NonNull
     private final UserRepository userRepository;
-    @NonNull
     private final SummonsReplyMergeService mergeService;
-    @NonNull
     private final JurorStatusRepository jurorStatusRepository;
-    @NonNull
     private final JurorHistoryRepository jurorHistoryRepository;
-    @NonNull
     private final PrintDataService printDataService;
     private final JurorHistoryService jurorHistoryService;
     private final JurorResponseAuditRepositoryMod jurorResponseAuditRepositoryMod;
-
+    private final JurorPoolService jurorPoolService;
+    
     @Override
     @Transactional
     public void respondToExcusalRequest(BureauJwtPayload payload, ExcusalDecisionDto excusalDecisionDto,
@@ -83,7 +74,8 @@ public class ExcusalResponseServiceImpl implements ExcusalResponseService {
 
         checkExcusalCodeIsValid(excusalDecisionDto.getExcusalReasonCode());
 
-        JurorPool jurorPool = JurorPoolUtils.getLatestActiveJurorPoolRecord(jurorPoolRepository, jurorNumber);
+        JurorPool jurorPool = JurorPoolUtils.getActiveJurorPoolRecord(
+            jurorPoolRepository, jurorPoolService, jurorNumber);
 
         JurorPoolUtils.checkOwnershipForCurrentUser(jurorPool, owner);
 

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/ExcusalResponseServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/ExcusalResponseServiceImpl.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.juror.api.moj.service;
 
-import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -62,7 +61,7 @@ public class ExcusalResponseServiceImpl implements ExcusalResponseService {
     private final JurorHistoryService jurorHistoryService;
     private final JurorResponseAuditRepositoryMod jurorResponseAuditRepositoryMod;
     private final JurorPoolService jurorPoolService;
-    
+
     @Override
     @Transactional
     public void respondToExcusalRequest(BureauJwtPayload payload, ExcusalDecisionDto excusalDecisionDto,

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/JurorRecordServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/JurorRecordServiceImpl.java
@@ -855,16 +855,8 @@ public class JurorRecordServiceImpl implements JurorRecordService {
 
         final String owner = payload.getOwner();
 
-        List<JurorPool> jurorPools = JurorPoolUtils.getActiveJurorPoolRecords(jurorPoolRepository, jurorNumber);
-        JurorPool jurorPool = jurorPools.stream().filter(p -> {
-            if (JurorDigitalApplication.JUROR_OWNER.equals(owner)) {
-                return true;
-            } else {
-                return p.getOwner().equals(owner);
-            }
-        }).findFirst().orElseThrow(() ->
-            new MojException.Forbidden("Current user does not have ownership of any "
-                + "associated pools for juror", null));
+        JurorPool jurorPool = JurorPoolUtils.getActiveJurorPoolRecord(
+            jurorPoolRepository, jurorPoolService, jurorNumber);
 
         // Bureau should always be able to read record
         JurorPoolUtils.checkReadAccessForCurrentUser(jurorPool, owner);
@@ -1044,7 +1036,8 @@ public class JurorRecordServiceImpl implements JurorRecordService {
         final String contactLogNotes = WordUtils.capitalize(requestDto.getDecision().getDescription())
             + " the juror's name change. " + requestDto.getNotes();
 
-        JurorPool jurorPool = JurorPoolUtils.getLatestActiveJurorPoolRecord(jurorPoolRepository, jurorNumber);
+        JurorPool jurorPool = JurorPoolUtils.getActiveJurorPoolRecord(
+            jurorPoolRepository, jurorPoolService, jurorNumber);
         Juror juror = jurorPool.getJuror();
         JurorUtils.checkOwnershipForCurrentUser(juror, payload.getOwner());
 
@@ -1113,7 +1106,8 @@ public class JurorRecordServiceImpl implements JurorRecordService {
     @Transactional
     public PoliceCheckStatusDto updatePncStatus(final String jurorNumber, final PoliceCheck policeCheck) {
         log.info("Attempting to update PNC check status for juror {} to be {}", jurorNumber, policeCheck);
-        final JurorPool jurorPool = JurorPoolUtils.getLatestActiveJurorPoolRecord(jurorPoolRepository, jurorNumber);
+        final JurorPool jurorPool = JurorPoolUtils.getActiveJurorPoolRecord(
+            jurorPoolRepository, jurorPoolService, jurorNumber);
         final Juror juror = jurorPool.getJuror();
 
         final PoliceCheck oldPoliceCheckValue = juror.getPoliceCheck();

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/ReissueLetterServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/ReissueLetterServiceImpl.java
@@ -40,6 +40,7 @@ public class ReissueLetterServiceImpl implements ReissueLetterService {
     private final PrintDataService printDataService;
     private final JurorStatusRepository jurorStatusRepository;
     private final JurorHistoryService jurorHistoryService;
+    private final JurorPoolService jurorPoolService;
 
     @Override
     @Transactional(readOnly = true)
@@ -284,8 +285,8 @@ public class ReissueLetterServiceImpl implements ReissueLetterService {
         if (FormCode.ENG_SUMMONS_REMINDER.getCode().equals(letter.getFormCode())
             || FormCode.BI_SUMMONS_REMINDER.getCode().equals(letter.getFormCode())) {
 
-            JurorPool jurorPool = JurorPoolUtils.getLatestActiveJurorPoolRecord(jurorPoolRepository,
-                letter.getJurorNumber());
+            JurorPool jurorPool = JurorPoolUtils.getActiveJurorPoolRecord(
+                jurorPoolRepository, jurorPoolService, letter.getJurorNumber());
 
             jurorPool.setReminderSent(true);
 

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/deferralmaintenance/ManageDeferralsServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/deferralmaintenance/ManageDeferralsServiceImpl.java
@@ -3,8 +3,6 @@ package uk.gov.hmcts.juror.api.moj.service.deferralmaintenance;
 import com.querydsl.core.Tuple;
 import io.micrometer.common.util.StringUtils;
 import jakarta.transaction.Transactional;
-import jakarta.validation.constraints.NotNull;
-import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.BooleanUtils;
@@ -119,6 +117,7 @@ public class ManageDeferralsServiceImpl implements ManageDeferralsService {
     private final JurorHistoryService jurorHistoryService;
     private final PrintDataService printDataService;
     private final JurorPoolService jurorPoolService;
+
     /**
      * When Jurors defer their service to a future date, a record gets added to the currently_deferred table.
      * Both Court officers and Bureau officers can process a deferral, creating two types:

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/deferralmaintenance/ManageDeferralsServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/deferralmaintenance/ManageDeferralsServiceImpl.java
@@ -56,6 +56,7 @@ import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorPaperResponseRep
 import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorResponseAuditRepositoryMod;
 import uk.gov.hmcts.juror.api.moj.service.AssignOnUpdateServiceMod;
 import uk.gov.hmcts.juror.api.moj.service.JurorHistoryService;
+import uk.gov.hmcts.juror.api.moj.service.JurorPoolService;
 import uk.gov.hmcts.juror.api.moj.service.PoolMemberSequenceService;
 import uk.gov.hmcts.juror.api.moj.service.PrintDataService;
 import uk.gov.hmcts.juror.api.moj.service.SummonsReplyMergeService;
@@ -101,39 +102,23 @@ public class ManageDeferralsServiceImpl implements ManageDeferralsService {
     private static final String POSTPONE_REASON_CODE = "P";
     private static final String POSTPONE_INFO = "Add Postpone";
 
-    @NonNull
     private final CurrentlyDeferredRepository currentlyDeferredRepository;
-    @NonNull
     private final WelshCourtLocationRepository welshCourtLocationRepository;
-    @NonNull
     private final JurorRepository jurorRepository;
-    @NonNull
     private final JurorPoolRepository jurorPoolRepository;
-    @NonNull
     private final PoolRequestRepository poolRequestRepository;
-    @NonNull
     private final PoolHistoryRepository poolHistoryRepository;
-    @NonNull
     private final JurorHistoryRepository jurorHistoryRepository;
-    @NonNull
     private final JurorStatusRepository jurorStatusRepository;
-    @NonNull
     private final PoolMemberSequenceService poolMemberSequenceService;
-    @NotNull
     private final JurorDigitalResponseRepositoryMod digitalResponseRepository;
-    @NotNull
     private final JurorPaperResponseRepositoryMod paperResponseRepository;
-    @NotNull
     private final AssignOnUpdateServiceMod assignOnUpdateService;
-    @NotNull
     private final SummonsReplyMergeService mergeService;
-    @NotNull
     private final JurorResponseAuditRepositoryMod jurorResponseAuditRepositoryMod;
-    @NonNull
     private final JurorHistoryService jurorHistoryService;
-    @NonNull
     private final PrintDataService printDataService;
-
+    private final JurorPoolService jurorPoolService;
     /**
      * When Jurors defer their service to a future date, a record gets added to the currently_deferred table.
      * Both Court officers and Bureau officers can process a deferral, creating two types:
@@ -190,7 +175,8 @@ public class ManageDeferralsServiceImpl implements ManageDeferralsService {
     public void processJurorDeferral(BureauJwtPayload payload, String jurorNumber,
                                      DeferralReasonRequestDto deferralReasonDto) {
         String auditorUsername = payload.getLogin();
-        JurorPool jurorPool = JurorPoolUtils.getLatestActiveJurorPoolRecord(jurorPoolRepository, jurorNumber);
+        JurorPool jurorPool = JurorPoolUtils.getActiveJurorPoolRecord(
+            jurorPoolRepository, jurorPoolService, jurorNumber);
         JurorPoolUtils.checkOwnershipForCurrentUser(jurorPool, payload.getOwner());
 
         // if not empty then we need to move the juror to the active pool
@@ -239,7 +225,8 @@ public class ManageDeferralsServiceImpl implements ManageDeferralsService {
     public void changeJurorDeferralDate(BureauJwtPayload payload, String jurorNumber,
                                         DeferralReasonRequestDto deferralReasonDto) {
         String auditorUsername = payload.getLogin();
-        JurorPool jurorPool = JurorPoolUtils.getLatestActiveJurorPoolRecord(jurorPoolRepository, jurorNumber);
+        JurorPool jurorPool = JurorPoolUtils.getActiveJurorPoolRecord(
+            jurorPoolRepository, jurorPoolService, jurorNumber);
         JurorPoolUtils.checkOwnershipForCurrentUser(jurorPool, payload.getOwner());
 
         // if not empty then we need to move the juror to the active pool
@@ -252,7 +239,6 @@ public class ManageDeferralsServiceImpl implements ManageDeferralsService {
 
             JurorPool newJurorPool = new JurorPool();
             if (poolRequest.isPresent()) {
-                PoolRequest request = poolRequest.get();
                 newJurorPool = addMemberToNewPool(
                     poolRequest.get(),
                     jurorPool,
@@ -308,7 +294,8 @@ public class ManageDeferralsServiceImpl implements ManageDeferralsService {
 
             // Add deferred member to active pool
             log.trace("Juror {} - adding pool member to requested active pool", jurorNumber);
-            JurorPool jurorPool = JurorPoolUtils.getLatestActiveJurorPoolRecord(jurorPoolRepository, jurorNumber);
+            JurorPool jurorPool = JurorPoolUtils.getActiveJurorPoolRecord(
+                jurorPoolRepository, jurorPoolService, jurorNumber);
             JurorPoolUtils.checkOwnershipForCurrentUser(jurorPool, payload.getOwner());
 
             JurorPool newJurorPool = addMemberToNewPool(poolRequest, jurorPool, payload.getLogin(),
@@ -333,7 +320,8 @@ public class ManageDeferralsServiceImpl implements ManageDeferralsService {
         int countJurorsPostponed = 0;
         for (String jurorNumber : request.jurorNumbers) {
             // validation
-            JurorPool jurorPool = JurorPoolUtils.getLatestActiveJurorPoolRecord(jurorPoolRepository, jurorNumber);
+            JurorPool jurorPool = JurorPoolUtils.getActiveJurorPoolRecord(
+                jurorPoolRepository, jurorPoolService, jurorNumber);
             JurorPoolUtils.checkOwnershipForCurrentUser(jurorPool, payload.getOwner());
 
             if (jurorPool.getPoolNumber().equalsIgnoreCase(request.getPoolNumber())) {
@@ -454,7 +442,8 @@ public class ManageDeferralsServiceImpl implements ManageDeferralsService {
         log.trace("Juror {}: Enter findActivePoolsForDates", jurorNumber);
         String owner = payload.getOwner();
 
-        JurorPool jurorPool = JurorPoolUtils.getLatestActiveJurorPoolRecord(jurorPoolRepository, jurorNumber);
+        JurorPool jurorPool = JurorPoolUtils.getActiveJurorPoolRecord(
+            jurorPoolRepository, jurorPoolService, jurorNumber);
         JurorPoolUtils.checkOwnershipForCurrentUser(jurorPool, payload.getOwner());
 
         String currentCourtLocation = jurorPool.getCourt().getLocCode();
@@ -567,7 +556,8 @@ public class ManageDeferralsServiceImpl implements ManageDeferralsService {
 
         String customErrorMessage = String.format("Cannot find deferred record for juror number %s - ", jurorNumber);
 
-        JurorPool jurorPool = JurorPoolUtils.getLatestActiveJurorPoolRecord(jurorPoolRepository, jurorNumber);
+        JurorPool jurorPool = JurorPoolUtils.getActiveJurorPoolRecord(
+            jurorPoolRepository, jurorPoolService, jurorNumber);
         JurorPoolUtils.checkOwnershipForCurrentUser(jurorPool, payload.getOwner());
 
         Optional<CurrentlyDeferred> currentlyDeferred = currentlyDeferredRepository.findById(jurorNumber);

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/utils/JurorPoolUtils.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/utils/JurorPoolUtils.java
@@ -108,8 +108,8 @@ public final class JurorPoolUtils {
      * @param jurorPoolRepository JPA interface to the database to generate and execute SQL queries
      * @param jurorNumber         9-digit numeric string to identify jurors
      * @return a collection (list) of juror pool association records. Although the juror number can uniquely identify
-     * an individual, sometimes one individual can have multiple, active, editable juror pool associative
-     * records, for example when they have been transferred.
+     *          an individual, sometimes one individual can have multiple, active, editable juror pool associative
+     *          records, for example when they have been transferred.
      */
     public static List<JurorPool> getActiveJurorPoolRecords(JurorPoolRepository jurorPoolRepository,
                                                             String jurorNumber) {
@@ -129,12 +129,12 @@ public final class JurorPoolUtils {
      * Query the database and return the latest active, juror pool associations for a given juror number. Ordered by
      * start date descending (latest first).
      *
-     * @deprecated Use getActiveJurorPoolRecord(JurorPoolRepository jurorPoolRepository,
-     *                                                      JurorPoolService jurorPoolService,
-     *                                                      String jurorNumber)
      * @param jurorPoolRepository JPA interface to the database to generate and execute SQL queries
      * @param jurorNumber         9-digit numeric string to identify jurors
      * @return a juror pool association record with the latest service start date for a given juror
+     * @deprecated Use getActiveJurorPoolRecord(JurorPoolRepository jurorPoolRepository,
+     *                                                      JurorPoolService jurorPoolService,
+     *                                                      String jurorNumber)
      */
     @Deprecated(forRemoval = true)
     public static JurorPool getLatestActiveJurorPoolRecord(JurorPoolRepository jurorPoolRepository,

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/utils/JurorPoolUtils.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/utils/JurorPoolUtils.java
@@ -155,7 +155,7 @@ public final class JurorPoolUtils {
     public static JurorPool getActiveJurorPoolRecord(JurorPoolRepository jurorPoolRepository,
                                                      JurorPoolService jurorPoolService,
                                                      String jurorNumber) {
-        if (SecurityUtil.isBureau() || SecurityUtil.isSystem()) {
+        if (!SecurityUtil.hasBureauJwtPayload() || SecurityUtil.isBureau() || SecurityUtil.isSystem()) {
             return getLatestActiveJurorPoolRecord(jurorPoolRepository, jurorNumber);
         }
         return jurorPoolService.getJurorPoolFromUser(jurorNumber);

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/utils/JurorPoolUtils.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/utils/JurorPoolUtils.java
@@ -9,6 +9,7 @@ import uk.gov.hmcts.juror.api.moj.domain.JurorPool;
 import uk.gov.hmcts.juror.api.moj.exception.JurorRecordException;
 import uk.gov.hmcts.juror.api.moj.exception.MojException;
 import uk.gov.hmcts.juror.api.moj.repository.JurorPoolRepository;
+import uk.gov.hmcts.juror.api.moj.service.JurorPoolService;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -107,8 +108,8 @@ public final class JurorPoolUtils {
      * @param jurorPoolRepository JPA interface to the database to generate and execute SQL queries
      * @param jurorNumber         9-digit numeric string to identify jurors
      * @return a collection (list) of juror pool association records. Although the juror number can uniquely identify
-     *          an individual, sometimes one individual can have multiple, active, editable juror pool associative
-     *          records, for example when they have been transferred.
+     * an individual, sometimes one individual can have multiple, active, editable juror pool associative
+     * records, for example when they have been transferred.
      */
     public static List<JurorPool> getActiveJurorPoolRecords(JurorPoolRepository jurorPoolRepository,
                                                             String jurorNumber) {
@@ -128,10 +129,14 @@ public final class JurorPoolUtils {
      * Query the database and return the latest active, juror pool associations for a given juror number. Ordered by
      * start date descending (latest first).
      *
+     * @deprecated Use getActiveJurorPoolRecord(JurorPoolRepository jurorPoolRepository,
+     *                                                      JurorPoolService jurorPoolService,
+     *                                                      String jurorNumber)
      * @param jurorPoolRepository JPA interface to the database to generate and execute SQL queries
      * @param jurorNumber         9-digit numeric string to identify jurors
      * @return a juror pool association record with the latest service start date for a given juror
      */
+    @Deprecated(forRemoval = true)
     public static JurorPool getLatestActiveJurorPoolRecord(JurorPoolRepository jurorPoolRepository,
                                                            String jurorNumber) {
         log.debug("Retrieving active juror records for juror number {}", jurorNumber);
@@ -145,6 +150,15 @@ public final class JurorPoolUtils {
 
         log.debug("{} records retrieved for juror number {}", jurorPools.size(), jurorNumber);
         return jurorPools.get(0);
+    }
+
+    public static JurorPool getActiveJurorPoolRecord(JurorPoolRepository jurorPoolRepository,
+                                                     JurorPoolService jurorPoolService,
+                                                     String jurorNumber) {
+        if (SecurityUtil.isBureau() || SecurityUtil.isSystem()) {
+            return getLatestActiveJurorPoolRecord(jurorPoolRepository, jurorNumber);
+        }
+        return jurorPoolService.getJurorPoolFromUser(jurorNumber);
     }
 
     /**

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/utils/SecurityUtil.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/utils/SecurityUtil.java
@@ -174,4 +174,8 @@ public final class SecurityUtil {
     public static boolean canEditApprovalLimit() {
         return isAdministration() || isManager() && isCourt();
     }
+
+    public static boolean isSystem() {
+        return AUTO_USER.equals(getUsername()) || getUserType().equals(UserType.SYSTEM);
+    }
 }

--- a/src/test/java/uk/gov/hmcts/juror/api/TestUtils.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/TestUtils.java
@@ -171,4 +171,27 @@ public final class TestUtils {
         MockedStatic<SecurityUtil> securityUtil = getSecurityUtilMock();
         securityUtil.when(SecurityUtil::getActiveUsersBureauPayload).thenReturn(payload);
     }
+
+    public static void mockBureauUser() {
+        mockSecurityUtil(BureauJwtPayload.builder()
+            .owner("400")
+            .locCode("400")
+            .userType(UserType.BUREAU)
+            .activeUserType(UserType.BUREAU)
+            .build());
+
+    }
+
+    public static void mockCourtUser(String owner) {
+        mockCourtUser(owner, owner);
+    }
+
+    public static void mockCourtUser(String owner, String locCode) {
+        mockSecurityUtil(BureauJwtPayload.builder()
+            .owner(owner)
+            .locCode(locCode)
+            .userType(UserType.COURT)
+            .activeUserType(UserType.COURT)
+            .build());
+    }
 }

--- a/src/test/java/uk/gov/hmcts/juror/api/TestUtils.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/TestUtils.java
@@ -17,6 +17,7 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
@@ -70,10 +71,13 @@ public final class TestUtils {
     }
 
     public static BureauJwtPayload createJwt(String owner, String username, String userLevel, List<String> courts) {
+        UserType userType = "400".equals(owner) ? UserType.BUREAU : UserType.COURT;
         return BureauJwtPayload.builder()
             .owner(owner)
             .locCode(owner)
             .login(username)
+            .activeUserType(userType)
+            .userType(userType)
             .staff(staffBuilder(username, Integer.valueOf(userLevel), courts))
             .userLevel(userLevel)
             .build();
@@ -176,6 +180,7 @@ public final class TestUtils {
         mockSecurityUtil(BureauJwtPayload.builder()
             .owner("400")
             .locCode("400")
+            .roles(Set.of())
             .userType(UserType.BUREAU)
             .activeUserType(UserType.BUREAU)
             .build());
@@ -190,6 +195,7 @@ public final class TestUtils {
         mockSecurityUtil(BureauJwtPayload.builder()
             .owner(owner)
             .locCode(locCode)
+            .roles(Set.of())
             .userType(UserType.COURT)
             .activeUserType(UserType.COURT)
             .build());

--- a/src/test/java/uk/gov/hmcts/juror/api/TestUtils.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/TestUtils.java
@@ -15,6 +15,7 @@ import uk.gov.hmcts.juror.api.moj.utils.SecurityUtil;
 
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
@@ -171,9 +172,11 @@ public final class TestUtils {
         return SECURITY_UTIL_MOCK;
     }
 
-    public static void mockSecurityUtil(BureauJwtPayload payload) {
+    public static BureauJwtPayload mockSecurityUtil(BureauJwtPayload payload) {
         MockedStatic<SecurityUtil> securityUtil = getSecurityUtilMock();
+        securityUtil.when(SecurityUtil::hasBureauJwtPayload).thenReturn(true);
         securityUtil.when(SecurityUtil::getActiveUsersBureauPayload).thenReturn(payload);
+        return payload;
     }
 
     public static void mockBureauUser() {
@@ -187,17 +190,34 @@ public final class TestUtils {
 
     }
 
-    public static void mockCourtUser(String owner) {
-        mockCourtUser(owner, owner);
+    public static BureauJwtPayload mockCourtUser(String owner) {
+        return mockCourtUser(owner, owner);
     }
 
-    public static void mockCourtUser(String owner, String locCode) {
-        mockSecurityUtil(BureauJwtPayload.builder()
+    public static BureauJwtPayload mockCourtUser(String owner, String locCode, Collection<Role> roles) {
+        return mockSecurityUtil(BureauJwtPayload.builder()
             .owner(owner)
             .locCode(locCode)
-            .roles(Set.of())
+            .roles(roles)
             .userType(UserType.COURT)
             .activeUserType(UserType.COURT)
+            .staff(BureauJwtPayload.Staff.builder()
+                .courts(List.of(owner, locCode))
+                .build())
+            .build());
+    }
+
+    public static BureauJwtPayload mockCourtUser(String owner, String locCode) {
+        return mockCourtUser(owner, locCode, Set.of());
+    }
+
+    public static BureauJwtPayload mockSystemUser() {
+        return mockSecurityUtil(BureauJwtPayload.builder()
+            .owner("400")
+            .locCode("400")
+            .roles(Set.of())
+            .userType(UserType.SYSTEM)
+            .activeUserType(UserType.SYSTEM)
             .build());
     }
 }

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/DeferralResponseServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/DeferralResponseServiceImplTest.java
@@ -40,6 +40,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(SpringRunner.class)
+@SuppressWarnings("PMD.TooManyMethods")
 public class DeferralResponseServiceImplTest {
 
     @Mock

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/ExcusalResponseServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/ExcusalResponseServiceImplTest.java
@@ -138,7 +138,7 @@ public class ExcusalResponseServiceImplTest {
 
         excusalResponseService.respondToExcusalRequest(payload, excusalDecisionDto, jurorNumber);
 
-        Mockito.verify(jurorPoolRepository, Mockito.times(1))
+        verify(jurorPoolRepository, times(1))
             .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(any(), Mockito.anyBoolean());
 
         verifyHappyPaperPath(payload, jurorNumber);
@@ -166,7 +166,7 @@ public class ExcusalResponseServiceImplTest {
         verifyHappyPaperPath(courtPayload, jurorNumber);
         verifyHappyRefuseJurorPoolPath(2, false);
 
-        Mockito.verify(printDataService, Mockito.times(0))
+        verify(printDataService, times(0))
             .printExcusalDeniedLetter(any());
     }
 
@@ -195,7 +195,7 @@ public class ExcusalResponseServiceImplTest {
         final BureauJwtPayload payload = TestUtils.createJwt("400", "SOME_USER");
         excusalResponseService.respondToExcusalRequest(payload, excusalDecisionDto, JUROR_NUMBER);
 
-        Mockito.verify(jurorPoolRepository, Mockito.times(1))
+        verify(jurorPoolRepository, times(1))
             .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(any(), Mockito.anyBoolean());
 
         verifyHappyPaperPath(payload, JUROR_NUMBER);
@@ -215,7 +215,7 @@ public class ExcusalResponseServiceImplTest {
 
         excusalResponseService.respondToExcusalRequest(courtPayload, excusalDecisionDto, JUROR_NUMBER2);
 
-        Mockito.verify(jurorPoolRepository, Mockito.times(1))
+        verify(jurorPoolRepository, times(1))
             .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(any(), Mockito.anyBoolean());
 
         verifyHappyPaperPath(courtPayload, JUROR_NUMBER2);
@@ -235,7 +235,7 @@ public class ExcusalResponseServiceImplTest {
 
         excusalResponseService.respondToExcusalRequest(payload, excusalDecisionDto, JUROR_NUMBER);
 
-        Mockito.verify(jurorPoolRepository, Mockito.times(1))
+        verify(jurorPoolRepository, times(1))
             .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(any(), Mockito.anyBoolean());
 
         verifyHappyDigitalPath(payload, JUROR_NUMBER);
@@ -255,12 +255,12 @@ public class ExcusalResponseServiceImplTest {
 
         excusalResponseService.respondToExcusalRequest(courtPayload, excusalDecisionDto, JUROR_NUMBER2);
 
-        Mockito.verify(jurorPoolRepository, Mockito.times(1))
+        verify(jurorPoolRepository, times(1))
             .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(any(), Mockito.anyBoolean());
 
         verifyHappyDigitalPath(courtPayload, JUROR_NUMBER2);
         verifyHappyRefuseJurorPoolPath(2, false);
-        Mockito.verify(printDataService, Mockito.times(0))
+        verify(printDataService, times(0))
             .printExcusalDeniedLetter(any());
     }
 
@@ -290,7 +290,7 @@ public class ExcusalResponseServiceImplTest {
 
         excusalResponseService.respondToExcusalRequest(payload, excusalDecisionDto, JUROR_NUMBER);
 
-        Mockito.verify(jurorPoolRepository, Mockito.times(1))
+        verify(jurorPoolRepository, times(1))
             .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(any(), Mockito.anyBoolean());
 
         verifyHappyDigitalPath(payload, JUROR_NUMBER);
@@ -311,7 +311,7 @@ public class ExcusalResponseServiceImplTest {
 
         excusalResponseService.respondToExcusalRequest(courtPayload, excusalDecisionDto, JUROR_NUMBER2);
 
-        Mockito.verify(jurorPoolRepository, Mockito.times(1))
+        verify(jurorPoolRepository, times(1))
             .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(any(), Mockito.anyBoolean());
 
         verifyHappyDigitalPath(courtPayload, JUROR_NUMBER2);
@@ -343,15 +343,15 @@ public class ExcusalResponseServiceImplTest {
 
         excusalResponseService.respondToExcusalRequest(payload, excusalDecisionDto, JUROR_NUMBER);
 
-        Mockito.verify(jurorPoolRepository, Mockito.times(1))
+        verify(jurorPoolRepository, times(1))
             .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(any(), Mockito.anyBoolean());
 
-        Mockito.verify(jurorPaperResponseRepository, Mockito.times(2)).findByJurorNumber(JUROR_NUMBER);
-        Mockito.verify(jurorResponseRepository, Mockito.never()).findById(JUROR_NUMBER);
-        Mockito.verify(userRepository, Mockito.times(1)).findByUsername(payload.getLogin());
-        Mockito.verify(mergeService, Mockito.times(1))
+        verify(jurorPaperResponseRepository, times(2)).findByJurorNumber(JUROR_NUMBER);
+        verify(jurorResponseRepository, Mockito.never()).findById(JUROR_NUMBER);
+        verify(userRepository, times(1)).findByUsername(payload.getLogin());
+        verify(mergeService, times(1))
             .mergePaperResponse(any(), any());
-        Mockito.verify(mergeService, Mockito.never()).mergeDigitalResponse(any(), any());
+        verify(mergeService, Mockito.never()).mergeDigitalResponse(any(), any());
         verifyHappyGrantJurorPoolPathNoLetter(); // deceased jurors don't get letters
         verifyHappyExcusalLetter(jurorPool, excusalDecisionDto);
     }
@@ -369,7 +369,7 @@ public class ExcusalResponseServiceImplTest {
             .isThrownBy(() -> excusalResponseService.respondToExcusalRequest(payload, excusalDecisionDto,
                 JUROR_NUMBER2));
 
-        Mockito.verify(jurorPoolRepository, Mockito.times(1))
+        verify(jurorPoolRepository, times(1))
             .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(any(), Mockito.anyBoolean());
 
         verifyFailedInitialChecksPath(payload, JUROR_NUMBER2);
@@ -388,7 +388,7 @@ public class ExcusalResponseServiceImplTest {
             .isThrownBy(() -> excusalResponseService.respondToExcusalRequest(courtPayload, excusalDecisionDto,
                 JUROR_NUMBER));
 
-        Mockito.verify(jurorPoolRepository, Mockito.times(1))
+        verify(jurorPoolRepository, times(1))
             .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(any(), Mockito.anyBoolean());
 
         verifyFailedInitialChecksPath(courtPayload, JUROR_NUMBER);
@@ -420,11 +420,11 @@ public class ExcusalResponseServiceImplTest {
         BureauJwtPayload payload = TestUtils.createJwt("400", "SOME_USER");
         excusalResponseService.respondToExcusalRequest(payload, excusalDecisionDto, JUROR_NUMBER);
 
-        Mockito.verify(jurorPoolRepository, Mockito.times(1))
+        verify(jurorPoolRepository, times(1))
             .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(any(), Mockito.anyBoolean());
 
-        Mockito.verify(jurorPaperResponseRepository, Mockito.times(2)).findByJurorNumber(JUROR_NUMBER);
-        Mockito.verify(jurorResponseRepository, Mockito.never()).findByJurorNumber(JUROR_NUMBER);
+        verify(jurorPaperResponseRepository, times(2)).findByJurorNumber(JUROR_NUMBER);
+        verify(jurorResponseRepository, Mockito.never()).findByJurorNumber(JUROR_NUMBER);
         verifyHappyExcusalLetter(jurorPool, excusalDecisionDto);
     }
 
@@ -454,11 +454,11 @@ public class ExcusalResponseServiceImplTest {
 
         excusalResponseService.respondToExcusalRequest(payload, excusalDecisionDto, JUROR_NUMBER);
 
-        Mockito.verify(jurorPoolRepository, Mockito.times(1))
+        verify(jurorPoolRepository, times(1))
             .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(any(), Mockito.anyBoolean());
 
-        Mockito.verify(jurorPaperResponseRepository, Mockito.never()).findById(JUROR_NUMBER);
-        Mockito.verify(jurorResponseRepository, Mockito.times(1)).findByJurorNumber(JUROR_NUMBER);
+        verify(jurorPaperResponseRepository, Mockito.never()).findById(JUROR_NUMBER);
+        verify(jurorResponseRepository, times(1)).findByJurorNumber(JUROR_NUMBER);
         verifyHappyExcusalLetter(jurorPool, excusalDecisionDto);
     }
 
@@ -473,7 +473,7 @@ public class ExcusalResponseServiceImplTest {
             .isThrownBy(() -> excusalResponseService.respondToExcusalRequest(payload, excusalDecisionDto,
                 JUROR_NUMBER));
 
-        Mockito.verify(jurorPoolRepository, Mockito.never())
+        verify(jurorPoolRepository, Mockito.never())
             .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(any(), Mockito.anyBoolean());
 
         verifyFailedInitialChecksPath(payload, JUROR_NUMBER);
@@ -492,7 +492,7 @@ public class ExcusalResponseServiceImplTest {
             .isThrownBy(() -> excusalResponseService.respondToExcusalRequest(payload, excusalDecisionDto,
                 JUROR_NUMBER));
 
-        Mockito.verify(jurorPoolRepository, Mockito.never())
+        verify(jurorPoolRepository, Mockito.never())
             .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(any(), Mockito.anyBoolean());
 
         verifyFailedInitialChecksPath(payload, JUROR_NUMBER);
@@ -508,7 +508,7 @@ public class ExcusalResponseServiceImplTest {
         Assertions.assertThatExceptionOfType(MojException.NotFound.class)
             .isThrownBy(() -> excusalResponseService.respondToExcusalRequest(payload, excusalDecisionDto, jurorNumber));
 
-        Mockito.verify(jurorPoolRepository, Mockito.times(1))
+        verify(jurorPoolRepository, times(1))
             .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(any(), Mockito.anyBoolean());
 
         verifyFailedInitialChecksPath(payload, jurorNumber);
@@ -525,12 +525,12 @@ public class ExcusalResponseServiceImplTest {
 
         excusalResponseService.respondToExcusalRequest(payload, excusalDecisionDto, JUROR_NUMBER);
 
-        Mockito.verify(jurorPoolRepository, Mockito.times(1))
+        verify(jurorPoolRepository, times(1))
             .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(any(), Mockito.anyBoolean());
 
-        Mockito.verify(jurorPaperResponseRepository, Mockito.times(1))
+        verify(jurorPaperResponseRepository, times(1))
             .findByJurorNumber(JUROR_NUMBER);
-        Mockito.verify(jurorResponseRepository, Mockito.never()).findByJurorNumber(JUROR_NUMBER);
+        verify(jurorResponseRepository, Mockito.never()).findByJurorNumber(JUROR_NUMBER);
 
         verifyFailedAtResponseStatusPath(payload);
     }
@@ -556,7 +556,7 @@ public class ExcusalResponseServiceImplTest {
 
         excusalResponseService.respondToExcusalRequest(payload, excusalDecisionDto, JUROR_NUMBER);
 
-        Mockito.verify(jurorPoolRepository, Mockito.times(1))
+        verify(jurorPoolRepository, times(1))
             .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(any(), Mockito.anyBoolean());
 
         verifyHappyGrantJurorPoolPath();
@@ -573,7 +573,7 @@ public class ExcusalResponseServiceImplTest {
 
         excusalResponseService.respondToExcusalRequest(payload, excusalDecisionDto, JUROR_NUMBER);
 
-        Mockito.verify(jurorPoolRepository, Mockito.times(1))
+        verify(jurorPoolRepository, times(1))
             .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(any(), Mockito.anyBoolean());
 
         verifyHappyRefuseJurorPoolPath(2, true);
@@ -600,7 +600,7 @@ public class ExcusalResponseServiceImplTest {
 
         excusalResponseService.respondToExcusalRequest(payload, excusalDecisionDto, JUROR_NUMBER);
 
-        Mockito.verify(jurorPoolRepository, Mockito.times(1))
+        verify(jurorPoolRepository, times(1))
             .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(any(), Mockito.anyBoolean());
 
         verifyHappyGrantJurorPoolPathNoLetter(); // court users don't automatically send letters
@@ -614,11 +614,11 @@ public class ExcusalResponseServiceImplTest {
 
         excusalResponseService.respondToExcusalRequest(payload, excusalDecisionDto, JUROR_NUMBER2);
 
-        Mockito.verify(jurorPoolRepository, Mockito.times(1))
+        verify(jurorPoolRepository, times(1))
             .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(any(), Mockito.anyBoolean());
 
         verifyHappyRefuseJurorPoolPath(2, false);
-        Mockito.verify(printDataService, Mockito.times(0))
+        verify(printDataService, times(0))
             .printExcusalDeniedLetter(any());
     }
 
@@ -633,7 +633,7 @@ public class ExcusalResponseServiceImplTest {
                 excusalResponseService.respondToExcusalRequest(payload, excusalDecisionDto, JUROR_NUMBER2);
             });
 
-        Mockito.verify(jurorPoolRepository, Mockito.times(1))
+        verify(jurorPoolRepository, times(1))
             .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(any(), Mockito.anyBoolean());
 
         verifyFailedInitialChecksPath(payload, JUROR_NUMBER2);
@@ -650,88 +650,88 @@ public class ExcusalResponseServiceImplTest {
                 excusalResponseService.respondToExcusalRequest(payload, excusalDecisionDto, JUROR_NUMBER);
             });
 
-        Mockito.verify(jurorPoolRepository, Mockito.times(1))
+        verify(jurorPoolRepository, times(1))
             .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(any(), Mockito.anyBoolean());
 
         verifyFailedInitialChecksPath(payload, JUROR_NUMBER);
     }
 
     private void verifyHappyRefuseJurorPoolPath(int jurorHistoryRepositoryTimes, boolean shouldCreateNonExcusedLetter) {
-        Mockito.verify(jurorPoolRepository, Mockito.times(1)).save(any());
-        Mockito.verify(jurorHistoryRepository, Mockito.times(jurorHistoryRepositoryTimes)).save(any());
+        verify(jurorPoolRepository, times(1)).save(any());
+        verify(jurorHistoryRepository, times(jurorHistoryRepositoryTimes)).save(any());
         if (shouldCreateNonExcusedLetter) {
-            Mockito.verify(jurorHistoryService).createNonExcusedLetterHistory(any(), eq("Refused Excusal"));
+            verify(jurorHistoryService).createNonExcusedLetterHistory(any(), eq("Refused Excusal"));
         } else {
-            Mockito.verify(jurorHistoryService, Mockito.never()).createNonExcusedLetterHistory(any(), any());
+            verify(jurorHistoryService, Mockito.never()).createNonExcusedLetterHistory(any(), any());
         }
     }
 
     private void verifyHappyGrantJurorPoolPath() {
-        Mockito.verify(jurorPoolRepository, Mockito.times(1)).save(any());
-        Mockito.verify(jurorHistoryRepository, Mockito.times(1)).save(any());
-        Mockito.verify(jurorHistoryService).createExcusedLetter(any());
+        verify(jurorPoolRepository, times(1)).save(any());
+        verify(jurorHistoryRepository, times(1)).save(any());
+        verify(jurorHistoryService).createExcusedLetter(any());
     }
 
     private void verifyHappyGrantJurorPoolPathNoLetter() {
-        Mockito.verify(jurorPoolRepository, Mockito.times(1)).save(any());
-        Mockito.verify(jurorHistoryRepository, Mockito.times(1)).save(any());
-        Mockito.verify(printDataService, Mockito.never()).printExcusalLetter(Mockito.any());
+        verify(jurorPoolRepository, times(1)).save(any());
+        verify(jurorHistoryRepository, times(1)).save(any());
+        verify(printDataService, Mockito.never()).printExcusalLetter(Mockito.any());
     }
 
     private void verifyHappyPaperPath(BureauJwtPayload payload, String jurorNumber) {
-        Mockito.verify(jurorPaperResponseRepository, Mockito.times(2)).findByJurorNumber(jurorNumber);
-        Mockito.verify(jurorResponseRepository, Mockito.never()).findById(jurorNumber);
-        Mockito.verify(userRepository, Mockito.times(1)).findByUsername(payload.getLogin());
-        Mockito.verify(mergeService, Mockito.times(1))
+        verify(jurorPaperResponseRepository, times(2)).findByJurorNumber(jurorNumber);
+        verify(jurorResponseRepository, Mockito.never()).findById(jurorNumber);
+        verify(userRepository, times(1)).findByUsername(payload.getLogin());
+        verify(mergeService, times(1))
             .mergePaperResponse(any(), any());
-        Mockito.verify(mergeService, Mockito.never()).mergeDigitalResponse(any(), any());
+        verify(mergeService, Mockito.never()).mergeDigitalResponse(any(), any());
     }
 
     private void verifyHappyDigitalPath(BureauJwtPayload payload, String jurorNumber) {
-        Mockito.verify(jurorPaperResponseRepository, Mockito.never()).findById(jurorNumber);
-        Mockito.verify(jurorResponseRepository, Mockito.times(1)).findByJurorNumber(jurorNumber);
-        Mockito.verify(userRepository, Mockito.times(1)).findByUsername(payload.getLogin());
-        Mockito.verify(mergeService, Mockito.never()).mergePaperResponse(any(), any());
-        Mockito.verify(mergeService, Mockito.times(1)).mergeDigitalResponse(any(), any());
+        verify(jurorPaperResponseRepository, Mockito.never()).findById(jurorNumber);
+        verify(jurorResponseRepository, times(1)).findByJurorNumber(jurorNumber);
+        verify(userRepository, times(1)).findByUsername(payload.getLogin());
+        verify(mergeService, Mockito.never()).mergePaperResponse(any(), any());
+        verify(mergeService, times(1)).mergeDigitalResponse(any(), any());
     }
 
     private void verifyHappyExcusalDeniedLetter() {
-        Mockito.verify(printDataService, Mockito.times(1))
+        verify(printDataService, times(1))
             .printExcusalDeniedLetter(any());
         // Negative check for excusal letter
-        //Mockito.verify(printDataService, Mockito.never())
+        //verify(printDataService, Mockito.never())
         //.getLetterToEnqueue(payload.getOwner(), jurorNumber);
-        //Mockito.verify(excusalLetterService, Mockito.never()).enqueueLetter(any());
+        //verify(excusalLetterService, Mockito.never()).enqueueLetter(any());
     }
 
     private void verifyHappyExcusalLetter(JurorPool jurorPool,
                                           ExcusalDecisionDto excusalDecisionDto) {
         if (ExcusalCodeEnum.D.getCode().equals(excusalDecisionDto.getExcusalReasonCode())) {
-            Mockito.verify(printDataService, Mockito.never())
+            verify(printDataService, Mockito.never())
                 .printExcusalLetter(jurorPool);
         } else {
-            Mockito.verify(printDataService, Mockito.times(1))
+            verify(printDataService, times(1))
                 .printExcusalLetter(jurorPool);
         }
-        Mockito.verify(printDataService, Mockito.never())
+        verify(printDataService, Mockito.never())
             .printExcusalDeniedLetter(any());
     }
 
     private void verifyFailedAtResponseStatusPath(BureauJwtPayload payload) {
-        Mockito.verify(userRepository, Mockito.never()).findByUsername(payload.getLogin());
-        Mockito.verify(mergeService, Mockito.never()).mergePaperResponse(any(), any());
-        Mockito.verify(mergeService, Mockito.never()).mergeDigitalResponse(any(), any());
+        verify(userRepository, Mockito.never()).findByUsername(payload.getLogin());
+        verify(mergeService, Mockito.never()).mergePaperResponse(any(), any());
+        verify(mergeService, Mockito.never()).mergeDigitalResponse(any(), any());
     }
 
     private void verifyFailedInitialChecksPath(BureauJwtPayload payload, String jurorNumber) {
-        Mockito.verify(jurorPaperResponseRepository, Mockito.never()).findById(jurorNumber);
-        Mockito.verify(jurorResponseRepository, Mockito.never()).findByJurorNumber(jurorNumber);
-        Mockito.verify(userRepository, Mockito.never()).findByUsername(payload.getLogin());
-        Mockito.verify(mergeService, Mockito.never()).mergePaperResponse(any(), any());
-        Mockito.verify(mergeService, Mockito.never()).mergeDigitalResponse(any(), any());
-        Mockito.verify(jurorPoolRepository, Mockito.never()).save(any());
-        Mockito.verify(jurorHistoryRepository, Mockito.never()).save(any());
-        Mockito.verify(printDataService, Mockito.never()).printExcusalDeniedLetter(any());
+        verify(jurorPaperResponseRepository, Mockito.never()).findById(jurorNumber);
+        verify(jurorResponseRepository, Mockito.never()).findByJurorNumber(jurorNumber);
+        verify(userRepository, Mockito.never()).findByUsername(payload.getLogin());
+        verify(mergeService, Mockito.never()).mergePaperResponse(any(), any());
+        verify(mergeService, Mockito.never()).mergeDigitalResponse(any(), any());
+        verify(jurorPoolRepository, Mockito.never()).save(any());
+        verify(jurorHistoryRepository, Mockito.never()).save(any());
+        verify(printDataService, Mockito.never()).printExcusalDeniedLetter(any());
     }
 
     private ExcusalDecisionDto createTestExcusalDecisionRequest() {

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/ExcusalResponseServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/ExcusalResponseServiceImplTest.java
@@ -96,7 +96,7 @@ public class ExcusalResponseServiceImplTest {
 
         JurorPool jurorPool400 = createTestJurorPool("400", "123456789");
         Mockito.doReturn(jurorPool400)
-                .when(jurorPoolService).getJurorPoolFromUser("123456789");
+            .when(jurorPoolService).getJurorPoolFromUser("123456789");
         Mockito.doReturn(Collections.singletonList(jurorPool400))
             .when(jurorPoolRepository)
             .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc("123456789", true);
@@ -121,7 +121,7 @@ public class ExcusalResponseServiceImplTest {
     }
 
     @AfterEach
-    void afterEach(){
+    void afterEach() {
         TestUtils.afterAll();
     }
 
@@ -142,7 +142,7 @@ public class ExcusalResponseServiceImplTest {
             .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(any(), Mockito.anyBoolean());
 
         verifyHappyPaperPath(payload, jurorNumber);
-        verifyHappyRefuseJurorPoolPath(2,true);
+        verifyHappyRefuseJurorPoolPath(2, true);
         verifyHappyExcusalDeniedLetter();
     }
 
@@ -164,7 +164,7 @@ public class ExcusalResponseServiceImplTest {
             .getJurorPoolFromUser(jurorNumber);
 
         verifyHappyPaperPath(courtPayload, jurorNumber);
-        verifyHappyRefuseJurorPoolPath(2,false);
+        verifyHappyRefuseJurorPoolPath(2, false);
 
         Mockito.verify(printDataService, Mockito.times(0))
             .printExcusalDeniedLetter(any());
@@ -239,7 +239,7 @@ public class ExcusalResponseServiceImplTest {
             .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(any(), Mockito.anyBoolean());
 
         verifyHappyDigitalPath(payload, JUROR_NUMBER);
-        verifyHappyRefuseJurorPoolPath(2,true);
+        verifyHappyRefuseJurorPoolPath(2, true);
         verifyHappyExcusalDeniedLetter();
     }
 
@@ -259,7 +259,7 @@ public class ExcusalResponseServiceImplTest {
             .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(any(), Mockito.anyBoolean());
 
         verifyHappyDigitalPath(courtPayload, JUROR_NUMBER2);
-        verifyHappyRefuseJurorPoolPath(2,false);
+        verifyHappyRefuseJurorPoolPath(2, false);
         Mockito.verify(printDataService, Mockito.times(0))
             .printExcusalDeniedLetter(any());
     }
@@ -576,7 +576,7 @@ public class ExcusalResponseServiceImplTest {
         Mockito.verify(jurorPoolRepository, Mockito.times(1))
             .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(any(), Mockito.anyBoolean());
 
-        verifyHappyRefuseJurorPoolPath(2,true);
+        verifyHappyRefuseJurorPoolPath(2, true);
         verifyHappyExcusalDeniedLetter();
     }
 
@@ -617,7 +617,7 @@ public class ExcusalResponseServiceImplTest {
         Mockito.verify(jurorPoolRepository, Mockito.times(1))
             .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(any(), Mockito.anyBoolean());
 
-        verifyHappyRefuseJurorPoolPath(2,false);
+        verifyHappyRefuseJurorPoolPath(2, false);
         Mockito.verify(printDataService, Mockito.times(0))
             .printExcusalDeniedLetter(any());
     }

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/JurorRecordServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/JurorRecordServiceTest.java
@@ -147,7 +147,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.juror.api.moj.controller.request.FilterableJurorDetailsRequestDto.IncludeType.NAME_DETAILS;
 
 @ExtendWith(SpringExtension.class)
 @SuppressWarnings({"PMD.ExcessiveImports", "PMD.CouplingBetweenObjects",
@@ -3507,7 +3506,7 @@ class JurorRecordServiceTest {
                     .jurorVersion(1L)
                     .include(List.of(
                         FilterableJurorDetailsRequestDto.IncludeType.PAYMENT_DETAILS,
-                        NAME_DETAILS,
+                        FilterableJurorDetailsRequestDto.IncludeType.NAME_DETAILS,
                         FilterableJurorDetailsRequestDto.IncludeType.ADDRESS_DETAILS,
                         FilterableJurorDetailsRequestDto.IncludeType.MILEAGE))
                     .build());
@@ -3562,7 +3561,7 @@ class JurorRecordServiceTest {
                 includeTypeValidator.accept(paymentDetails, response.getPaymentDetails(),
                     FilterableJurorDetailsRequestDto.IncludeType.PAYMENT_DETAILS);
                 includeTypeValidator.accept(nameDetails, response.getNameDetails(),
-                    NAME_DETAILS);
+                    FilterableJurorDetailsRequestDto.IncludeType.NAME_DETAILS);
                 includeTypeValidator.accept(jurorAddressDto, response.getAddress(),
                     FilterableJurorDetailsRequestDto.IncludeType.ADDRESS_DETAILS);
 

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/deferralmaintenance/ManageDeferralsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/deferralmaintenance/ManageDeferralsServiceTest.java
@@ -7,6 +7,7 @@ import ch.qos.logback.core.read.ListAppender;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -55,6 +56,7 @@ import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorPaperResponseRep
 import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorResponseAuditRepositoryMod;
 import uk.gov.hmcts.juror.api.moj.service.AssignOnUpdateServiceMod;
 import uk.gov.hmcts.juror.api.moj.service.JurorHistoryService;
+import uk.gov.hmcts.juror.api.moj.service.JurorPoolService;
 import uk.gov.hmcts.juror.api.moj.service.PoolMemberSequenceService;
 import uk.gov.hmcts.juror.api.moj.service.PrintDataService;
 import uk.gov.hmcts.juror.api.moj.service.SummonsReplyMergeService;
@@ -136,6 +138,8 @@ class ManageDeferralsServiceTest {
     private JurorHistoryService jurorHistoryService;
     @Mock
     private WelshCourtLocationRepository welshCourtLocationRepository;
+    @Mock
+    private JurorPoolService jurorPoolService;
 
     @InjectMocks
     ManageDeferralsServiceImpl manageDeferralsService;
@@ -157,6 +161,11 @@ class ManageDeferralsServiceTest {
         logger.addAppender(listAppender);
     }
 
+    @AfterEach
+    void afterEach(){
+        TestUtils.afterAll();
+    }
+
     @DisplayName("Process juror postponement")
     @Nested
     class ProcessJurorPostponement {
@@ -164,6 +173,7 @@ class ManageDeferralsServiceTest {
         @Test
         @SuppressWarnings({"PMD.TooManyFields"})
         void processJurorPostponementHappyPathMoveToActivePoolPoliceChecked() {
+            TestUtils.mockBureauUser();
             LocalDate newAttendanceDate = LocalDate.now();
             LocalDate oldAttendanceDate = LocalDate.of(2023, 6, 6);
 
@@ -217,6 +227,7 @@ class ManageDeferralsServiceTest {
         @Test
         @SuppressWarnings({"PMD.TooManyFields"})
         void processJurorPostponementHappyPathMoveToActivePoolNotPoliceChecked() {
+            TestUtils.mockBureauUser();
             LocalDate newAttendanceDate = LocalDate.now();
             LocalDate oldAttendanceDate = LocalDate.of(2023, 6, 6);
 
@@ -268,6 +279,7 @@ class ManageDeferralsServiceTest {
 
         @Test
         void processJurorPostponementHappyPathMoveToActivePoolMultipleJurors() {
+            TestUtils.mockBureauUser();
             LocalDate newAttendanceDate = LocalDate.now();
             LocalDate oldAttendanceDate = LocalDate.of(2023, 6, 6);
 
@@ -328,6 +340,7 @@ class ManageDeferralsServiceTest {
 
         @Test
         void processJurorPostponementUnhappyPathInvalidReasonCode() {
+            TestUtils.mockBureauUser();
             final BureauJwtPayload bureauPayload = TestUtils.createJwt(BUREAU_OWNER, BUREAU_USER);
 
             doReturn(createJurorPoolMember(JUROR_123456789)).when(jurorPoolRepository)
@@ -350,6 +363,7 @@ class ManageDeferralsServiceTest {
 
         @Test
         void processJurorPostponementUnhappyPathJurorNumberNotFound() {
+            TestUtils.mockBureauUser();
             final BureauJwtPayload bureauPayload = TestUtils.createJwt(BUREAU_OWNER, BUREAU_USER);
             DeferralReasonRequestDto dto = new DeferralReasonRequestDto();
             dto.setPoolNumber(POOL_111111111);
@@ -374,6 +388,7 @@ class ManageDeferralsServiceTest {
 
         @Test
         void processJurorPostponementUnhappyPathPoolNumberNotFound() {
+            TestUtils.mockBureauUser();
             final BureauJwtPayload bureauPayload = TestUtils.createJwt(BUREAU_OWNER, BUREAU_USER);
 
             doReturn(createJurorPoolMember(JUROR_123456789)).when(jurorPoolRepository)
@@ -396,6 +411,7 @@ class ManageDeferralsServiceTest {
 
         @Test
         void processJurorPostponementHappyPathMoveToCurrentlyDeferred() {
+            TestUtils.mockBureauUser();
             final BureauJwtPayload bureauPayload = TestUtils.createJwt(BUREAU_OWNER, BUREAU_USER,
                 UserType.BUREAU, Collections.singletonList(Role.MANAGER));
 
@@ -425,6 +441,7 @@ class ManageDeferralsServiceTest {
 
         @Test
         void processJurorPostponementUnhappyPathPostponeToExistingPoolNumber() {
+            TestUtils.mockBureauUser();
             final BureauJwtPayload bureauPayload = TestUtils.createJwt(BUREAU_OWNER, BUREAU_USER);
 
             ProcessJurorPostponementRequestDto request = new ProcessJurorPostponementRequestDto();
@@ -500,6 +517,7 @@ class ManageDeferralsServiceTest {
 
     @Test
     void deleteDeferralHappyPathBureauUser() {
+        TestUtils.mockBureauUser();
         final ArgumentCaptor<JurorPool> jurorPoolArgumentCaptor = ArgumentCaptor.forClass(JurorPool.class);
 
         final BureauJwtPayload bureauPayload = TestUtils.createJwt("400", "BUREAU_USER");
@@ -544,6 +562,7 @@ class ManageDeferralsServiceTest {
 
     @Test
     void deleteDeferralDeferralNotFound() {
+        TestUtils.mockBureauUser();
         final BureauJwtPayload bureauPayload = TestUtils.createJwt("400", "BUREAU_USER");
 
         String jurorNumber = "123456789";
@@ -927,6 +946,7 @@ class ManageDeferralsServiceTest {
             .findByPoolNumber("111111111");
         doReturn(jurorPools).when(jurorPoolRepository)
             .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(jurorNumber, true);
+        doReturn(jurorPools.get(0)).when(jurorPoolService).getJurorPoolFromUser(jurorNumber);
         doReturn(Optional.of(jurorStatus)).when(jurorStatusRepository).findById(any());
     }
 
@@ -965,6 +985,7 @@ class ManageDeferralsServiceTest {
 
     @Test
     void processJuror_deferral_digital_happy_path_moveToActivePool() {
+        TestUtils.mockBureauUser();
         LocalDate newAttendanceDate = LocalDate.now();
         LocalDate oldAttendanceDate = LocalDate.of(2022, 6, 6);
         final BureauJwtPayload bureauPayload = TestUtils.createJwt("400", "BUREAU_USER");
@@ -1003,6 +1024,7 @@ class ManageDeferralsServiceTest {
 
     @Test
     void changeDeferralDate_happy_path_moveToActivePool() {
+        TestUtils.mockBureauUser();
         LocalDate newAttendanceDate = LocalDate.now();
         LocalDate oldAttendanceDate = LocalDate.of(2022, 6, 6);
         final BureauJwtPayload bureauPayload = TestUtils.createJwt("400", "BUREAU_USER");
@@ -1036,6 +1058,7 @@ class ManageDeferralsServiceTest {
 
     @Test
     void changeDeferralDate_happy_path_moveToActivePool_RemoveFromDeferralMaintenance() {
+        TestUtils.mockBureauUser();
         LocalDate newAttendanceDate = LocalDate.now();
         LocalDate oldAttendanceDate = LocalDate.of(2022, 6, 6);
         final BureauJwtPayload bureauPayload = TestUtils.createJwt("400", "BUREAU_USER");
@@ -1071,6 +1094,7 @@ class ManageDeferralsServiceTest {
 
     @Test
     void changeDeferralDate_happy_path_moveToDeferralMaintenance() {
+        TestUtils.mockBureauUser();
         final BureauJwtPayload bureauPayload = TestUtils.createJwt("400", "BUREAU_USER");
         String jurorNumber = "123456789";
         LocalDate oldAttendanceDate = LocalDate.of(2022, 6, 6);
@@ -1100,6 +1124,7 @@ class ManageDeferralsServiceTest {
 
     @Test
     void processJuror_deferral_paper_happy_path_moveToActivePool() {
+        TestUtils.mockBureauUser();
         LocalDate newAttendanceDate = LocalDate.now();
         LocalDate oldAttendanceDate = LocalDate.of(2022, 6, 6);
         final BureauJwtPayload bureauPayload = TestUtils.createJwt("400", "BUREAU_USER");
@@ -1133,6 +1158,7 @@ class ManageDeferralsServiceTest {
 
     @Test
     void processJuror_deferral_digital_happy_path_moveToDeferralMaintenance() {
+        TestUtils.mockBureauUser();
         final BureauJwtPayload bureauPayload = TestUtils.createJwt("400", "BUREAU_USER");
         String jurorNumber = "123456789";
         LocalDate oldAttendanceDate = LocalDate.of(2022, 6, 6);
@@ -1164,6 +1190,7 @@ class ManageDeferralsServiceTest {
 
     @Test
     void processJuror_deferral_paper_happy_path_moveToDeferralMaintenance() {
+        TestUtils.mockBureauUser();
         final BureauJwtPayload bureauPayload = TestUtils.createJwt("400", "BUREAU_USER");
         String jurorNumber = "123456789";
         LocalDate oldAttendanceDate = LocalDate.of(2022, 6, 6);
@@ -1192,6 +1219,7 @@ class ManageDeferralsServiceTest {
 
     @Test
     void processJurorDeferralCourtUser() {
+        TestUtils.mockCourtUser("415");
         final BureauJwtPayload courtPayload = TestUtils.createJwt("415", "COURT_USER");
         String jurorNumber = "123456789";
         LocalDate oldAttendanceDate = LocalDate.of(2022, 6, 6);
@@ -1220,6 +1248,7 @@ class ManageDeferralsServiceTest {
 
     @Test
     void test_findActivePoolsForDates_happyPath() {
+        TestUtils.mockBureauUser();
         String bureauOwner = "400";
         final String jurorNumber = "123456789";
         final String currentCourtLocation = "415";
@@ -1457,6 +1486,7 @@ class ManageDeferralsServiceTest {
 
     @Test
     void test_findActivePoolsForDates_noDates() {
+        TestUtils.mockBureauUser();
         String bureauOwner = "400";
         String jurorNumber = "123456789";
         String currentCourtLocation = "415";
@@ -1524,6 +1554,7 @@ class ManageDeferralsServiceTest {
     @Test
     @SuppressWarnings("PMD.JUnitAssertionsShouldIncludeMessage")
     void testFindActivePoolsForDatesAndLocationCodeHappyPath() {
+        TestUtils.mockBureauUser();
         String bureauOwner = "400";
         final String jurorNumber = "123456789";
         final String currentCourtLocation = "415";
@@ -1899,6 +1930,7 @@ class ManageDeferralsServiceTest {
 
     @Test
     void test_moveJurorsToActivePool_singleJuror() {
+        TestUtils.mockBureauUser();
         final BureauJwtPayload payload = TestUtils.createJwt("400", "BUREAU_USER");
         final String courtLocationCode = "415";
         String poolNumber = "123456789";
@@ -1954,6 +1986,7 @@ class ManageDeferralsServiceTest {
 
     @Test
     void test_moveJurorsToActivePool_multipleJuror() {
+        TestUtils.mockBureauUser();
         final BureauJwtPayload payload = TestUtils.createJwt("400", "BUREAU_USER");
         final String courtLocationCode = "415";
         final String poolNumber = "123456789";

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/deferralmaintenance/ManageDeferralsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/deferralmaintenance/ManageDeferralsServiceTest.java
@@ -162,7 +162,7 @@ class ManageDeferralsServiceTest {
     }
 
     @AfterEach
-    void afterEach(){
+    void afterEach() {
         TestUtils.afterAll();
     }
 
@@ -210,7 +210,7 @@ class ManageDeferralsServiceTest {
             verify(jurorPoolRepository, times(2)).saveAndFlush(any());
             verify(jurorPoolRepository, times(2)).save(any());
             verify(jurorHistoryRepository, times(2)).save(any());
-            verify(jurorHistoryService).createPostponementLetterHistory(jurorPools.get(0),"");
+            verify(jurorHistoryService).createPostponementLetterHistory(jurorPools.get(0), "");
             verify(poolRequestRepository, times(1)).findByPoolNumber(POOL_111111111);
             verify(poolRequestRepository, times(1)).findByPoolNumber(POOL_111111112);
             verify(poolMemberSequenceService, times(1))
@@ -263,7 +263,7 @@ class ManageDeferralsServiceTest {
             verify(jurorPoolRepository, times(2)).saveAndFlush(any());
             verify(jurorPoolRepository, times(2)).save(any());
             verify(jurorHistoryRepository, times(2)).save(any());
-            verify(jurorHistoryService).createPostponementLetterHistory(jurorPool.get(0),"");
+            verify(jurorHistoryService).createPostponementLetterHistory(jurorPool.get(0), "");
             verify(poolRequestRepository, times(1)).findByPoolNumber(POOL_111111111);
             verify(poolRequestRepository, times(1)).findByPoolNumber(POOL_111111112);
             verify(poolMemberSequenceService, times(1))
@@ -325,8 +325,8 @@ class ManageDeferralsServiceTest {
             verify(jurorPoolRepository, times(4)).saveAndFlush(any());
             verify(jurorPoolRepository, times(4)).save(any());
             verify(jurorHistoryRepository, times(4)).save(any());
-            verify(jurorHistoryService).createPostponementLetterHistory(jurorPools1.get(0),"");
-            verify(jurorHistoryService).createPostponementLetterHistory(jurorPools2.get(0),"");
+            verify(jurorHistoryService).createPostponementLetterHistory(jurorPools1.get(0), "");
+            verify(jurorHistoryService).createPostponementLetterHistory(jurorPools2.get(0), "");
             verify(poolRequestRepository, times(4)).findByPoolNumber(anyString());
             verify(poolMemberSequenceService, times(2))
                 .getPoolMemberSequenceNumber(any(String.class));
@@ -427,7 +427,7 @@ class ManageDeferralsServiceTest {
             verify(jurorPoolRepository, times(0)).saveAndFlush(any());
             verify(jurorPoolRepository, times(2)).save(any());
             verify(jurorHistoryRepository, times(1)).save(any());
-            verify(jurorHistoryService).createPostponementLetterHistory(jurorPools.get(0),"");
+            verify(jurorHistoryService).createPostponementLetterHistory(jurorPools.get(0), "");
             verify(poolRequestRepository, times(0)).findByPoolNumber(anyString());
             verify(poolMemberSequenceService, times(0))
                 .getPoolMemberSequenceNumber(any(String.class));

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/deferralmaintenance/ManageDeferralsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/deferralmaintenance/ManageDeferralsServiceTest.java
@@ -1416,6 +1416,7 @@ class ManageDeferralsServiceTest {
 
     @Test
     void test_findActivePoolsForDates_invalidAccess() {
+        TestUtils.mockBureauUser();
         String bureauOwner = "400";
         String jurorNumber = "123456789";
         String currentCourtLocation = "415";

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/letter/ReissueLetterServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/letter/ReissueLetterServiceTest.java
@@ -29,6 +29,7 @@ import uk.gov.hmcts.juror.api.moj.repository.BulkPrintDataRepository;
 import uk.gov.hmcts.juror.api.moj.repository.JurorPoolRepository;
 import uk.gov.hmcts.juror.api.moj.repository.JurorStatusRepository;
 import uk.gov.hmcts.juror.api.moj.service.JurorHistoryService;
+import uk.gov.hmcts.juror.api.moj.service.JurorPoolService;
 import uk.gov.hmcts.juror.api.moj.service.PrintDataService;
 import uk.gov.hmcts.juror.api.moj.service.ReissueLetterService;
 import uk.gov.hmcts.juror.api.moj.service.ReissueLetterServiceImpl;
@@ -67,6 +68,8 @@ public class ReissueLetterServiceTest {
 
     @Mock
     private JurorHistoryService jurorHistoryService;
+    @Mock
+    private JurorPoolService jurorPoolService;
 
     @InjectMocks
     ReissueLetterServiceImpl reissueLetterService;

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/staff/StaffServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/staff/StaffServiceTest.java
@@ -98,7 +98,7 @@ public class StaffServiceTest {
         .build();
 
     @AfterEach
-    void afterEach(){
+    void afterEach() {
         TestUtils.afterAll();
     }
 

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/staff/StaffServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/staff/StaffServiceTest.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.juror.api.moj.service.staff;
 
 import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -73,15 +74,6 @@ public class StaffServiceTest {
 
     private static final String JUROR_NUMBER = "123456789";
 
-    private static final DigitalResponse JUROR_RESPONSE_INVALID_CLOSED = DigitalResponse.builder()
-        .jurorNumber(JUROR_NUMBER)
-        .replyType(ReplyType.builder().type("Digital").build())
-        .processingComplete(true)
-        .urgent(false)
-        .processingStatus(ProcessingStatus.CLOSED)
-        .build();
-
-
     private static final String TARGET_LOGIN = "assignee";
 
     private static final User TARGET_LOGIN_ENTITY = User.builder()
@@ -104,6 +96,11 @@ public class StaffServiceTest {
         .userType(UserType.BUREAU)
         .active(true)
         .build();
+
+    @AfterEach
+    void afterEach(){
+        TestUtils.afterAll();
+    }
 
     @ParameterizedTest
     @ValueSource(strings = {"Paper", "Digital"})
@@ -270,7 +267,7 @@ public class StaffServiceTest {
             .active(true)
             .build();
 
-        TestUtils.setUpMockAuthentication("400", ASSIGNING_LOGIN, "1", Collections.singletonList("400"));
+        TestUtils.mockBureauUser();
 
         doReturn(normalUser).when(mockuserRepository).findByUsername(ASSIGNING_LOGIN);
         MojException.Forbidden exception = Assertions.assertThrows(MojException.Forbidden.class,


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7804)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=664)


### Change description ###


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
