### PR TITLE
Summons processed on date not correct on the summons reply view

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/response/JurorPaperResponseDetailDto.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/response/JurorPaperResponseDetailDto.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.juror.api.moj.domain.authentication.UserDetailsDto;
 import uk.gov.hmcts.juror.api.validation.LocalDateOfBirth;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static uk.gov.hmcts.juror.api.validation.ValidationConstants.EMAIL_ADDRESS_REGEX;
@@ -267,6 +268,11 @@ public class JurorPaperResponseDetailDto implements IJurorResponse {
     @JsonProperty("current_owner")
     @Schema(name = "Current Owner", description = "Current owner (3 digit code) of the juror record")
     private String currentOwner;
+
+    @JsonProperty("completedAt")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @Schema(name = "Completed At", description = "Date and time the juror paper response was completed")
+    private LocalDateTime completedAt;
 
     @AllArgsConstructor
     @NoArgsConstructor

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/response/JurorPaperResponseDetailDto.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/response/JurorPaperResponseDetailDto.java
@@ -14,6 +14,7 @@ import org.hibernate.validator.constraints.Length;
 import uk.gov.hmcts.juror.api.moj.controller.response.jurorresponse.IJurorResponse;
 import uk.gov.hmcts.juror.api.moj.domain.authentication.UserDetailsDto;
 import uk.gov.hmcts.juror.api.validation.LocalDateOfBirth;
+import uk.gov.hmcts.juror.api.validation.ValidationConstants;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -269,8 +270,8 @@ public class JurorPaperResponseDetailDto implements IJurorResponse {
     @Schema(name = "Current Owner", description = "Current owner (3 digit code) of the juror record")
     private String currentOwner;
 
-    @JsonProperty("completedAt")
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @JsonProperty("completed_at")
+    @JsonFormat(pattern = ValidationConstants.DATETIME_FORMAT)
     @Schema(name = "Completed At", description = "Date and time the juror paper response was completed")
     private LocalDateTime completedAt;
 

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/JurorPaperResponseServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/JurorPaperResponseServiceImpl.java
@@ -204,6 +204,8 @@ public class JurorPaperResponseServiceImpl implements JurorPaperResponseService 
         jurorPaperResponseDetailDto.setProcessingStatus(jurorPaperResponse.getProcessingStatus().getDescription());
         jurorPaperResponseDetailDto.setWelsh(jurorPaperResponse.getWelsh());
 
+        jurorPaperResponseDetailDto.setCompletedAt(jurorPaperResponse.getCompletedAt());
+
         // copy the existing name and address values from Juror record
         copyExistingJurorDetails(jurorPaperResponseDetailDto, juror);
 


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7952)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=666)


### Change description ###
The date always gets displayed as todays date.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
