### PR TITLE
INC2529995 - Mismatch in figures between Allocated work from 'Assign Replies' (20) and user's queue to process (18) [HMCTS Ref INC5632895]

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/bureau/service/BureauBacklogAllocateServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/bureau/service/BureauBacklogAllocateServiceImpl.java
@@ -96,7 +96,8 @@ public class BureauBacklogAllocateServiceImpl implements BureauBacklogAllocateSe
             );
             if (staffMemberNonUrgentCount > 0) {
                 toBeAllocated.addAll(allocateResponses(
-                    JurorResponseQueries.byUnassignedTodoNonUrgent(),
+                    JurorResponseQueries.byUnassignedTodoNonUrgent()
+                        .and(JurorResponseQueries.jurorIsNotTransferred()),
                     staffMember,
                     staffMemberNonUrgentCount
                 ));
@@ -109,7 +110,8 @@ public class BureauBacklogAllocateServiceImpl implements BureauBacklogAllocateSe
             );
             if (staffMemberUrgentCount > 0) {
                 toBeAllocated.addAll(allocateResponses(
-                    JurorResponseQueries.byUnassignedTodoUrgent(),
+                    JurorResponseQueries.byUnassignedTodoUrgent()
+                        .and(JurorResponseQueries.jurorIsNotTransferred()),
                     staffMember,
                     staffMemberUrgentCount
                 ));

--- a/src/main/java/uk/gov/hmcts/juror/api/bureau/service/BureauOfficerAllocatedRepliesServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/bureau/service/BureauOfficerAllocatedRepliesServiceImpl.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.juror.api.bureau.controller.response.BureauBacklogCountData;
 import uk.gov.hmcts.juror.api.bureau.controller.response.BureauOfficerAllocatedData;
 import uk.gov.hmcts.juror.api.bureau.controller.response.BureauOfficerAllocatedResponses;
@@ -21,6 +22,7 @@ public class BureauOfficerAllocatedRepliesServiceImpl implements BureauOfficerAl
     private final JurorDigitalResponseRepositoryMod jurorResponseRepository;
 
     @Override
+    @Transactional
     public BureauOfficerAllocatedResponses getBackLogData() {
         Tuple backlogStats = jurorResponseRepository.getAssignRepliesStatistics();
 

--- a/src/main/java/uk/gov/hmcts/juror/api/bureau/service/BureauServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/bureau/service/BureauServiceImpl.java
@@ -20,7 +20,6 @@ import uk.gov.hmcts.juror.api.moj.domain.Juror;
 import uk.gov.hmcts.juror.api.moj.domain.JurorPool;
 import uk.gov.hmcts.juror.api.moj.domain.ModJurorDetail;
 import uk.gov.hmcts.juror.api.moj.domain.PoolRequest;
-import uk.gov.hmcts.juror.api.moj.domain.QJuror;
 import uk.gov.hmcts.juror.api.moj.domain.QJurorPool;
 import uk.gov.hmcts.juror.api.moj.domain.QModJurorDetail;
 import uk.gov.hmcts.juror.api.moj.domain.QPoolRequest;
@@ -128,7 +127,8 @@ public class BureauServiceImpl implements BureauService {
     private Map<ProcessingStatus, Long> getJurorResponseCounts(String username) {
         return jurorCommonResponseRepositoryMod.getJurorResponseCounts(
             QCombinedJurorResponse.combinedJurorResponse.staff.username.eq(username),
-            QCombinedJurorResponse.combinedJurorResponse.processingStatus.ne(ProcessingStatus.CLOSED)
+            QCombinedJurorResponse.combinedJurorResponse.processingStatus.ne(ProcessingStatus.CLOSED),
+            QCombinedJurorResponse.combinedJurorResponse.juror.bureauTransferDate.isNull()
         );
     }
 
@@ -179,7 +179,7 @@ public class BureauServiceImpl implements BureauService {
                     .map(tuple -> {
                         CombinedJurorResponse jurorResponseRepository1 =
                             tuple.get(QCombinedJurorResponse.combinedJurorResponse);
-                        Juror juror = tuple.get(QJuror.juror);
+                        Juror juror = jurorResponseRepository1.getJuror();
                         JurorPool jurorPool = tuple.get(QJurorPool.jurorPool);
                         PoolRequest pool = tuple.get(QPoolRequest.poolRequest);
                         return bureauTransformsService.detailToDto(jurorResponseRepository1, juror, jurorPool, pool);

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/domain/jurorresponse/CombinedJurorResponse.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/domain/jurorresponse/CombinedJurorResponse.java
@@ -4,10 +4,12 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
 import jakarta.validation.constraints.NotNull;
@@ -21,6 +23,7 @@ import org.hibernate.validator.constraints.Length;
 import uk.gov.hmcts.juror.api.juror.domain.ProcessingStatus;
 import uk.gov.hmcts.juror.api.moj.domain.Address;
 import uk.gov.hmcts.juror.api.moj.domain.ContactLog;
+import uk.gov.hmcts.juror.api.moj.domain.Juror;
 import uk.gov.hmcts.juror.api.moj.domain.User;
 import uk.gov.hmcts.juror.api.validation.LocalDateOfBirth;
 import uk.gov.hmcts.juror.api.validation.ValidationConstants;
@@ -48,6 +51,11 @@ public class CombinedJurorResponse extends Address implements Serializable {
     @Length(max = 9)
     @NotNull
     private String jurorNumber;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "juror_number", referencedColumnName = "juror_number", insertable = false, updatable = false,
+        nullable = false)
+    private Juror juror;
 
     @Column(name = "date_received")
     @NotNull

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/jurorresponse/IJurorCommonResponseRepositoryModImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/jurorresponse/IJurorCommonResponseRepositoryModImpl.java
@@ -7,7 +7,6 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import uk.gov.hmcts.juror.api.juror.domain.ProcessingStatus;
-import uk.gov.hmcts.juror.api.moj.domain.QJuror;
 import uk.gov.hmcts.juror.api.moj.domain.QJurorPool;
 import uk.gov.hmcts.juror.api.moj.domain.QPoolRequest;
 import uk.gov.hmcts.juror.api.moj.domain.jurorresponse.QCombinedJurorResponse;
@@ -28,18 +27,16 @@ public class IJurorCommonResponseRepositoryModImpl implements IJurorCommonRespon
                                                                   Predicate... predicates) {
         JPAQuery<Tuple> query = getJpaQueryFactory().select(
                 QCombinedJurorResponse.combinedJurorResponse,
-                QJuror.juror,
                 QJurorPool.jurorPool,
                 QPoolRequest.poolRequest
             )
             .from(QCombinedJurorResponse.combinedJurorResponse)
-            .join(QJuror.juror)
-            .on(QJuror.juror.jurorNumber.eq(QCombinedJurorResponse.combinedJurorResponse.jurorNumber))
-
-            .join(QJurorPool.jurorPool).on(QJurorPool.jurorPool.juror.eq(QJuror.juror))
+            .join(QJurorPool.jurorPool)
+            .on(QJurorPool.jurorPool.juror.eq(QCombinedJurorResponse.combinedJurorResponse.juror))
             .join(QPoolRequest.poolRequest).on(QPoolRequest.poolRequest.eq(QJurorPool.jurorPool.pool))
             .where(QCombinedJurorResponse.combinedJurorResponse.staff.username.eq(staffLogin))
             .where(QCombinedJurorResponse.combinedJurorResponse.processingStatus.in(processingStatus))
+            .where(QCombinedJurorResponse.combinedJurorResponse.juror.bureauTransferDate.isNull())
             .where(QJurorPool.jurorPool.isActive.isTrue())
             .where(QJurorPool.jurorPool.owner.eq(SecurityUtil.BUREAU_OWNER));
 
@@ -57,10 +54,10 @@ public class IJurorCommonResponseRepositoryModImpl implements IJurorCommonRespon
                 QCombinedJurorResponse.combinedJurorResponse.count()
             )
             .from(QCombinedJurorResponse.combinedJurorResponse)
-            .join(QJuror.juror)
-            .on(QJuror.juror.jurorNumber.eq(QCombinedJurorResponse.combinedJurorResponse.jurorNumber))
-            .join(QJurorPool.jurorPool).on(QJurorPool.jurorPool.juror.eq(QJuror.juror))
+            .join(QJurorPool.jurorPool)
+            .on(QJurorPool.jurorPool.juror.eq(QCombinedJurorResponse.combinedJurorResponse.juror))
             .where(QJurorPool.jurorPool.isActive.isTrue())
+            .where(QCombinedJurorResponse.combinedJurorResponse.juror.bureauTransferDate.isNull())
             .where(QJurorPool.jurorPool.owner.eq(SecurityUtil.BUREAU_OWNER));
 
         if (predicates != null && predicates.length > 0) {

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/jurorresponse/JurorDigitalResponseRepositoryModImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/jurorresponse/JurorDigitalResponseRepositoryModImpl.java
@@ -6,7 +6,9 @@ import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.juror.api.juror.domain.ProcessingStatus;
+import uk.gov.hmcts.juror.api.moj.domain.QJuror;
 import uk.gov.hmcts.juror.api.moj.domain.QUser;
 import uk.gov.hmcts.juror.api.moj.domain.UserType;
 import uk.gov.hmcts.juror.api.moj.domain.jurorresponse.QDigitalResponse;
@@ -31,27 +33,32 @@ public class JurorDigitalResponseRepositoryModImpl implements IJurorDigitalRespo
                 digitalResponse.count().as("allReplies"))
             .from(digitalResponse)
             .where(digitalResponse.processingStatus.eq(ProcessingStatus.TODO))
+            .where(digitalResponse.juror.bureauTransferDate.isNull())
             .where(digitalResponse.staff.isNull());
         return query.fetchOne();
     }
 
     @Override
+    @Transactional
     public List<Tuple> getAssignRepliesStatisticForUsers() {
         JPAQuery<Tuple> query = getJpaQueryFactory().select(
                 user.username.as("login"),
                 user.name.as("name"),
                 new CaseBuilder()
-                    .when(digitalResponse.urgent.isFalse())
+                    .when(digitalResponse.urgent.isFalse().and(QJuror.juror.isNotNull()))
                     .then(1L).otherwise(0L).sum().as("nonUrgent"),
                 new CaseBuilder()
-                    .when(digitalResponse.urgent.isTrue())
+                    .when(digitalResponse.urgent.isTrue().and(QJuror.juror.isNotNull()))
                     .then(1L).otherwise(0L).sum().as("urgent"),
                 digitalResponse.count().as("allReplies")
             ).from(user)
             .where(user.userType.eq(UserType.BUREAU))
             .where(user.active.isTrue())
             .leftJoin(digitalResponse)
-            .on(user.eq(digitalResponse.staff).and(digitalResponse.processingStatus.eq(ProcessingStatus.TODO)))
+            .on(user.eq(digitalResponse.staff)
+                .and(digitalResponse.processingStatus.eq(ProcessingStatus.TODO)))
+            .leftJoin(QJuror.juror).on(QJuror.juror.jurorNumber.eq(digitalResponse.jurorNumber)
+                .and(QJuror.juror.bureauTransferDate.isNull()))
             .groupBy(user.username, user.name);
         return query.fetch();
     }

--- a/src/test/java/uk/gov/hmcts/juror/api/bureau/service/BureauBacklogAllocateServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/bureau/service/BureauBacklogAllocateServiceImplTest.java
@@ -80,10 +80,12 @@ public class BureauBacklogAllocateServiceImplTest {
         // because the mock repo will return nothing
 
 
-        doReturn(nonUrgentResponses).when(responseRepo).findAll(JurorResponseQueries.byUnassignedTodoNonUrgent(),
+        doReturn(nonUrgentResponses).when(responseRepo).findAll(JurorResponseQueries.byUnassignedTodoNonUrgent()
+                .and(JurorResponseQueries.jurorIsNotTransferred()),
             PageRequest.of(0, NON_URGENT_TO_ALLOCATE_TO_STAFF, Sort.Direction.ASC, "dateReceived"));
 
-        doReturn(urgentResponses).when(responseRepo).findAll(JurorResponseQueries.byUnassignedTodoUrgent(),
+        doReturn(urgentResponses).when(responseRepo).findAll(JurorResponseQueries.byUnassignedTodoUrgent()
+                .and(JurorResponseQueries.jurorIsNotTransferred()),
             PageRequest.of(0, URGENT_TO_ALLOCATE_TO_STAFF, Sort.Direction.ASC, "dateReceived"));
 
 


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7899)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=700)


### Change description ###
Your Work/To Do is showing 18 Jurors, but "Assign Replies" shows 20 
The user has got 20 jurors assigned with status of "TODO" in juror_response table.



!image-20240724-093051.png|width=466,height=379,alt="image-20240724-093051.png"!





!image-20240724-093058.png|width=780,height=649,alt="image-20240724-093058.png"!



Akik has done some initial analysis. The 2 extra jurors(440406091 & 347411804) were transferred to court(before migration) and has got owner other than 400. Code should apply a filter before showing the count.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
