### PR TITLE
Expense Audit Report - When an appearance is created, then deleted, then created again we have duplicate audit entries for the same day

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/AppearanceRepository.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/AppearanceRepository.java
@@ -97,4 +97,8 @@ public interface AppearanceRepository extends IAppearanceRepository, JpaReposito
                                                                             Collection<String> locCode);
 
     Optional<Appearance> findByLocCodeAndJurorNumberAndAttendanceDate(String locCode, String jurorNumber, LocalDate attendanceDate);
+
+    @Query(value = "select max(a.version) from juror_mod.appearance_audit a where "
+        + "a.juror_number = ?1 and a.attendance_date = ?2 and a.loc_code = ?3", nativeQuery = true)
+    Long getLastVersionNumber(String jurorNumber, LocalDate date, String locCode);
 }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/AppearanceCreationService.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/AppearanceCreationService.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.juror.api.moj.service;
+
+import uk.gov.hmcts.juror.api.juror.domain.CourtLocation;
+import uk.gov.hmcts.juror.api.moj.domain.Appearance;
+
+import java.time.LocalDate;
+
+public interface AppearanceCreationService {
+    Appearance createAppearance(String jurorNumber, LocalDate appearanceDate, CourtLocation courtLocation,
+                                String poolNumber, boolean appearanceConfirmed);
+
+    Appearance createAbsentAppearance(String jurorNumber, LocalDate attendanceDate, CourtLocation courtLocation,
+                                      String poolNumber, boolean appearanceConfirmed);
+
+
+    Appearance createNoneAttendanceAppearance(String jurorNumber, LocalDate nonAttendanceDate,
+                                              CourtLocation courtLocation, String poolNumber,
+                                              boolean appearanceConfirmed);
+
+}

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/AppearanceCreationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/AppearanceCreationServiceImpl.java
@@ -1,0 +1,85 @@
+package uk.gov.hmcts.juror.api.moj.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.juror.api.juror.domain.CourtLocation;
+import uk.gov.hmcts.juror.api.moj.domain.Appearance;
+import uk.gov.hmcts.juror.api.moj.enumeration.AppearanceStage;
+import uk.gov.hmcts.juror.api.moj.enumeration.AttendanceType;
+import uk.gov.hmcts.juror.api.moj.repository.AppearanceRepository;
+import uk.gov.hmcts.juror.api.moj.utils.SecurityUtil;
+
+import java.time.LocalDate;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor(onConstructor_ = {@Autowired})
+public class AppearanceCreationServiceImpl implements AppearanceCreationService {
+    private final AppearanceRepository appearanceRepository;
+
+    @Override
+    public Appearance createAppearance(String jurorNumber, LocalDate appearanceDate, CourtLocation courtLocation,
+                                       String poolNumber, boolean appearanceConfirmed) {
+        return addStandardAttributes(Appearance.builder()
+                .jurorNumber(jurorNumber)
+                .attendanceDate(appearanceDate)
+                .courtLocation(courtLocation)
+                .poolNumber(poolNumber)
+                .appearanceConfirmed(appearanceConfirmed),
+            jurorNumber, appearanceDate, courtLocation)
+            .build();
+    }
+
+    @Override
+    public Appearance createAbsentAppearance(String jurorNumber, LocalDate attendanceDate, CourtLocation courtLocation,
+                                             String poolNumber, boolean appearanceConfirmed) {
+        return addStandardAttributes(Appearance.builder()
+                .jurorNumber(jurorNumber)
+                .poolNumber(poolNumber)
+                .attendanceDate(attendanceDate)
+                .courtLocation(courtLocation)
+                .noShow(Boolean.TRUE)
+                .attendanceType(AttendanceType.ABSENT)
+                .appearanceConfirmed(appearanceConfirmed),
+            jurorNumber, attendanceDate, courtLocation)
+            .build();
+    }
+
+
+    @Override
+    public Appearance createNoneAttendanceAppearance(String jurorNumber, LocalDate nonAttendanceDate,
+                                                     CourtLocation courtLocation, String poolNumber,
+                                                     boolean appearanceConfirmed) {
+        return
+            addStandardAttributes(
+                Appearance.builder()
+                    .jurorNumber(jurorNumber)
+                    .attendanceDate(nonAttendanceDate)
+                    .courtLocation(courtLocation)
+                    .poolNumber(poolNumber)
+                    .nonAttendanceDay(Boolean.TRUE)
+                    .attendanceType(AttendanceType.NON_ATTENDANCE)
+                    .appearanceStage(AppearanceStage.EXPENSE_ENTERED)
+                    .isDraftExpense(true)
+                    .appearanceConfirmed(appearanceConfirmed),
+                jurorNumber, nonAttendanceDate, courtLocation)
+                .build();
+    }
+
+    //Public for test use should only be used internally
+    public Appearance.AppearanceBuilder addStandardAttributes(Appearance.AppearanceBuilder appearanceBuilder,
+                                                       String jurorNumber, LocalDate appearanceDate,
+                                                       CourtLocation courtLocation) {
+        return appearanceBuilder
+            .createdBy(SecurityUtil.getActiveLogin())
+            .version(getLastVersionNumber(jurorNumber, appearanceDate, courtLocation.getLocCode()));
+    }
+
+    //Public for test use should only be used internally
+    public Long getLastVersionNumber(String jurorNumber, LocalDate date, String locCode) {
+        Long lastVersion = appearanceRepository.getLastVersionNumber(jurorNumber, date, locCode);
+        return lastVersion == null ? 0 : lastVersion + 1;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/PoolRequestServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/PoolRequestServiceImpl.java
@@ -324,7 +324,7 @@ public class PoolRequestServiceImpl implements PoolRequestService {
     private PoolRequest convertFromDto(PoolRequestDto poolRequestDto, String owner, String login) {
         String courtLocationCode = poolRequestDto.getLocationCode();
 
-        log.debug("Retrieve the Court Location object from the database for: " + courtLocationCode);
+        log.debug("Retrieve the Court Location object from the database for: {}", courtLocationCode);
         CourtLocation courtLocation = RepositoryUtils.retrieveFromDatabase(poolRequestDto.getLocationCode(),
             courtLocationRepository);
 
@@ -344,7 +344,7 @@ public class PoolRequestServiceImpl implements PoolRequestService {
                 poolRequestDto.getAttendanceTime()));
         }
 
-        log.debug("Retrieve the Pool Type object from the database for: " + poolRequestDto.getPoolType());
+        log.debug("Retrieve the Pool Type object from the database for: {}", poolRequestDto.getPoolType());
         poolRequest.setPoolType(RepositoryUtils.retrieveFromDatabase(poolRequestDto.getPoolType(), poolTypeRepository));
 
         poolRequestRepository.save(poolRequest);

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceService.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/jurormanagement/JurorAppearanceService.java
@@ -55,6 +55,10 @@ public interface JurorAppearanceService {
 
     boolean hasAttendances(String jurorNumber);
 
+    Optional<Appearance> getAppearance(String jurorNumber,
+                                       LocalDate appearanceDate,
+                                       String locCode);
+
     void realignAttendanceType(Appearance appearance);
 
     void realignAttendanceType(String jurorNumber);

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/trial/TrialServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/trial/TrialServiceImplTest.java
@@ -115,9 +115,9 @@ class TrialServiceImplTest {
 
 
     @BeforeEach
-    void beforeEach(){
+    void beforeEach() {
         doAnswer(invocation -> invocation.getArgument(0)).when(appearanceCreationService)
-            .addStandardAttributes(any(),any(), any(), any());
+            .addStandardAttributes(any(), any(), any(), any());
     }
 
     @Test
@@ -350,7 +350,8 @@ class TrialServiceImplTest {
             .findByTrialTrialNumberAndTrialCourtLocationLocCode(trialNumber, "415");
         verify(panelRepository, times(panelMembers.size())).saveAndFlush(any());
         verify(jurorHistoryService, times(panelMembers.size())).createJuryAttendanceHistory(any(), any(), any());
-        verify(appearanceRepository, times(panelMembers.size())).saveAndFlush(appearanceArgumentCaptor.capture());
+        verify(jurorAppearanceService, times(panelMembers.size()))
+            .realignAttendanceType(appearanceArgumentCaptor.capture());
         Appearance appearance = appearanceArgumentCaptor.getValue();
         assertThat(appearance.getSatOnJury()).as("Sat on Jury").isTrue();
         assertThat(appearance.getAttendanceType()).as("Attendance type").isEqualTo(AttendanceType.HALF_DAY);
@@ -390,7 +391,8 @@ class TrialServiceImplTest {
             .findByTrialTrialNumberAndTrialCourtLocationLocCode(trialNumber, "415");
         verify(panelRepository, times(panelMembers.size())).saveAndFlush(any());
         verify(jurorHistoryService, times(panelMembers.size())).createJuryAttendanceHistory(any(), any(), any());
-        verify(appearanceRepository, times(panelMembers.size())).saveAndFlush(appearanceArgumentCaptor.capture());
+        verify(jurorAppearanceService, times(panelMembers.size()))
+            .realignAttendanceType(appearanceArgumentCaptor.capture());
         Appearance appearance = appearanceArgumentCaptor.getValue();
         assertThat(appearance.getSatOnJury()).as("Sat on Jury").isTrue();
         assertThat(appearance.getAttendanceType()).as("Attendance type").isEqualTo(AttendanceType.FULL_DAY);
@@ -429,7 +431,8 @@ class TrialServiceImplTest {
             .findByTrialTrialNumberAndTrialCourtLocationLocCode(trialNumber, "415");
         verify(panelRepository, times(panelMembers.size())).saveAndFlush(any());
         verify(jurorHistoryService, times(panelMembers.size())).createJuryAttendanceHistory(any(), any(), any());
-        verify(appearanceRepository, times(panelMembers.size())).saveAndFlush(appearanceArgumentCaptor.capture());
+        verify(jurorAppearanceService, times(panelMembers.size()))
+            .realignAttendanceType(appearanceArgumentCaptor.capture());
         Appearance appearance = appearanceArgumentCaptor.getValue();
         assertThat(appearance.getSatOnJury()).as("Sat on Jury").isTrue();
         assertThat(appearance.getAttendanceType()).as("Attendance type").isEqualTo(AttendanceType.FULL_DAY_LONG_TRIAL);
@@ -468,7 +471,8 @@ class TrialServiceImplTest {
             .findByTrialTrialNumberAndTrialCourtLocationLocCode(trialNumber, "415");
         verify(panelRepository, times(panelMembers.size())).saveAndFlush(any());
         verify(jurorHistoryService, times(panelMembers.size())).createJuryAttendanceHistory(any(), any(), any());
-        verify(appearanceRepository, times(panelMembers.size())).saveAndFlush(appearanceArgumentCaptor.capture());
+        verify(jurorAppearanceService, times(panelMembers.size()))
+            .realignAttendanceType(appearanceArgumentCaptor.capture());
         Appearance appearance = appearanceArgumentCaptor.getValue();
         assertThat(appearance.getSatOnJury()).as("Sat on Jury").isTrue();
         assertThat(appearance.getAttendanceType()).as("Attendance type").isEqualTo(AttendanceType.HALF_DAY_LONG_TRIAL);
@@ -498,8 +502,7 @@ class TrialServiceImplTest {
             .findByTrialTrialNumberAndTrialCourtLocationLocCode(trialNumber, "415");
         verify(panelRepository, times(panelMembers.size())).saveAndFlush(any());
         verify(jurorHistoryService, times(panelMembers.size())).createJuryAttendanceHistory(any(), any(), any());
-        ArgumentCaptor<Appearance> appearanceArgumentCaptor = ArgumentCaptor.forClass(Appearance.class);
-        verify(appearanceRepository, times(panelMembers.size())).saveAndFlush(appearanceArgumentCaptor.capture());
+        verify(jurorAppearanceService, times(panelMembers.size())).realignAttendanceType(any(Appearance.class));
     }
 
     @Test
@@ -525,7 +528,8 @@ class TrialServiceImplTest {
         verify(completeService, times(panelMembers.size())).completeService(anyString(), any());
         verify(jurorHistoryService, times(panelMembers.size())).createJuryAttendanceHistory(any(), any(), any());
         ArgumentCaptor<Appearance> appearanceArgumentCaptor = ArgumentCaptor.forClass(Appearance.class);
-        verify(appearanceRepository, times(panelMembers.size())).saveAndFlush(appearanceArgumentCaptor.capture());
+        verify(jurorAppearanceService, times(panelMembers.size()))
+            .realignAttendanceType(appearanceArgumentCaptor.capture());
         assertThat(appearanceArgumentCaptor.getValue().getSatOnJury()).as("Sat on Jury").isTrue();
     }
 

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/trial/TrialServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/trial/TrialServiceImplTest.java
@@ -1,10 +1,12 @@
 package uk.gov.hmcts.juror.api.moj.service.trial;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -41,6 +43,7 @@ import uk.gov.hmcts.juror.api.moj.repository.trial.CourtroomRepository;
 import uk.gov.hmcts.juror.api.moj.repository.trial.JudgeRepository;
 import uk.gov.hmcts.juror.api.moj.repository.trial.PanelRepository;
 import uk.gov.hmcts.juror.api.moj.repository.trial.TrialRepository;
+import uk.gov.hmcts.juror.api.moj.service.AppearanceCreationServiceImpl;
 import uk.gov.hmcts.juror.api.moj.service.CompleteServiceServiceImpl;
 import uk.gov.hmcts.juror.api.moj.service.JurorHistoryService;
 import uk.gov.hmcts.juror.api.moj.service.expense.JurorExpenseService;
@@ -102,10 +105,20 @@ class TrialServiceImplTest {
     @Mock
     private JurorHistoryService jurorHistoryService;
 
+    @Mock(answer = Answers.CALLS_REAL_METHODS)
+    private AppearanceCreationServiceImpl appearanceCreationService;
+
     @InjectMocks
     TrialServiceImpl trialService;
 
     BureauJwtPayload payload = createJwtPayload("415", "COURT_USER");
+
+
+    @BeforeEach
+    void beforeEach(){
+        doAnswer(invocation -> invocation.getArgument(0)).when(appearanceCreationService)
+            .addStandardAttributes(any(),any(), any(), any());
+    }
 
     @Test
     void testCreateTrial() {


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-8001)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=681)


### Change description ###
Expense Audit Report - When an appearance is created, then deleted, then created again we have duplicate audit entries for the same day. When trying to access the audit report it will not load and defaults to the "Sorry technical error" screen.



01/08 344513805 - Juror number example

Ben applied a data fix to correct the initial issue -

Code fix required

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
