### PR TITLE
Space is missing before <welsh_courtname> in t_message_template

### DIFF
--- a/src/main/resources/db/migrationv2/V2_23_message_template.sql
+++ b/src/main/resources/db/migrationv2/V2_23_message_template.sql
@@ -1,0 +1,23 @@
+update table juror_mod.t_message_template
+set text  = 'Eich Gwasanaeth Rheithgor','Cysylltwch â Swyddfa Rheithgor <welsh_courtname> drwy ffonio <court_phone>  ynghylch eich gwasanaeth rheithgor.'
+where id = 26;
+
+update table juror_mod.t_message_template
+set text  = 'Eich Gwasanaeth Rheithgor','Nodyn Atgoffa: Cofiwch fynychu eich Gwasanaeth Rheithgor yn Llys <welsh_courtname> ar <attend_date> am <attend_time>. Os oes gennych unrhyw gwestiynau, cysylltwch â''r swyddfa rheithgor drwy ffonio <court_phone>.'
+where id = 18;
+
+update table juror_mod.t_message_template
+set text  = 'Eich Gwasanaeth Rheithgor','Bu ichi fethu â mynychu eich Gwasanaeth Rheithgor yn Llys <welsh_courtname> ar <attend_date>. Cysylltwch â''r Swyddfa Rheithgor drwy ffonio <court_phone>.'
+where id = 19;
+
+update table juror_mod.t_message_template
+set text  = 'Eich Gwasanaeth Rheithgor','Mae dyddiad mynychu eich Gwasanaeth Rheithgor wedi newid i <attend_date> am <attend_time> yn Llys <welsh_courtname>. Mae''r dyddiau pan na fydd eich angen yn y llys dal yn ffurfio rhan o''ch gwasanaeth rheithgor ac ni fyddant yn cael eu hychwanegu ar y diwedd. Os oes gennych unrhyw gwestiynau, cysylltwch â''r swyddfa rheithgor drwy ffonio <court_phone>.'
+where id = 20;
+
+update table juror_mod.t_message_template
+set text  = 'Eich Gwasanaeth Rheithgor','Mae angen i chi fynychu''r llys eto ar gyfer eich Gwasanaeth Rheithgor ar <attend_date> am <attend_time> yn Llys <welsh_courtname>. Os oes gennych unrhyw gwestiynau, cysylltwch â''r swyddfa rheithgor drwy ffonio <court_phone>.'
+where id = 24;
+
+update table juror_mod.t_message_template
+set text  = 'Eich Gwasanaeth Rheithgor','Rydych wedi cael eich dewis i fod yn rhan o banel a bydd Rheithgor yn cael ei ddewis o blith y panel hwnnw. Ewch i Lys <welsh_courtname> ar <attend_date> am <attend_time>. Os oes gennych unrhyw gwestiynau, cysylltwch â''r swyddfa rheithgor drwy ffonio <court_phone>.'
+where id = 28;


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-8057)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=707)


### Change description ###


!image-20240814-112042.png|width=1727,height=273,alt="image-20240814-112042.png"!



!image-20240814-112111.png|width=692,height=499,alt="image-20240814-112111.png"!

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
