### PR TITLE
INC2536487 - When reprinting reminders, the user get a error message - unable to reprint for selected jurors [HMCTS Ref INC5634218]

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/LetterController.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/LetterController.java
@@ -116,9 +116,7 @@ public class LetterController {
     @IsBureauUser
     public ResponseEntity<ReissueLetterReponseDto> reissueLetter(
         @RequestBody @Valid @NotNull ReissueLetterRequestDto request) {
-
         ReissueLetterReponseDto response = reissueLetterService.reissueLetter(request);
-
         return ResponseEntity.ok(response);
     }
 

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/letter/ReissueLetterServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/letter/ReissueLetterServiceTest.java
@@ -46,6 +46,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -777,12 +778,6 @@ public class ReissueLetterServiceTest {
             final ReissueLetterRequestDto reissueLetterRequestDto =
                 getReissueLetterRequestDto(reissueLetterRequestData);
 
-            final BulkPrintData bulkPrintData = getBulkPrintData(reissueLetterRequestData);
-
-            doReturn(Optional.of(bulkPrintData)).when(bulkPrintDataRepository)
-                .findByJurorNumberFormCodeDatePrinted(reissueLetterRequestData.getJurorNumber(),
-                    reissueLetterRequestData.getFormCode(), reissueLetterRequestData.getDatePrinted());
-
             doReturn(Optional.empty()).when(bulkPrintDataRepository)
                 .findByJurorNumberFormCodeAndPending(reissueLetterRequestData.getJurorNumber(),
                     reissueLetterRequestData.getFormCode());
@@ -800,7 +795,7 @@ public class ReissueLetterServiceTest {
 
             reissueLetterService.reissueLetter(reissueLetterRequestDto);
 
-            verify(bulkPrintDataRepository, times(1))
+            verify(bulkPrintDataRepository, never())
                 .findByJurorNumberFormCodeDatePrinted(reissueLetterRequestData.getJurorNumber(),
                     reissueLetterRequestData.getFormCode(), reissueLetterRequestData.getDatePrinted());
 


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-8055)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=704)


### Change description ###
INC2536487 - When reprinting reminders, the user get a error message - unable to reprint for selected jurors [HMCTS Ref INC5634218]



When reprinting reminders, the user get a error message - “Unable to reprint letters for the selected jurors”.

It is happening when trying to select all Juror records in a pool (451240901) and then send out a reminder letter. 
Error in the log:

{"timestamp":"2024-07-30 10:40:01","message":"*eq(null) is not allowed. Use isNull() instead*"}

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
