### PR TITLE
Jurors remaining in a summoned status when an excusal is refused. The Juror should go into a "Responded" status.

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/ExcusalResponseServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/ExcusalResponseServiceImpl.java
@@ -217,6 +217,10 @@ public class ExcusalResponseServiceImpl implements ExcusalResponseService {
         juror.setExcusalRejected("Y");
         jurorRepository.save(juror);
 
+        if (jurorPool.getStatus().getStatus() == IJurorStatus.SUMMONED) {
+            jurorPool.setStatus(getPoolStatus(IJurorStatus.RESPONDED));
+        }
+
         jurorPool.setUserEdtq(payload.getLogin());
         jurorPoolRepository.save(jurorPool);
 
@@ -243,7 +247,7 @@ public class ExcusalResponseServiceImpl implements ExcusalResponseService {
         jurorHistoryRepository.save(jurorHistory);
 
         // bureau only - queue letter for xerox
-        if (payload.getOwner().equals("400")) {
+        if (SecurityUtil.isBureau()) {
             printDataService.printExcusalDeniedLetter(jurorPool);
 
             jurorHistoryService.createNonExcusedLetterHistory(jurorPool, "Refused Excusal");

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/ExcusalResponseServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/ExcusalResponseServiceImplTest.java
@@ -1,14 +1,14 @@
 package uk.gov.hmcts.juror.api.moj.service;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Before;
-import org.junit.Test;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.juror.api.TestUtils;
 import uk.gov.hmcts.juror.api.bureau.domain.ExcusalCodeRepository;
 import uk.gov.hmcts.juror.api.config.bureau.BureauJwtPayload;
@@ -50,8 +50,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @SuppressWarnings({"PMD.TooManyMethods", "PMD.ExcessiveImports"})
-@RunWith(SpringRunner.class)
-public class ExcusalResponseServiceImplTest {
+@ExtendWith(SpringExtension.class)
+class ExcusalResponseServiceImplTest {
 
     private static final String JUROR_NUMBER = "123456789";
     private static final String JUROR_NUMBER2 = "987654321";
@@ -85,8 +85,8 @@ public class ExcusalResponseServiceImplTest {
     @InjectMocks
     private ExcusalResponseServiceImpl excusalResponseService;
 
-    @Before
-    public void setUpMocks() {
+    @BeforeEach
+    void setUpMocks() {
         List<ExcusalCode> excusalCodes = new ArrayList<>();
         ExcusalCode excusalCodeEntity = new ExcusalCode("A", "MOVED FROM AREA", false, true, false, false);
         excusalCodes.add(excusalCodeEntity);
@@ -126,7 +126,7 @@ public class ExcusalResponseServiceImplTest {
     }
 
     @Test
-    public void test_refuseExcusalRequest_happyPath_paperResponse_bureauUser_bureauOwner() {
+    void testRefuseExcusalRequestHappyPathPaperResponseBureauUserBureauOwner() {
         TestUtils.mockBureauUser();
         String jurorNumber = "123456789";
         BureauJwtPayload payload = TestUtils.createJwt("400", "SOME_USER");
@@ -147,7 +147,7 @@ public class ExcusalResponseServiceImplTest {
     }
 
     @Test
-    public void test_refuseExcusalRequest_happyPath_paperResponse_courtUser_courtOwner() {
+    void testRefuseExcusalRequestHappyPathPaperResponseCourtUserCourtOwner() {
         String jurorNumber = "987654321";
         TestUtils.mockCourtUser("415");
         BureauJwtPayload courtPayload = TestUtils.createJwt("415", "SOME_USER");
@@ -171,7 +171,7 @@ public class ExcusalResponseServiceImplTest {
     }
 
     @Test
-    public void test_grantExcusalRequest_happyPath_paperResponse_bureauUser_bureauOwner() {
+    void testGrantExcusalRequestHappyPathPaperResponseBureauUserBureauOwner() {
 
         ExcusalDecisionDto excusalDecisionDto = createTestExcusalDecisionRequest();
         excusalDecisionDto.setExcusalDecision(ExcusalDecision.GRANT);
@@ -204,7 +204,8 @@ public class ExcusalResponseServiceImplTest {
     }
 
     @Test
-    public void test_grantExcusalRequest_happyPath_paperResponse_courtUser_courtOwner() {
+    void testGrantExcusalRequestHappyPathPaperResponseCourtUserCourtOwner() {
+        TestUtils.mockCourtUser("415");
         final BureauJwtPayload courtPayload = TestUtils.createJwt("415", "SOME_USER");
 
         ExcusalDecisionDto excusalDecisionDto = createTestExcusalDecisionRequest();
@@ -215,15 +216,15 @@ public class ExcusalResponseServiceImplTest {
 
         excusalResponseService.respondToExcusalRequest(courtPayload, excusalDecisionDto, JUROR_NUMBER2);
 
-        verify(jurorPoolRepository, times(1))
-            .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(any(), Mockito.anyBoolean());
+        verify(jurorPoolService, times(1))
+            .getJurorPoolFromUser(any());
 
         verifyHappyPaperPath(courtPayload, JUROR_NUMBER2);
         verifyHappyGrantJurorPoolPathNoLetter(); // court users don't automatically send letters
     }
 
     @Test
-    public void test_refuseExcusalRequest_happyPath_digitalResponse_bureauUser_bureauOwner() {
+    void testRefuseExcusalRequestHappyPathDigitalResponseBureauUserBureauOwner() {
         TestUtils.mockBureauUser();
         final BureauJwtPayload payload = TestUtils.createJwt("400", "SOME_USER");
 
@@ -244,7 +245,8 @@ public class ExcusalResponseServiceImplTest {
     }
 
     @Test
-    public void test_refuseExcusalRequest_happyPath_digitalResponse_courtUser_courtOwner() {
+    void testRefuseExcusalRequestHappyPathDigitalResponseCourtUserCourtOwner() {
+        TestUtils.mockCourtUser("415");
         final BureauJwtPayload courtPayload = TestUtils.createJwt("415", "SOME_USER");
 
         ExcusalDecisionDto excusalDecisionDto = createTestExcusalDecisionRequest();
@@ -255,8 +257,8 @@ public class ExcusalResponseServiceImplTest {
 
         excusalResponseService.respondToExcusalRequest(courtPayload, excusalDecisionDto, JUROR_NUMBER2);
 
-        verify(jurorPoolRepository, times(1))
-            .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(any(), Mockito.anyBoolean());
+        verify(jurorPoolService, times(1))
+            .getJurorPoolFromUser(any());
 
         verifyHappyDigitalPath(courtPayload, JUROR_NUMBER2);
         verifyHappyRefuseJurorPoolPath(2, false);
@@ -265,7 +267,7 @@ public class ExcusalResponseServiceImplTest {
     }
 
     @Test
-    public void test_grantExcusalRequest_happyPath_digitalResponse_bureauUser_bureauOwner() {
+    void testGrantExcusalRequestHappyPathDigitalResponseBureauUserBureauOwner() {
         TestUtils.mockBureauUser();
         final BureauJwtPayload payload = TestUtils.createJwt("400", "SOME_USER");
 
@@ -299,7 +301,8 @@ public class ExcusalResponseServiceImplTest {
     }
 
     @Test
-    public void test_grantExcusalRequest_happyPath_digitalResponse_courtUser_courtOwner() {
+    void testGrantExcusalRequestHappyPathDigitalResponseCourtUserCourtOwner() {
+        TestUtils.mockCourtUser("415");
         final BureauJwtPayload courtPayload = TestUtils.createJwt("415", "SOME_USER");
 
         ExcusalDecisionDto excusalDecisionDto = createTestExcusalDecisionRequest();
@@ -311,15 +314,16 @@ public class ExcusalResponseServiceImplTest {
 
         excusalResponseService.respondToExcusalRequest(courtPayload, excusalDecisionDto, JUROR_NUMBER2);
 
-        verify(jurorPoolRepository, times(1))
-            .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(any(), Mockito.anyBoolean());
+        verify(jurorPoolService, times(1))
+            .getJurorPoolFromUser(any());
 
         verifyHappyDigitalPath(courtPayload, JUROR_NUMBER2);
         verifyHappyGrantJurorPoolPathNoLetter(); // court users don't automatically send letters
     }
 
     @Test
-    public void test_grantExcusalRequest_happyPath_excusalCodeDeceased() {
+    void testGrantExcusalRequestHappyPathExcusalCodeDeceased() {
+        TestUtils.mockBureauUser();
         final BureauJwtPayload payload = TestUtils.createJwt("400", "SOME_USER");
 
         ExcusalDecisionDto excusalDecisionDto = createTestExcusalDecisionRequest();
@@ -357,7 +361,8 @@ public class ExcusalResponseServiceImplTest {
     }
 
     @Test
-    public void test_excusalRequest_paperResponse_bureauUser_courtOwner() {
+    void testExcusalRequestPaperResponseBureauUserCourtOwner() {
+        TestUtils.mockBureauUser();
         BureauJwtPayload payload = TestUtils.createJwt("400", "SOME_USER");
 
         ExcusalDecisionDto excusalDecisionDto = createTestExcusalDecisionRequest();
@@ -376,7 +381,8 @@ public class ExcusalResponseServiceImplTest {
     }
 
     @Test
-    public void test_excusalRequest_paperResponse_courtUser_bureauOwner() {
+    void testExcusalRequestPaperResponseCourtUserBureauOwner() {
+        TestUtils.mockCourtUser("415");
         BureauJwtPayload courtPayload = TestUtils.createJwt("415", "SOME_USER");
 
         ExcusalDecisionDto excusalDecisionDto = createTestExcusalDecisionRequest();
@@ -388,14 +394,14 @@ public class ExcusalResponseServiceImplTest {
             .isThrownBy(() -> excusalResponseService.respondToExcusalRequest(courtPayload, excusalDecisionDto,
                 JUROR_NUMBER));
 
-        verify(jurorPoolRepository, times(1))
-            .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(any(), Mockito.anyBoolean());
+        verify(jurorPoolService, times(1))
+            .getJurorPoolFromUser(any());
 
         verifyFailedInitialChecksPath(courtPayload, JUROR_NUMBER);
     }
 
     @Test
-    public void test_excusalRequest_paperResponse_alreadyClosed() {
+    void testExcusalRequestPaperResponseAlreadyClosed() {
         final ExcusalDecisionDto excusalDecisionDto = createTestExcusalDecisionRequest();
 
         PaperResponse jurorPaperResponse = createTestJurorPaperResponse(JUROR_NUMBER);
@@ -429,7 +435,8 @@ public class ExcusalResponseServiceImplTest {
     }
 
     @Test
-    public void test_excusalRequest_digitalResponse_alreadyClosed() {
+    void testExcusalRequestDigitalResponseAlreadyClosed() {
+        TestUtils.mockBureauUser();
         final BureauJwtPayload payload = TestUtils.createJwt("400", "SOME_USER");
 
         ExcusalDecisionDto excusalDecisionDto = createTestExcusalDecisionRequest();
@@ -463,7 +470,7 @@ public class ExcusalResponseServiceImplTest {
     }
 
     @Test
-    public void test_excusalRequest_invalidExcusalCode() {
+    void testExcusalRequestInvalidExcusalCode() {
         final BureauJwtPayload payload = TestUtils.createJwt("400", "SOME_USER");
 
         ExcusalDecisionDto excusalDecisionDto = createTestExcusalDecisionRequest();
@@ -480,7 +487,7 @@ public class ExcusalResponseServiceImplTest {
     }
 
     @Test
-    public void test_excusalRequest_unableToRetrieveValidExcusalCodeList() {
+    void testExcusalRequestUnableToRetrieveValidExcusalCodeList() {
         BureauJwtPayload payload = TestUtils.createJwt("400", "SOME_USER");
 
         List<ExcusalCode> emptyList = Collections.emptyList();
@@ -499,8 +506,9 @@ public class ExcusalResponseServiceImplTest {
     }
 
     @Test
-    public void test_excusalRequest_noJurorRecord() {
+    void testExcusalRequestNoJurorRecord() {
         String jurorNumber = "111111111";
+        TestUtils.mockBureauUser();
         BureauJwtPayload payload = TestUtils.createJwt("400", "SOME_USER");
 
         ExcusalDecisionDto excusalDecisionDto = createTestExcusalDecisionRequest();
@@ -515,7 +523,8 @@ public class ExcusalResponseServiceImplTest {
     }
 
     @Test
-    public void test_excusalRequest_paperResponseDoesNotExist() {
+    void testExcusalRequestPaperResponseDoesNotExist() {
+        TestUtils.mockBureauUser();
         BureauJwtPayload payload = TestUtils.createJwt("400", "SOME_USER");
 
         ExcusalDecisionDto excusalDecisionDto = createTestExcusalDecisionRequest();
@@ -536,7 +545,7 @@ public class ExcusalResponseServiceImplTest {
     }
 
     @Test
-    public void test_excusalRequest_withoutResponse_grant_bureauUser_bureauOwner() {
+    void testExcusalRequestWithoutResponseGrantBureauUserBureauOwner() {
         TestUtils.mockBureauUser();
         final BureauJwtPayload payload = TestUtils.createJwt("400", "SOME_USER");
 
@@ -564,7 +573,7 @@ public class ExcusalResponseServiceImplTest {
     }
 
     @Test
-    public void test_excusalRequest_withoutResponse_refuse_bureauUser_bureauOwner() {
+    void testExcusalRequestWithoutResponseRefuseBureauUserBureauOwner() {
         TestUtils.mockBureauUser();
         final BureauJwtPayload payload = TestUtils.createJwt("400", "SOME_USER");
 
@@ -581,7 +590,8 @@ public class ExcusalResponseServiceImplTest {
     }
 
     @Test
-    public void test_excusalRequest_withoutResponse_grant_courtUser_courtOwner() {
+    void testExcusalRequestWithoutResponseGrantCourtUserCourtOwner() {
+        TestUtils.mockCourtUser("415");
         final BureauJwtPayload payload = TestUtils.createJwt("415", "SOME_USER");
 
         final ExcusalDecisionDto excusalDecisionDto = createTestExcusalDecisionRequestNoResponse(ExcusalDecision.GRANT);
@@ -595,27 +605,28 @@ public class ExcusalResponseServiceImplTest {
         poolRequest.setPoolNumber("987654321");
         jurorPool.setPool(new PoolRequest());
 
-        Mockito.doReturn(List.of(jurorPool)).when(jurorPoolRepository)
-            .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(JUROR_NUMBER, true);
+        Mockito.doReturn(jurorPool).when(jurorPoolService)
+            .getJurorPoolFromUser(JUROR_NUMBER);
 
         excusalResponseService.respondToExcusalRequest(payload, excusalDecisionDto, JUROR_NUMBER);
 
-        verify(jurorPoolRepository, times(1))
-            .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(any(), Mockito.anyBoolean());
+        verify(jurorPoolService, times(1))
+            .getJurorPoolFromUser(any());
 
         verifyHappyGrantJurorPoolPathNoLetter(); // court users don't automatically send letters
     }
 
     @Test
-    public void test_excusalRequest_withoutResponse_refuse_courtUser_courtOwner() {
+    void testExcusalRequestWithoutResponseRefuseCourtUserCourtOwner() {
+        TestUtils.mockCourtUser("415");
         final BureauJwtPayload payload = TestUtils.createJwt("415", "SOME_USER");
 
         ExcusalDecisionDto excusalDecisionDto = createTestExcusalDecisionRequestNoResponse(ExcusalDecision.REFUSE);
 
         excusalResponseService.respondToExcusalRequest(payload, excusalDecisionDto, JUROR_NUMBER2);
 
-        verify(jurorPoolRepository, times(1))
-            .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(any(), Mockito.anyBoolean());
+        verify(jurorPoolService, times(1))
+            .getJurorPoolFromUser(any());
 
         verifyHappyRefuseJurorPoolPath(2, false);
         verify(printDataService, times(0))
@@ -623,7 +634,8 @@ public class ExcusalResponseServiceImplTest {
     }
 
     @Test
-    public void test_excusalRequest_withoutResponse_grant_bureauUser_courtOwner() {
+    void testExcusalRequestWithoutResponseGrantBureauUserCourtOwner() {
+        TestUtils.mockBureauUser();
         final BureauJwtPayload payload = TestUtils.createJwt("400", "SOME_USER");
 
         ExcusalDecisionDto excusalDecisionDto = createTestExcusalDecisionRequestNoResponse(ExcusalDecision.GRANT);
@@ -640,7 +652,8 @@ public class ExcusalResponseServiceImplTest {
     }
 
     @Test
-    public void test_excusalRequest_withoutResponse_grant_courtUser_bureauOwner() {
+    void testExcusalRequestWithoutResponseGrantCourtUserBureauOwner() {
+        TestUtils.mockCourtUser("415");
         final BureauJwtPayload payload = TestUtils.createJwt("415", "SOME_USER");
 
         ExcusalDecisionDto excusalDecisionDto = createTestExcusalDecisionRequestNoResponse(ExcusalDecision.GRANT);
@@ -650,8 +663,8 @@ public class ExcusalResponseServiceImplTest {
                 excusalResponseService.respondToExcusalRequest(payload, excusalDecisionDto, JUROR_NUMBER);
             });
 
-        verify(jurorPoolRepository, times(1))
-            .findByJurorJurorNumberAndIsActiveOrderByPoolReturnDateDesc(any(), Mockito.anyBoolean());
+        verify(jurorPoolService, times(1))
+            .getJurorPoolFromUser(any());
 
         verifyFailedInitialChecksPath(payload, JUROR_NUMBER);
     }


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7966)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=675)


### Change description ###
Jurors remaining in a summoned status when an excusal is refused. The Juror should go into a "Responded" status.

This logic was missing from the code. Needs an update to put them in "Responded" to ensure they get the confirmation pack.

Can we see how many jurors with a refused excusal/2nd deferral are in a "summoned state". We need these to be updated so the confirmation letter can go out.

The same applies for deferral denied

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
