### PR TITLE
Returning a jury doesn't set the trial number on appearance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -287,7 +287,7 @@ pmdTest {
     maxFailures = 294
 }
 pmdMain {
-    maxFailures = 784
+    maxFailures = 781
 }
 pmd {
     maxFailures = 0

--- a/build.gradle
+++ b/build.gradle
@@ -287,7 +287,7 @@ pmdTest {
     maxFailures = 294
 }
 pmdMain {
-    maxFailures = 794
+    maxFailures = 784
 }
 pmd {
     maxFailures = 0

--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/CompleteServiceControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/CompleteServiceControllerITest.java
@@ -178,11 +178,11 @@ class CompleteServiceControllerITest extends AbstractIntegrationTest {
                     response.getBody(), false);
 
             JurorPool jurorPool = jurorPoolRepository.findByJurorJurorNumberAndPoolPoolNumber("641500005", "415220901");
-            assertEquals(IJurorStatus.COMPLETED, jurorPool.getStatus().getStatus(),
-                "Juror pool status should update to completed");
+            assertEquals(IJurorStatus.RESPONDED, jurorPool.getStatus().getStatus(),
+                "Juror pool status should not be updated");
             Juror juror = jurorPool.getJuror();
-            assertNotNull(juror.getCompletionDate(),
-                "Completion date should update to provided completion date");
+            assertNull(juror.getCompletionDate(),
+                "Completion date should not be update to provided completion date");
         }
 
         @Test

--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorExpenseControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorExpenseControllerITest.java
@@ -2446,7 +2446,8 @@ class JurorExpenseControllerITest extends AbstractIntegrationTest {
                 ResponseEntity<List<String>> response = template.exchange(
                     new RequestEntity<>(List.of(expenseDto), httpHeaders, POST,
                         URI.create(toUrl(COURT_LOCATION, paymentMethod))),
-                    new ParameterizedTypeReference<>() {});
+                    new ParameterizedTypeReference<>() {
+                    });
                 assertThat(response.getStatusCode())
                     .as("Expect the HTTP GET request to be successful")
                     .isEqualTo(HttpStatus.OK);
@@ -2513,12 +2514,12 @@ class JurorExpenseControllerITest extends AbstractIntegrationTest {
                 assertFinancialAuditDetailsAppearances(financialAuditDetailsAppearances.get(2),
                     id, LocalDate.of(2023, 1, 10), 3);
 
-                assertApproved(
-                    appearanceRepository.findByJurorNumberAndAttendanceDate(JUROR_NUMBER, LocalDate.of(2023, 1, 8)));
-                assertApproved(
-                    appearanceRepository.findByJurorNumberAndAttendanceDate(JUROR_NUMBER, LocalDate.of(2023, 1, 9)));
-                assertApproved(
-                    appearanceRepository.findByJurorNumberAndAttendanceDate(JUROR_NUMBER, LocalDate.of(2023, 1, 10)));
+                assertApproved(appearanceRepository
+                    .findByLocCodeAndJurorNumberAndAttendanceDate("415", JUROR_NUMBER, LocalDate.of(2023, 1, 8)));
+                assertApproved(appearanceRepository
+                    .findByLocCodeAndJurorNumberAndAttendanceDate("415", JUROR_NUMBER, LocalDate.of(2023, 1, 9)));
+                assertApproved(appearanceRepository
+                    .findByLocCodeAndJurorNumberAndAttendanceDate("415", JUROR_NUMBER, LocalDate.of(2023, 1, 10)));
                 assertJurorHistory(JUROR_NUMBER, HistoryCodeMod.ARAMIS_EXPENSES_FILE_CREATED, "COURT_USER",
                     "£1,683.98", "415230101", LocalDate.of(2023, 1, 10), "F" + id);
                 assertPaymentData(JUROR_NUMBER, new BigDecimal("1683.98"), new BigDecimal("702.98"),
@@ -2569,11 +2570,14 @@ class JurorExpenseControllerITest extends AbstractIntegrationTest {
                     id, LocalDate.of(2023, 2, 10), 3);
 
                 assertApproved(
-                    appearanceRepository.findByJurorNumberAndAttendanceDate(JUROR_NUMBER, LocalDate.of(2023, 2, 8)));
+                    appearanceRepository.findByLocCodeAndJurorNumberAndAttendanceDate("415", JUROR_NUMBER,
+                        LocalDate.of(2023, 2, 8)));
                 assertApproved(
-                    appearanceRepository.findByJurorNumberAndAttendanceDate(JUROR_NUMBER, LocalDate.of(2023, 2, 9)));
+                    appearanceRepository.findByLocCodeAndJurorNumberAndAttendanceDate("415", JUROR_NUMBER,
+                        LocalDate.of(2023, 2, 9)));
                 assertApproved(
-                    appearanceRepository.findByJurorNumberAndAttendanceDate(JUROR_NUMBER, LocalDate.of(2023, 2, 10)));
+                    appearanceRepository.findByLocCodeAndJurorNumberAndAttendanceDate("415", JUROR_NUMBER,
+                        LocalDate.of(2023, 2, 10)));
                 assertJurorHistory(JUROR_NUMBER, HistoryCodeMod.CASH_PAYMENT_APPROVAL, "COURT_USER", "£1,683.98",
                     "415230101", LocalDate.of(2023, 2, 10), "F" + id);
                 List<PaymentData> paymentDataList = paymentDataRepository.findByJurorNumber(JUROR_NUMBER);
@@ -2646,14 +2650,14 @@ class JurorExpenseControllerITest extends AbstractIntegrationTest {
                     id, LocalDate.of(2023, 1, 16), 4, 12_344L);
 
                 assertApproved(
-                    appearanceRepository.findByJurorNumberAndAttendanceDate(JUROR_NUMBER,
-                        LocalDate.of(2023, 1, 14)));
+                    appearanceRepository.findByLocCodeAndJurorNumberAndAttendanceDate(
+                        "415", JUROR_NUMBER, LocalDate.of(2023, 1, 14)));
                 assertApproved(
-                    appearanceRepository.findByJurorNumberAndAttendanceDate(JUROR_NUMBER,
-                        LocalDate.of(2023, 1, 15)));
+                    appearanceRepository.findByLocCodeAndJurorNumberAndAttendanceDate(
+                        "415", JUROR_NUMBER, LocalDate.of(2023, 1, 15)));
                 assertApproved(
-                    appearanceRepository.findByJurorNumberAndAttendanceDate(JUROR_NUMBER,
-                        LocalDate.of(2023, 1, 16)));
+                    appearanceRepository.findByLocCodeAndJurorNumberAndAttendanceDate(
+                        "415", JUROR_NUMBER, LocalDate.of(2023, 1, 16)));
 
                 assertJurorHistory(JUROR_NUMBER, HistoryCodeMod.ARAMIS_EXPENSES_FILE_CREATED, "COURT_USER",
                     "£409.00",

--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorManagementControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorManagementControllerITest.java
@@ -1108,7 +1108,7 @@ class JurorManagementControllerITest extends AbstractIntegrationTest {
 
             // verify attendance details have been updated x 2 checked in
             Appearance appearance1 =
-                appearanceRepository.findByJurorNumberAndAttendanceDate(JUROR1, request.getCommonData()
+                appearanceRepository.findByLocCodeAndJurorNumberAndAttendanceDate("415", JUROR1, request.getCommonData()
                     .getAttendanceDate()).orElseThrow(() ->
                     new MojException.NotFound("No appearance record found", null));
             assertThat(appearance1.getAppearanceStage()).isEqualTo(EXPENSE_ENTERED);
@@ -1116,7 +1116,7 @@ class JurorManagementControllerITest extends AbstractIntegrationTest {
             assertThat(appearance1.isAppearanceConfirmed()).isTrue();
 
             Appearance appearance2 =
-                appearanceRepository.findByJurorNumberAndAttendanceDate(JUROR6, request.getCommonData()
+                appearanceRepository.findByLocCodeAndJurorNumberAndAttendanceDate("415", JUROR6, request.getCommonData()
                     .getAttendanceDate()).orElseThrow(() ->
                     new MojException.NotFound("No appearance record found", null));
             assertThat(appearance2.getAppearanceStage()).isEqualTo(EXPENSE_ENTERED);

--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/PanelControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/PanelControllerITest.java
@@ -399,7 +399,7 @@ class PanelControllerITest extends AbstractIntegrationTest {
                 "Expected history code to be VRET")
             .isEqualTo("VRET");
         Appearance appearance =
-            appearanceRepository.findByJurorNumberAndAttendanceDate(panelMember.getJurorNumber(),
+            appearanceRepository.findByLocCodeAndJurorNumberAndAttendanceDate("415", panelMember.getJurorNumber(),
                 LocalDate.now()).orElseThrow(() ->
                 new MojException.NotFound("No appearance record found", null));
         JurorPool jurorPool = PanelUtils.getAssociatedJurorPool(jurorPoolRepository, panelMember);

--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/TrialControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/TrialControllerITest.java
@@ -733,7 +733,7 @@ class TrialControllerITest extends AbstractIntegrationTest {
             assertThat(panel.isCompleted()).as("Expected panel completed status to be true").isTrue();
 
             Appearance appearance =
-                appearanceRepository.findByJurorNumberAndAttendanceDate(panel.getJurorNumber(),
+                appearanceRepository.findByLocCodeAndJurorNumberAndAttendanceDate("415", panel.getJurorNumber(),
                     LocalDate.now()).orElseThrow(() ->
                     new MojException.NotFound("No appearance record found", null));
 
@@ -799,7 +799,7 @@ class TrialControllerITest extends AbstractIntegrationTest {
                 .isEqualTo(2);
 
             Appearance appearance =
-                appearanceRepository.findByJurorNumberAndAttendanceDate(panel.getJurorNumber(),
+                appearanceRepository.findByLocCodeAndJurorNumberAndAttendanceDate("415", panel.getJurorNumber(),
                     LocalDate.now()).orElseThrow(() ->
                     new MojException.NotFound("No appearance record found", null));
             assertThat(appearance.getTimeIn()).as("Expect time in to be null").isEqualTo(LocalTime.of(9, 30));
@@ -850,7 +850,7 @@ class TrialControllerITest extends AbstractIntegrationTest {
                 "Expect completion date to be " + LocalDate.now()).isEqualTo(LocalDate.now());
 
             Appearance appearance =
-                appearanceRepository.findByJurorNumberAndAttendanceDate(panel.getJurorNumber(),
+                appearanceRepository.findByLocCodeAndJurorNumberAndAttendanceDate("415", panel.getJurorNumber(),
                     LocalDate.now()).orElseThrow(() ->
                     new MojException.NotFound("No appearance record found", null));
 

--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/TrialControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/TrialControllerITest.java
@@ -243,6 +243,8 @@ class TrialControllerITest extends AbstractIntegrationTest {
 
         TrialDto trialRequest2 = createTrialRequest();
         trialRequest2.setCourtLocation("462");
+        trialRequest2.setCourtroomId(67L);
+        trialRequest2.setJudgeId(22L);
         ResponseEntity<TrialSummaryDto> responseEntity =
             restTemplate.exchange(new RequestEntity<>(trialRequest2, httpHeaders, POST,
                 URI.create(URL_CREATE)), TrialSummaryDto.class);
@@ -283,6 +285,8 @@ class TrialControllerITest extends AbstractIntegrationTest {
 
         //Create second trial
         TrialDto trialRequest2 = createTrialRequest();
+        trialRequest2.setCourtroomId(67L);
+        trialRequest2.setJudgeId(22L);
         trialRequest2.setCourtLocation("462");
         trialRequest2.setProtectedTrial(Boolean.TRUE);
 

--- a/src/integration-test/resources/db/trial/Trial.sql
+++ b/src/integration-test/resources/db/trial/Trial.sql
@@ -3,17 +3,17 @@ SELECT setval('juror_mod.courtroom_id_seq', 65);
 SELECT setval('juror_mod.judge_id_seq', 20);
 
 -- Dummy test data
-insert into juror_mod.judge (owner, code, description) values
-('415', '1234','Test judge'),
-('462', '4321','Judge Test'),
-('416', '4322','Judge Test2'),
-('416', '4323','Judge Test3');
+insert into juror_mod.judge (id, owner, code, description) values
+(21,'415', '1234','Test judge'),
+(22,'415', '4321','Judge Test'),
+(23,'416', '4322','Judge Test2'),
+(24,'416', '4323','Judge Test3');
 
-insert into juror_mod.courtroom (loc_code, room_number, description) values
-('415', '1', 'large room fits 100 people'),
-('462', '2', 'large room fits 100 people'),
-('416', '3', 'large room fits 101 people'),
-('416', '4', 'large room fits 102 people');
+insert into juror_mod.courtroom (id, loc_code, room_number, description) values
+(66,'415', '1', 'large room fits 100 people'),
+(67,'462', '2', 'large room fits 100 people'),
+(68,'416', '3', 'large room fits 101 people'),
+(69,'416', '4', 'large room fits 102 people');
 
 insert into juror_mod.trial (trial_number, loc_code, description, judge, trial_type, trial_start_date, trial_end_date, anonymous, courtroom) values
 ('T100000000','462', 'TEST DEFENDANT', 22,'CIV', current_date, current_date, false, 67),

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/trial/PanelController.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/trial/PanelController.java
@@ -4,7 +4,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
@@ -38,8 +37,7 @@ import java.util.List;
 @RequiredArgsConstructor(onConstructor_ = {@Autowired})
 public class PanelController {
 
-    @NonNull
-    private PanelService panelService;
+    private final PanelService panelService;
 
     @GetMapping("/available-jurors")
     @Operation(summary = "Retrieves a list of jurors for a court location")

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/AppearanceRepository.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/AppearanceRepository.java
@@ -22,9 +22,6 @@ public interface AppearanceRepository extends IAppearanceRepository, JpaReposito
 
     long countByJurorNumber(String jurorNumber);
 
-    Optional<Appearance> findByJurorNumberAndAttendanceDate(String jurorNumber, LocalDate attendanceDate);
-
-
     List<Appearance> findAllByCourtLocationLocCodeAndJurorNumber(String locCode, String jurorNumber);
 
     List<Appearance> findAllByJurorNumber(String jurorNumber);
@@ -84,19 +81,17 @@ public interface AppearanceRepository extends IAppearanceRepository, JpaReposito
         + "and( a.attendanceType is null or a.attendanceType not in (AttendanceType.ABSENT))")
     long countNoneAbsentAttendances(String jurorNumber);
 
-
-    Optional<Appearance> findByJurorNumberAndAttendanceDateAndAppearanceStage(String jurorNumber,
-                                                                              LocalDate attendanceDate,
-                                                                              AppearanceStage appearanceStage);
-
-
-    List<Appearance> findAllByJurorNumberAndPoolNumber(String jurorNumber, String poolNumber);
+    Optional<Appearance> findByLocCodeAndJurorNumberAndAttendanceDateAndAppearanceStage(String locCode,
+                                                                                        String jurorNumber,
+                                                                                        LocalDate attendanceDate,
+                                                                                        AppearanceStage appearanceStage);
 
 
     Optional<Appearance> findFirstByAttendanceAuditNumberEqualsAndLocCodeIn(String auditNumber,
                                                                             Collection<String> locCode);
 
-    Optional<Appearance> findByLocCodeAndJurorNumberAndAttendanceDate(String locCode, String jurorNumber, LocalDate attendanceDate);
+    Optional<Appearance> findByLocCodeAndJurorNumberAndAttendanceDate(String locCode, String jurorNumber,
+                                                                      LocalDate attendanceDate);
 
     @Query(value = "select max(a.version) from juror_mod.appearance_audit a where "
         + "a.juror_number = ?1 and a.attendance_date = ?2 and a.loc_code = ?3", nativeQuery = true)

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/trial/PanelRepositoryImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/trial/PanelRepositoryImpl.java
@@ -43,7 +43,7 @@ public class PanelRepositoryImpl implements IPanelRepository {
             .where(TRIAL.trialNumber.eq(trialNumber))
             .where(JUROR_POOL.pool.courtLocation.eq(COURT_LOCATION))
             .where(JUROR_POOL.isActive.isTrue())
-            .where(PANEL.result.eq(PanelResult.JUROR))
+            .where(PANEL.result.isNull().or(PANEL.result.eq(PanelResult.JUROR)))
             .where(JUROR_POOL.status.status.in(IJurorStatus.JUROR, IJurorStatus.PANEL))
             .fetch();
     }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/CompleteServiceService.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/CompleteServiceService.java
@@ -3,12 +3,17 @@ package uk.gov.hmcts.juror.api.moj.service;
 import uk.gov.hmcts.juror.api.moj.controller.request.CompleteServiceJurorNumberListDto;
 import uk.gov.hmcts.juror.api.moj.controller.request.JurorNumberListDto;
 import uk.gov.hmcts.juror.api.moj.controller.response.CompleteServiceValidationResponseDto;
+import uk.gov.hmcts.juror.api.moj.domain.JurorPool;
+
+import java.time.LocalDate;
 
 public interface CompleteServiceService {
     CompleteServiceValidationResponseDto validateCanCompleteService(
         String poolNumber, JurorNumberListDto jurorNumberListDto);
 
     void uncompleteJurorsService(String jurorNumber, String poolNumber);
+
+    boolean completeServiceSingle(JurorPool jurorPool, LocalDate completionDate);
 
     void completeService(String poolNumber,
                          CompleteServiceJurorNumberListDto completeServiceJurorNumberListDto);

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/utils/RepositoryUtils.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/utils/RepositoryUtils.java
@@ -55,12 +55,16 @@ public class RepositoryUtils {
      * @return the unboxed object from the database result
      */
     public static <T> T unboxOptionalRecord(Optional<T> repoResult, String id) {
+        return unboxOptionalRecord(repoResult, id, "Record");
+    }
+
+    public static <T> T unboxOptionalRecord(Optional<T> repoResult, String id, String supportText) {
         if (repoResult.isPresent()) {
-            log.debug("Database record exists for the ID: " + id);
+            log.debug("{} exists for the ID: {}", supportText, id);
             return repoResult.get();
         }
         throw new MojException.NotFound(
-            String.format("Unable to find a valid record in the database for %s", id),
+            String.format("Unable to find a valid %s in the database for %s.",supportText, id),
             null
         );
     }

--- a/src/main/java/uk/gov/hmcts/juror/api/validation/ResponseInspectorImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/validation/ResponseInspectorImpl.java
@@ -55,8 +55,8 @@ public class ResponseInspectorImpl implements ResponseInspector {
     }
 
     @Override
-    public boolean isThirdPartyResponse(@NonNull final DigitalResponse r) {
-        boolean isThirdPartyResponse = !Strings.isNullOrEmpty(r.getThirdPartyFName());
+    public boolean isThirdPartyResponse(@NonNull final DigitalResponse response) {
+        boolean isThirdPartyResponse = !Strings.isNullOrEmpty(response.getThirdPartyFName());
         if (log.isDebugEnabled()) {
             log.debug("Third party response: {}", isThirdPartyResponse);
         }
@@ -65,23 +65,23 @@ public class ResponseInspectorImpl implements ResponseInspector {
 
     @Transactional(readOnly = true)
     @Override
-    public boolean hasAdjustments(@NonNull final DigitalResponse r) {
-        if ((r.getReasonableAdjustments() != null && !r.getReasonableAdjustments().isEmpty())
-            //    if ((r.getSpecialNeeds() != null && !r.getSpecialNeeds().isEmpty())
-            || !Strings.isNullOrEmpty(r.getReasonableAdjustmentsArrangements())) {
-            log.debug("Response {} has reasonable adjustments", r.getJurorNumber());
+    public boolean hasAdjustments(@NonNull final DigitalResponse response) {
+        if ((response.getReasonableAdjustments() != null && !response.getReasonableAdjustments().isEmpty())
+            //    if ((response.getSpecialNeeds() != null && !response.getSpecialNeeds().isEmpty())
+            || !Strings.isNullOrEmpty(response.getReasonableAdjustmentsArrangements())) {
+            log.debug("Response {} has reasonable adjustments", response.getJurorNumber());
             return true;
         }
 
-        log.trace("Response {} does not have reasonable adjustments", r.getJurorNumber());
+        log.trace("Response {} does not have reasonable adjustments", response.getJurorNumber());
         return false;
     }
 
     @Override
-    public boolean isWelshLanguage(@NonNull final DigitalResponse r) {
+    public boolean isWelshLanguage(@NonNull final DigitalResponse response) {
         if (appSettingService.isWelshEnabled()) {
-            if (BooleanUtils.isTrue(r.getWelsh())) {
-                log.debug("Juror response {} is Welsh language response.", r.getJurorNumber());
+            if (BooleanUtils.isTrue(response.getWelsh())) {
+                log.debug("Juror response {} is Welsh language response.", response.getJurorNumber());
                 return true;
             }
         }
@@ -89,55 +89,53 @@ public class ResponseInspectorImpl implements ResponseInspector {
     }
 
     @Override
-    public String activeContactEmail(@NonNull final DigitalResponse r) {
-        if (isThirdPartyResponse(r)) {
-            if (BooleanUtils.isFalse(r.getJurorEmailDetails())) {
+    public String activeContactEmail(@NonNull final DigitalResponse response) {
+        if (isThirdPartyResponse(response)) {
+            if (BooleanUtils.isFalse(response.getJurorEmailDetails())) {
                 log.debug("Active contact email is third party.");
-                return r.getEmailAddress();
+                return response.getEmailAddress();
             }
         }
-        log.debug("Active contact email is juror.");
-        return r.getEmail();
+        log.debug("Active contact email is juroresponse.");
+        return response.getEmail();
     }
 
     @Override
-    public NotifyTemplateType responseType(@NonNull final DigitalResponse r) {
-        final String jurorNumber = r.getJurorNumber();
+    public NotifyTemplateType responseType(@NonNull final DigitalResponse response) {
+        final String jurorNumber = response.getJurorNumber();
 
         // fail fast
-        if (isJurorDeceased(r)) {
+        if (isJurorDeceased(response)) {
             log.debug("{} Excusal deceased", jurorNumber);
             return NotifyTemplateType.EXCUSAL_DECEASED;
         }
 
-        if (isJurorAgeDisqualified(r)) {
+        if (isJurorAgeDisqualified(response)) {
             log.debug("{} Disqualification age", jurorNumber);
             return NotifyTemplateType.DISQUALIFICATION_AGE;
         }
 
-        if (isExcusal(r)) {
+        if (isExcusal(response)) {
             log.debug("{} Excusal", jurorNumber);
             return NotifyTemplateType.EXCUSAL;
         }
-        if (isDeferral(r)) {
+        if (isDeferral(response)) {
             log.debug("{} Deferral", jurorNumber);
             return NotifyTemplateType.DEFERRAL;
         }
 
-        // is now a straight through since other types have been checked.
-        log.warn("{} Acceptance");
         return NotifyTemplateType.STRAIGHT_THROUGH;//default value
     }
 
     @Override
-    public boolean isJurorAgeDisqualified(final DigitalResponse r) {
+    public boolean isJurorAgeDisqualified(final DigitalResponse response) {
         try {
-            final JurorPool j = jurorRepository.findByJurorJurorNumber(r.getJurorNumber());
-            int age = getJurorAgeAtHearingDate(r.getDateOfBirth(), j.getNextDate());
+            final JurorPool j = jurorRepository.findByJurorJurorNumber(response.getJurorNumber());
+            int age = getJurorAgeAtHearingDate(response.getDateOfBirth(), j.getNextDate());
             if (log.isTraceEnabled()) {
                 log.trace(
                     "Juror DOB {} at hearing date {} will be {} years old",
-                    r.getDateOfBirth(),
+                    response.getDateOfBirth(),
                     j.getNextDate(),
                     age
                 );
@@ -166,49 +164,50 @@ public class ResponseInspectorImpl implements ResponseInspector {
     }
 
     @Override
-    public boolean isIneligible(final DigitalResponse r) {
-        if (BooleanUtils.isFalse(r.getResidency())) {
-            log.debug("Response {} ineligible - Residency", r.getJurorNumber());
+    public boolean isIneligible(final DigitalResponse response) {
+        if (BooleanUtils.isFalse(response.getResidency())) {
+            log.debug("Response {} ineligible - Residency", response.getJurorNumber());
             return true;
         }
 
-        if (BooleanUtils.isTrue(r.getBail())) {
-            log.debug("Response {} ineligible - Residency", r.getJurorNumber());
+        if (BooleanUtils.isTrue(response.getBail())) {
+            log.debug("Response {} ineligible - Residency", response.getJurorNumber());
             return true;
         }
 
-        if (BooleanUtils.isTrue(r.getMentalHealthAct())) {
-            log.debug("Response {} ineligible - Mental Health Act", r.getJurorNumber());
+        if (BooleanUtils.isTrue(response.getMentalHealthAct())) {
+            log.debug("Response {} ineligible - Mental Health Act", response.getJurorNumber());
             return true;
         }
 
-        if (BooleanUtils.isTrue(r.getConvictions())) {
-            log.debug("Response {} ineligible - Convictions", r.getJurorNumber());
+        if (BooleanUtils.isTrue(response.getConvictions())) {
+            log.debug("Response {} ineligible - Convictions", response.getJurorNumber());
             return true;
         }
 
-        if ((r.getCjsEmployments() != null && !r.getCjsEmployments().isEmpty())) {
-            log.debug("Response {} ineligible - CJS employments", r.getJurorNumber());
+        if ((response.getCjsEmployments() != null && !response.getCjsEmployments().isEmpty())) {
+            log.debug("Response {} ineligible - CJS employments", response.getJurorNumber());
             return true;
         }
 
-        log.trace("Response {} is eligible for jury service", r.getJurorNumber());
+        log.trace("Response {} is eligible for jury service", response.getJurorNumber());
         return false;
     }
 
     @Override
-    public boolean isDeferral(final DigitalResponse r) {
-        return !Strings.isNullOrEmpty(r.getDeferralReason());
+    public boolean isDeferral(final DigitalResponse response) {
+        return !Strings.isNullOrEmpty(response.getDeferralReason());
     }
 
     @Override
-    public boolean isExcusal(final DigitalResponse r) {
-        return !Strings.isNullOrEmpty(r.getExcusalReason());
+    public boolean isExcusal(final DigitalResponse response) {
+        return !Strings.isNullOrEmpty(response.getExcusalReason());
     }
 
     @Override
-    public boolean isJurorDeceased(final DigitalResponse r) {
-        return !Strings.isNullOrEmpty(r.getThirdPartyReason()) && DECEASED.equalsIgnoreCase(r.getThirdPartyReason());
+    public boolean isJurorDeceased(final DigitalResponse response) {
+        return !Strings.isNullOrEmpty(response.getThirdPartyReason())
+            && DECEASED.equalsIgnoreCase(response.getThirdPartyReason());
     }
 
     @Override
@@ -264,10 +263,10 @@ public class ResponseInspectorImpl implements ResponseInspector {
     }
 
     @Override
-    public int getPoolNotification(final DigitalResponse r) {
+    public int getPoolNotification(final DigitalResponse response) {
         try {
-            // final Pool p = poolRepository.findByJurorNumber(r.getJurorNumber());
-            final JurorPool j = jurorRepository.findByJurorJurorNumber(r.getJurorNumber());
+            // final Pool p = poolRepository.findByJurorNumber(response.getJurorNumber());
+            final JurorPool j = jurorRepository.findByJurorJurorNumber(response.getJurorNumber());
             return j.getJuror().getNotifications();
         } catch (Exception e) {
             log.error("Failed to retrieve the pool.notification value for this juror response.", e);
@@ -276,13 +275,13 @@ public class ResponseInspectorImpl implements ResponseInspector {
     }
 
     @Override
-    public boolean isWelshCourt(final DigitalResponse r) {
+    public boolean isWelshCourt(final DigitalResponse response) {
         boolean courtIsWelsh = false;
         try {
 
-            // final Pool p = poolRepository.findByJurorNumber(r.getJurorNumber());
-            final JurorPool j = jurorRepository.findByJurorJurorNumber(r.getJurorNumber());
-            if (isWelshLanguage(r) && welshCourtLocRepository.findByLocCode(j.getCourt().getLocCode()) != null) {
+            // final Pool p = poolRepository.findByJurorNumber(response.getJurorNumber());
+            final JurorPool j = jurorRepository.findByJurorJurorNumber(response.getJurorNumber());
+            if (isWelshLanguage(response) && welshCourtLocRepository.findByLocCode(j.getCourt().getLocCode()) != null) {
                 log.debug("Court (locCode) {} is Welsh.", j.getCourt().getLocCode());
                 courtIsWelsh = true;
             }

--- a/src/main/java/uk/gov/hmcts/juror/api/validation/ResponseInspectorImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/validation/ResponseInspectorImpl.java
@@ -67,7 +67,6 @@ public class ResponseInspectorImpl implements ResponseInspector {
     @Override
     public boolean hasAdjustments(@NonNull final DigitalResponse response) {
         if ((response.getReasonableAdjustments() != null && !response.getReasonableAdjustments().isEmpty())
-            //    if ((response.getSpecialNeeds() != null && !response.getSpecialNeeds().isEmpty())
             || !Strings.isNullOrEmpty(response.getReasonableAdjustmentsArrangements())) {
             log.debug("Response {} has reasonable adjustments", response.getJurorNumber());
             return true;
@@ -130,25 +129,25 @@ public class ResponseInspectorImpl implements ResponseInspector {
     @Override
     public boolean isJurorAgeDisqualified(final DigitalResponse response) {
         try {
-            final JurorPool j = jurorRepository.findByJurorJurorNumber(response.getJurorNumber());
-            int age = getJurorAgeAtHearingDate(response.getDateOfBirth(), j.getNextDate());
+            final JurorPool jurorPool = jurorRepository.findByJurorJurorNumber(response.getJurorNumber());
+            int age = getJurorAgeAtHearingDate(response.getDateOfBirth(), jurorPool.getNextDate());
             if (log.isTraceEnabled()) {
                 log.trace(
                     "Juror DOB {} at hearing date {} will be {} years old",
                     response.getDateOfBirth(),
-                    j.getNextDate(),
+                    jurorPool.getNextDate(),
                     age
                 );
             }
             if (age < getYoungestJurorAgeAllowed()) {
                 log.info("Juror {} too young for straight through as they are younger than {} on summon date",
-                    j.getJurorNumber(), getYoungestJurorAgeAllowed()
+                    jurorPool.getJurorNumber(), getYoungestJurorAgeAllowed()
                 );
                 return true;
             } else if (age >= getTooOldJurorAge()) {
                 log.info(
                     "Juror {} too old for straight through as they are {} or older on summon date",
-                    j.getJurorNumber(),
+                    jurorPool.getJurorNumber(),
                     getTooOldJurorAge()
                 );
                 return true;
@@ -266,10 +265,10 @@ public class ResponseInspectorImpl implements ResponseInspector {
     public int getPoolNotification(final DigitalResponse response) {
         try {
             // final Pool p = poolRepository.findByJurorNumber(response.getJurorNumber());
-            final JurorPool j = jurorRepository.findByJurorJurorNumber(response.getJurorNumber());
-            return j.getJuror().getNotifications();
-        } catch (Exception e) {
-            log.error("Failed to retrieve the pool.notification value for this juror response.", e);
+            final JurorPool jurorPool = jurorRepository.findByJurorJurorNumber(response.getJurorNumber());
+            return jurorPool.getJuror().getNotifications();
+        } catch (Exception exception) {
+            log.error("Failed to retrieve the pool.notification value for this juror response.", exception);
             return -1;
         }
     }
@@ -278,11 +277,10 @@ public class ResponseInspectorImpl implements ResponseInspector {
     public boolean isWelshCourt(final DigitalResponse response) {
         boolean courtIsWelsh = false;
         try {
-
-            // final Pool p = poolRepository.findByJurorNumber(response.getJurorNumber());
-            final JurorPool j = jurorRepository.findByJurorJurorNumber(response.getJurorNumber());
-            if (isWelshLanguage(response) && welshCourtLocRepository.findByLocCode(j.getCourt().getLocCode()) != null) {
-                log.debug("Court (locCode) {} is Welsh.", j.getCourt().getLocCode());
+            final JurorPool jurorPool = jurorRepository.findByJurorJurorNumber(response.getJurorNumber());
+            if (isWelshLanguage(response)
+                && welshCourtLocRepository.findByLocCode(jurorPool.getCourt().getLocCode()) != null) {
+                log.debug("Court (locCode) {} is Welsh.", jurorPool.getCourt().getLocCode());
                 courtIsWelsh = true;
             }
         } catch (Exception e) {

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/expense/JurorExpenseServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/expense/JurorExpenseServiceTest.java
@@ -4296,9 +4296,6 @@ class JurorExpenseServiceTest {
 
         @Test
         void positiveNotFound() {
-            when(appearanceRepository.findAllByJurorNumberAndPoolNumber(
-                TestConstants.VALID_COURT_LOCATION, TestConstants.VALID_JUROR_NUMBER
-            )).thenReturn(List.of());
 
             assertThat(jurorExpenseService.countExpenseTypes(
                 TestConstants.VALID_JUROR_NUMBER, TestConstants.VALID_POOL_NUMBER

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/trial/PanelServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/trial/PanelServiceImplTest.java
@@ -135,11 +135,11 @@ class PanelServiceImplTest {
         doReturn(createJurorPool(jurorNumbers, poolNumbers.get(0))).when(appearanceRepository)
             .getJurorsInPools(locCode, poolNumbers, date);
         doReturn(Optional.of(createAppearance("121212121"))).when(appearanceRepository)
-            .findByJurorNumberAndAttendanceDate("121212121", now());
+            .findByCourtLocationLocCodeAndJurorNumberAndAttendanceDate(locCode, "121212121", now());
         doReturn(Optional.of(createAppearance("121212121"))).when(appearanceRepository)
-            .findByJurorNumberAndAttendanceDate("121212121", now());
+            .findByCourtLocationLocCodeAndJurorNumberAndAttendanceDate(locCode, "121212121", now());
         doReturn(Optional.of(createAppearance("111111111"))).when(appearanceRepository)
-            .findByJurorNumberAndAttendanceDate("111111111", now());
+            .findByCourtLocationLocCodeAndJurorNumberAndAttendanceDate(locCode, "111111111", now());
 
 
         List<PanelListDto> dtoList = panelService.createPanel(2,
@@ -175,9 +175,9 @@ class PanelServiceImplTest {
         doReturn(createJurorPool(jurorNumbers, "415231201")).when(appearanceRepository)
             .retrieveAllJurors(locCode, date);
         doReturn(Optional.of(createAppearance("111111111"))).when(appearanceRepository)
-            .findByJurorNumberAndAttendanceDate("111111111", now());
+            .findByCourtLocationLocCodeAndJurorNumberAndAttendanceDate(locCode, "111111111", now());
         doReturn(Optional.of(createAppearance("121212121"))).when(appearanceRepository)
-            .findByJurorNumberAndAttendanceDate("121212121", now());
+            .findByCourtLocationLocCodeAndJurorNumberAndAttendanceDate(locCode, "121212121", now());
 
         List<PanelListDto> dtoList = panelService.createPanel(2,
             "T100000025",
@@ -214,9 +214,9 @@ class PanelServiceImplTest {
 
         doReturn(jurorPools).when(appearanceRepository).retrieveAllJurors(locCode, date);
         doReturn(Optional.of(createAppearance("121212121"))).when(appearanceRepository)
-            .findByJurorNumberAndAttendanceDate("121212121", now());
+            .findByCourtLocationLocCodeAndJurorNumberAndAttendanceDate(locCode, "121212121", now());
         doReturn(Optional.of(createAppearance("111111111"))).when(appearanceRepository)
-            .findByJurorNumberAndAttendanceDate("111111111", now());
+            .findByCourtLocationLocCodeAndJurorNumberAndAttendanceDate(locCode, "111111111", now());
 
         ArrayList<String> poolNumbers = new ArrayList<>();
         List<PanelListDto> dtoList = panelService.createPanel(2,
@@ -405,8 +405,8 @@ class PanelServiceImplTest {
                 .findByTrialTrialNumberAndTrialCourtLocationLocCodeAndJurorJurorNumber(
                     "T100000025", "415", member.getJurorNumber());
             doReturn(Optional.of(createAppearance(member.getJurorNumber()))).when(appearanceRepository)
-                .findByJurorNumberAndAttendanceDateAndAppearanceStage(member.getJurorNumber(),
-                    now(), AppearanceStage.CHECKED_IN);
+                .findByLocCodeAndJurorNumberAndAttendanceDateAndAppearanceStage(
+                    "415", member.getJurorNumber(), now(), AppearanceStage.CHECKED_IN);
             if (member.getResult() != PanelResult.JUROR) {
                 totalUnusedJurors++;
             }
@@ -444,8 +444,8 @@ class PanelServiceImplTest {
                     "415",
                     member.getJurorNumber());
             doReturn(Optional.of(createAppearance(member.getJurorNumber()))).when(appearanceRepository)
-                .findByJurorNumberAndAttendanceDateAndAppearanceStage(member.getJurorNumber(),
-                    now(), AppearanceStage.CHECKED_IN);
+                .findByLocCodeAndJurorNumberAndAttendanceDateAndAppearanceStage(
+                    "415", member.getJurorNumber(), now(), AppearanceStage.CHECKED_IN);
         }
 
         doReturn(Optional.of(createTrial())).when(trialRepository).findByTrialNumberAndCourtLocationLocCode(anyString(),
@@ -528,7 +528,7 @@ class PanelServiceImplTest {
                 .findByTrialTrialNumberAndTrialCourtLocationLocCodeAndJurorJurorNumber(
                     "T100000025", "415", member.getJurorNumber());
             doReturn(Optional.empty()).when(appearanceRepository)
-                .findByJurorNumberAndAttendanceDateAndAppearanceStage(member.getJurorNumber(),
+                .findByLocCodeAndJurorNumberAndAttendanceDateAndAppearanceStage("415", member.getJurorNumber(),
                     now(), AppearanceStage.CHECKED_IN);
         }
 
@@ -618,9 +618,7 @@ class PanelServiceImplTest {
                     .findByTrialTrialNumberAndTrialCourtLocationLocCode(anyString(), anyString());
 
                 List<String> jurorNumbers = new ArrayList<>();
-                for (int i = 0;
-                     i < maxJurors;
-                     i++) {
+                for (int i = 0; i < maxJurors; i++) {
                     jurorNumbers.add(jurorNumberFormat.formatted(i));
                 }
 
@@ -629,13 +627,11 @@ class PanelServiceImplTest {
                     .retrieveAllJurors(locCode, date);
 
                 List<Appearance> appearanceList = new ArrayList<>();
-                for (int i = 0;
-                     i < maxJurors;
-                     i++) {
+                for (int i = 0; i < maxJurors; i++) {
                     String jurorNumber = jurorNumbers.get(i);
                     Appearance appearance = createAppearance(jurorNumber);
                     doReturn(Optional.of(appearance)).when(appearanceRepository)
-                        .findByJurorNumberAndAttendanceDate(jurorNumber, now());
+                        .findByCourtLocationLocCodeAndJurorNumberAndAttendanceDate(locCode, jurorNumber, now());
                     appearanceList.add(appearance);
                 }
 
@@ -702,7 +698,7 @@ class PanelServiceImplTest {
                     String jurorNumber = jurorNumbers.get(i);
                     Appearance appearance = createAppearance(jurorNumber);
                     doReturn(Optional.of(appearance)).when(appearanceRepository)
-                        .findByJurorNumberAndAttendanceDate(jurorNumber, now());
+                        .findByCourtLocationLocCodeAndJurorNumberAndAttendanceDate(locCode, jurorNumber, now());
                     appearanceList.add(appearance);
                 }
 
@@ -957,8 +953,6 @@ class PanelServiceImplTest {
                     .findByTrialTrialNumberAndTrialCourtLocationLocCode(anyString(), anyString());
                 doReturn(createJurorPool(Collections.singletonList("111111111"), "415231201")).when(
                     appearanceRepository).retrieveAllJurors(locCode, date);
-                doReturn(Optional.of(createAppearance("111111111"))).when(appearanceRepository)
-                    .findByJurorNumberAndAttendanceDate("111111111", now());
 
                 MojException.BusinessRuleViolation exception = assertThrows(MojException.BusinessRuleViolation.class,
                     () -> {

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/trial/TrialServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/trial/TrialServiceImplTest.java
@@ -49,7 +49,6 @@ import uk.gov.hmcts.juror.api.moj.service.JurorHistoryService;
 import uk.gov.hmcts.juror.api.moj.service.expense.JurorExpenseService;
 import uk.gov.hmcts.juror.api.moj.service.jurormanagement.JurorAppearanceService;
 
-import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -320,21 +319,6 @@ class TrialServiceImplTest {
         when(panelRepository.findByTrialTrialNumberAndTrialCourtLocationLocCode(trialNumber, "415"))
             .thenReturn(panelMembers);
 
-
-        for (Panel panel : panelMembers) {
-            Appearance appearance = createAppearance(panel.getJurorNumber());
-
-            if ("null".equals(checkInTime)) {
-                appearance.setTimeIn(null);
-                appearance.setTimeOut(null);
-            } else {
-                appearance.setTimeIn(LocalTime.parse(checkInTime));
-                appearance.setTimeOut(LocalTime.parse(checkInTime));
-            }
-
-            when(appearanceRepository.findByJurorNumberAndAttendanceDate(panel.getJurorNumber(),
-                now())).thenReturn(Optional.of(appearance));
-        }
         doAnswer(invocationOnMock -> {
             Appearance appearance = invocationOnMock.getArgument(0);
             appearance.setAttendanceType(AttendanceType.HALF_DAY);
@@ -364,17 +348,6 @@ class TrialServiceImplTest {
         List<Panel> panelMembers = createPanelMembers(10, PanelResult.JUROR, trialNumber, IJurorStatus.JUROR);
         when(panelRepository.findByTrialTrialNumberAndTrialCourtLocationLocCode(trialNumber, "415"))
             .thenReturn(panelMembers);
-
-
-        for (Panel panel : panelMembers) {
-            Appearance appearance = createAppearance(panel.getJurorNumber());
-
-            appearance.setTimeIn(null);
-            appearance.setTimeOut(null);
-
-            when(appearanceRepository.findByJurorNumberAndAttendanceDate(panel.getJurorNumber(),
-                now())).thenReturn(Optional.of(appearance));
-        }
 
         doAnswer(invocationOnMock -> {
             Appearance appearance = invocationOnMock.getArgument(0);
@@ -406,16 +379,6 @@ class TrialServiceImplTest {
         when(panelRepository.findByTrialTrialNumberAndTrialCourtLocationLocCode(trialNumber, "415"))
             .thenReturn(panelMembers);
 
-
-        for (Panel panel : panelMembers) {
-            Appearance appearance = createAppearance(panel.getJurorNumber());
-
-            appearance.setTimeIn(null);
-            appearance.setTimeOut(null);
-
-            when(appearanceRepository.findByJurorNumberAndAttendanceDate(panel.getJurorNumber(),
-                now())).thenReturn(Optional.of(appearance));
-        }
         doAnswer(invocationOnMock -> {
             Appearance appearance = invocationOnMock.getArgument(0);
             appearance.setAttendanceType(AttendanceType.FULL_DAY_LONG_TRIAL);
@@ -446,16 +409,6 @@ class TrialServiceImplTest {
         when(panelRepository.findByTrialTrialNumberAndTrialCourtLocationLocCode(trialNumber, "415"))
             .thenReturn(panelMembers);
 
-
-        for (Panel panel : panelMembers) {
-            Appearance appearance = createAppearance(panel.getJurorNumber());
-
-            appearance.setTimeIn(null);
-            appearance.setTimeOut(null);
-
-            when(appearanceRepository.findByJurorNumberAndAttendanceDate(panel.getJurorNumber(),
-                now())).thenReturn(Optional.of(appearance));
-        }
         doAnswer(invocationOnMock -> {
             Appearance appearance = invocationOnMock.getArgument(0);
             appearance.setAttendanceType(AttendanceType.HALF_DAY_LONG_TRIAL);
@@ -487,13 +440,6 @@ class TrialServiceImplTest {
         doReturn(panelMembers).when(panelRepository)
             .findByTrialTrialNumberAndTrialCourtLocationLocCode(trialNumber, "415");
 
-        for (Panel panel : panelMembers) {
-            Appearance appearance = createAppearance(panel.getJurorNumber());
-            appearance.setTimeIn(null);
-            when(appearanceRepository.findByJurorNumberAndAttendanceDate(panel.getJurorNumber(),
-                now())).thenReturn(Optional.of(appearance));
-        }
-
         trialService
             .returnJury(payload, trialNumber, "415",
                 createReturnJuryDto(false, "09:30", null));
@@ -511,13 +457,6 @@ class TrialServiceImplTest {
         List<Panel> panelMembers = createPanelMembers(10, PanelResult.JUROR, trialNumber, IJurorStatus.JUROR);
         doReturn(panelMembers).when(panelRepository)
             .findByTrialTrialNumberAndTrialCourtLocationLocCode(trialNumber, "415");
-
-        for (Panel panel : panelMembers) {
-            createJurorPool(panel.getJuror(), panel.getTrial().getCourtLocation(), IJurorStatus.JUROR);
-            Appearance appearance = createAppearance(panel.getJurorNumber());
-            when(appearanceRepository.findByJurorNumberAndAttendanceDate(panel.getJurorNumber(),
-                now())).thenReturn(Optional.of(appearance));
-        }
 
         trialService.returnJury(payload, trialNumber, "415",
             createReturnJuryDto(true, "09:00", "10:00"));
@@ -734,20 +673,6 @@ class TrialServiceImplTest {
         createJurorPool(juror, panel.getTrial().getCourtLocation(), jurorStatusValue);
 
         return panel;
-    }
-
-    private Appearance createAppearance(String jurorNumber) {
-        CourtLocation courtlocation = new CourtLocation();
-        courtlocation.setLocCode("415");
-        courtlocation.setName("Chester");
-
-        Appearance appearance = new Appearance();
-        appearance.setAttendanceDate(now());
-        appearance.setTimeIn(LocalTime.now());
-        appearance.setJurorNumber(jurorNumber);
-        appearance.setCourtLocation(courtlocation);
-
-        return appearance;
     }
 
     private EndTrialDto createEndTrialDto() {

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/trial/TrialServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/trial/TrialServiceImplTest.java
@@ -464,7 +464,7 @@ class TrialServiceImplTest {
         verify(panelRepository, times(1))
             .findByTrialTrialNumberAndTrialCourtLocationLocCode(trialNumber, "415");
         verify(panelRepository, times(panelMembers.size())).saveAndFlush(any());
-        verify(completeService, times(panelMembers.size())).completeService(anyString(), any());
+        verify(completeService, times(panelMembers.size())).completeServiceSingle(any(), any());
         verify(jurorHistoryService, times(panelMembers.size())).createJuryAttendanceHistory(any(), any(), any());
         ArgumentCaptor<Appearance> appearanceArgumentCaptor = ArgumentCaptor.forClass(Appearance.class);
         verify(jurorAppearanceService, times(panelMembers.size()))


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7964)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=682)


### Change description ###
Class: TrialServiceImpl

Method: {{returnJury}}

A jury attendance audit number is applied but the trial number is not added to the appearance record (which it should be)

+*Other Fixes Applied:*+

* Updated panel logic to include loc_code filters
* Updated panel & trial logic to use transaction rejecting all database actions un error
* Added new errors when you create/edit a trial using a courtroom or judge that does not belong to that court location 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
