### PR TITLE
Third party details in the juror record does not save the details

### DIFF
--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/AuditControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/AuditControllerITest.java
@@ -97,7 +97,6 @@ public class AuditControllerITest {
             testBuilder()
                 .url(toUrl("INVALID"))
                 .triggerInvalid()
-                .printResponse()
                 .assertInvalidPathParam("INVALID is the incorrect data type or is not in the expected format (date)");
         }
     }

--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorRecordControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorRecordControllerITest.java
@@ -863,7 +863,6 @@ class JurorRecordControllerITest extends AbstractIntegrationTest {
         assertThat(response.getStatusCode())
             .as("Expect the HTTP GET request to be successful")
             .isEqualTo(HttpStatus.OK);
-
         JurorDetailsResponseDto jurorDetails = response.getBody();
 
         assertThat(jurorDetails).isNotNull();

--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/report/grouped/ExcusedAndDisqualifiedListReportITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/report/grouped/ExcusedAndDisqualifiedListReportITest.java
@@ -123,7 +123,6 @@ class ExcusedAndDisqualifiedListReportITest extends AbstractGroupedReportControl
         testBuilder()
             .jwt(getCourtJwt("414"))
             .triggerInvalid()
-            .printResponse()
             .assertMojForbiddenResponse("User not allowed to access this pool");
     }
 

--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/report/standard/PoolAttendanceAuditReportITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/report/standard/PoolAttendanceAuditReportITest.java
@@ -43,7 +43,6 @@ class PoolAttendanceAuditReportITest extends AbstractStandardReportControllerITe
 
     @Test
     void positiveTypical() {
-        testBuilder().triggerInvalid().printResponse();
         testBuilder()
             .triggerValid()
             .responseConsumer(this::verifyAndRemoveReportCreated)

--- a/src/integration-test/resources/db/JurorRecordController_jurorDetailThirdPartyRequestBureau.sql
+++ b/src/integration-test/resources/db/JurorRecordController_jurorDetailThirdPartyRequestBureau.sql
@@ -25,9 +25,7 @@ VALUES
     NULL, 'Y', NULL, 'N', NULL, 'N', NULL, 'N', NULL, 'C', '7/6/2023, 3/7/2023, 9/8/2023', NULL, NULL, 'N', 0,
     'TPFIRSTNAME',
     'TPLASTNAME', 'Son of the juror', '012033223', '07878787323', 'new_email@address.com', 'Unable to read english or welsh', 'OTHER_REASON',
-    false,
-     false,
-    NULL,
-     NULL,
-     'N',
-    NULL,    'N', 'Digital');
+    false,false,NULL,NULL,'N', NULL,'N','Digital');
+
+INSERT INTO juror_mod.juror_third_party (juror_number, first_name, last_name, relationship, main_phone, other_phone, email_address, reason, other_reason, contact_juror_by_phone, contact_juror_by_email)
+VALUES('641600096', 'TPFIRSTNAME', 'TPLASTNAME', 'Son of the juror', '012033223', '07878787323', NULL, 'Unable to read english or welsh', NULL, false, false);

--- a/src/integration-test/resources/db/JurorRecordController_processNameChangeApproval.sql
+++ b/src/integration-test/resources/db/JurorRecordController_processNameChangeApproval.sql
@@ -21,10 +21,10 @@ VALUES ('415', '111111111', '415230701', true, 2);
 
 INSERT INTO juror_mod.rev_info
 (revision_number, revision_timestamp)
-VALUES(0, EXTRACT (EPOCH FROM current_date));
+VALUES(1, EXTRACT (EPOCH FROM current_date));
 
 INSERT INTO juror_mod.juror_audit
 (revision, juror_number, rev_type, title, first_name, last_name, dob, address_line_1, address_line_4, postcode, pending_title,
 pending_first_name, pending_last_name)
-VALUES(0, '111111111', 1, NULL, 'FNAMEONE', 'LNAMEONE', '1989-03-31', '543 STREET NAME', 'ANYTOWN', 'CH1 2AN', 'Mr',
+VALUES(1, '111111111', 1, NULL, 'FNAMEONE', 'LNAMEONE', '1989-03-31', '543 STREET NAME', 'ANYTOWN', 'CH1 2AN', 'Mr',
 'Test' ,'Person');

--- a/src/main/java/uk/gov/hmcts/juror/api/bureau/service/ResponseStatusUpdateServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/bureau/service/ResponseStatusUpdateServiceImpl.java
@@ -27,6 +27,7 @@ import uk.gov.hmcts.juror.api.moj.repository.JurorStatusRepository;
 import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorDigitalResponseRepositoryMod;
 import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorReasonableAdjustmentRepository;
 import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorResponseAuditRepositoryMod;
+import uk.gov.hmcts.juror.api.moj.service.JurorThirdPartyService;
 import uk.gov.hmcts.juror.api.moj.utils.RepositoryUtils;
 
 import java.time.LocalDate;
@@ -53,6 +54,7 @@ public class ResponseStatusUpdateServiceImpl implements ResponseStatusUpdateServ
     private final JurorReasonableAdjustmentRepository specialNeedsRepository;
     private final WelshCourtLocationRepository welshCourtLocationRepository;
     private final JurorResponseAuditRepositoryMod jurorResponseAuditRepositoryMod;
+    private final JurorThirdPartyService jurorThirdPartyService;
 
 
     /**
@@ -163,6 +165,11 @@ public class ResponseStatusUpdateServiceImpl implements ResponseStatusUpdateServ
             specialNeedsByJurorNumber.size()
         );
 
+
+        if (updatedDetails.getThirdPartyFName() != null) {
+            jurorThirdPartyService.createOrUpdateThirdParty(jurorDetails.getJuror(), updatedDetails);
+        }
+
         //if multiple set need to M
         if (specialNeedsByJurorNumber.size() > 1) {
             jurorDetails.getJuror().setReasonableAdjustmentCode("M");
@@ -201,7 +208,7 @@ public class ResponseStatusUpdateServiceImpl implements ResponseStatusUpdateServ
 
         // perform merge or changes
         // check for changes in original values
-        boolean titleChanged = false;
+        boolean titleChanged;
         if (updatedDetails.getTitle() != null) {
             if (jurorDetails.getJuror().getTitle() != null) {
                 titleChanged = updatedDetails.getTitle().compareTo(jurorDetails.getJuror().getTitle()) != 0;

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/request/EditJurorRecordRequestDto.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/request/EditJurorRecordRequestDto.java
@@ -152,4 +152,7 @@ public class EditJurorRecordRequestDto {
     @Schema(description = "Determines if Juror requires Welsh language")
     private Boolean welshLanguageRequired;
 
+    @JsonProperty("third_party")
+    private JurorThirdPartyDto thirdParty;
+
 }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/request/JurorThirdPartyDto.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/request/JurorThirdPartyDto.java
@@ -1,0 +1,77 @@
+package uk.gov.hmcts.juror.api.moj.controller.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.validator.constraints.Length;
+import uk.gov.hmcts.juror.api.moj.service.JurorThirdPartyService;
+
+import static uk.gov.hmcts.juror.api.validation.ValidationConstants.EMAIL_ADDRESS_REGEX;
+import static uk.gov.hmcts.juror.api.validation.ValidationConstants.NO_PIPES_REGEX;
+import static uk.gov.hmcts.juror.api.validation.ValidationConstants.PHONE_NO_REGEX;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class JurorThirdPartyDto implements JurorThirdPartyService.ThirdPartyUpdateDto {
+
+    @JsonProperty("first_name")
+    @Length(max = 50)
+    @Pattern(regexp = NO_PIPES_REGEX)
+    @Schema(description = "Third party first name")
+    private String firstName;
+
+    @JsonProperty("last_name")
+    @Length(max = 50)
+    @Pattern(regexp = NO_PIPES_REGEX)
+    @Schema(description = "Third party last name")
+    private String lastName;
+
+    @JsonProperty("relationship")
+    @Length(max = 50)
+    @Pattern(regexp = NO_PIPES_REGEX)
+    @Schema(description = "Relationship to juror")
+    private String relationship;
+
+    @JsonProperty("main_phone")
+    @Length(max = 50)
+    @Pattern(regexp = PHONE_NO_REGEX)
+    @Schema(description = "Main phone number")
+    private String mainPhone;
+
+    @JsonProperty("other_phone")
+    @Length(max = 50)
+    @Pattern(regexp = PHONE_NO_REGEX)
+    @Schema(description = "Other phone number")
+    private String otherPhone;
+
+    @JsonProperty("email_address")
+    @Length(max = 254)
+    @Pattern(regexp = EMAIL_ADDRESS_REGEX)
+    @Schema(description = "Email address")
+    private String emailAddress;
+
+    @JsonProperty("reason")
+    @Length(max = 1250)
+    @Pattern(regexp = NO_PIPES_REGEX)
+    @Schema(description = "Reason for third party")
+    private String reason;
+
+    @JsonProperty("other_reason")
+    @Length(max = 1250)
+    @Pattern(regexp = NO_PIPES_REGEX)
+    @Schema(description = "Other reason for third party")
+    private String otherReason;
+
+    @JsonProperty("contact_juror_by_phone")
+    private boolean contactJurorByPhone;
+
+    @JsonProperty("contact_juror_by_email")
+    private boolean contactJurorByEmail;
+
+}

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/response/JurorDetailsResponseDto.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/response/JurorDetailsResponseDto.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.juror.api.juror.controller.request.JurorResponseDto;
 import uk.gov.hmcts.juror.api.juror.domain.WelshCourtLocationRepository;
 import uk.gov.hmcts.juror.api.moj.domain.Juror;
 import uk.gov.hmcts.juror.api.moj.domain.JurorPool;
+import uk.gov.hmcts.juror.api.moj.domain.JurorThirdParty;
 import uk.gov.hmcts.juror.api.moj.domain.PoliceCheck;
 import uk.gov.hmcts.juror.api.moj.enumeration.jurorresponse.ReasonableAdjustmentsEnum;
 import uk.gov.hmcts.juror.api.moj.repository.JurorStatusRepository;
@@ -114,7 +115,6 @@ public class JurorDetailsResponseDto {
     @Schema(name = "Optic Reference", description = "Eight digit Optic Reference Number for Juror")
     private String opticReference;
 
-
     /**
      * Initialise an instance of this DTO class using a JurorPool object to populate its properties.
      *
@@ -155,6 +155,25 @@ public class JurorDetailsResponseDto {
         }
         this.specialNeedMessage = juror.getReasonableAdjustmentMessage();
         this.opticReference = juror.getOpticRef();
+        setJurorThirdParty(juror.getThirdParty());
+    }
+
+    private void setJurorThirdParty(JurorThirdParty jurorThirdParty) {
+        if (jurorThirdParty == null) {
+            this.thirdParty = null;
+            return;
+        }
+        this.thirdParty = new JurorResponseDto.ThirdParty();
+        this.thirdParty.setThirdPartyFName(jurorThirdParty.getFirstName());
+        this.thirdParty.setThirdPartyLName(jurorThirdParty.getLastName());
+        this.thirdParty.setThirdPartyReason(jurorThirdParty.getReason());
+        this.thirdParty.setThirdPartyOtherReason(jurorThirdParty.getOtherReason());
+        this.thirdParty.setRelationship(jurorThirdParty.getRelationship());
+        this.thirdParty.setMainPhone(jurorThirdParty.getMainPhone());
+        this.thirdParty.setOtherPhone(jurorThirdParty.getOtherPhone());
+        this.thirdParty.setEmailAddress(jurorThirdParty.getEmailAddress());
+        this.thirdParty.setUseJurorEmailDetails(jurorThirdParty.isContactJurorByEmail());
+        this.thirdParty.setUseJurorPhoneDetails(jurorThirdParty.isContactJurorByPhone());
     }
 
     /**

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/domain/Juror.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/domain/Juror.java
@@ -211,7 +211,6 @@ public class Juror extends Address implements Serializable {
     private String summonsFile;
 
 
-
     @Length(max = 254)
     @Column(name = "h_email")
     private String email;
@@ -305,6 +304,10 @@ public class Juror extends Address implements Serializable {
     @Generated
     private String phoneNumberCombined;
 
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "juror_number")
+    @NotAudited
+    private JurorThirdParty thirdParty;
 
     @PrePersist
     @SuppressWarnings("PMD.UnusedPrivateMethod")

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/domain/JurorThirdParty.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/domain/JurorThirdParty.java
@@ -1,0 +1,78 @@
+package uk.gov.hmcts.juror.api.moj.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.hibernate.envers.Audited;
+import org.hibernate.validator.constraints.Length;
+
+import static uk.gov.hmcts.juror.api.validation.ValidationConstants.NO_PIPES_REGEX;
+
+@Entity
+@Table(name = "juror_third_party", schema = "juror_mod")
+@Getter
+@Setter
+@Audited
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class JurorThirdParty {
+
+    @Id
+    @NotNull
+    @Column(name = "juror_number")
+    private String jurorNumber;
+
+    @Column(name = "first_name")
+    @Length(max = 50)
+    private String firstName;
+
+    @Column(name = "last_name")
+    @Length(max = 50)
+    private String lastName;
+
+    @Column(name = "relationship")
+    @Length(max = 50)
+    @Pattern(regexp = NO_PIPES_REGEX)
+    private String relationship;
+
+    @Column(name = "main_phone")
+    @Length(max = 50)
+    private String mainPhone;
+
+    @Column(name = "other_phone")
+    @Length(max = 50)
+    private String otherPhone;
+
+    @Column(name = "email_address")
+    @Length(max = 254)
+    private String emailAddress;
+
+    @Column(name = "reason")
+    @Pattern(regexp = NO_PIPES_REGEX)
+    @Length(max = 1250)
+    private String reason;
+
+    @Column(name = "other_reason")
+    @Pattern(regexp = NO_PIPES_REGEX)
+    @Length(max = 1250)
+    private String otherReason;
+
+    @Column(name = "contact_juror_by_phone")
+    private boolean contactJurorByPhone;
+
+    @Column(name = "contact_juror_by_email")
+    private boolean contactJurorByEmail;
+
+    public JurorThirdParty(String jurorNumber) {
+        this.jurorNumber = jurorNumber;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/domain/jurorresponse/DigitalResponse.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/domain/jurorresponse/DigitalResponse.java
@@ -13,6 +13,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import uk.gov.hmcts.juror.api.moj.service.JurorThirdPartyService;
 import uk.gov.hmcts.juror.api.moj.validation.DigitalThirdPartyOtherReason;
 
 import static uk.gov.hmcts.juror.api.validation.ValidationConstants.NO_PIPES_REGEX;
@@ -27,7 +28,8 @@ import static uk.gov.hmcts.juror.api.validation.ValidationConstants.NO_PIPES_REG
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 @SuppressWarnings("PMD.TooManyFields")
-public class DigitalResponse extends AbstractJurorResponse {
+public class DigitalResponse extends AbstractJurorResponse
+    implements JurorThirdPartyService.ThirdPartyUpdateDto {
 
     @Column(name = "residency")
     @NotNull
@@ -106,5 +108,25 @@ public class DigitalResponse extends AbstractJurorResponse {
     public DigitalResponse() {
         super();
         super.setReplyType(new ReplyType("Digital", "Online response"));
+    }
+
+    @Override
+    public String getOtherReason() {
+        return this.getThirdPartyOtherReason();
+    }
+
+    @Override
+    public String getReason() {
+        return this.getThirdPartyReason();
+    }
+
+    @Override
+    public boolean isContactJurorByEmail() {
+        return this.getJurorEmailDetails() != null && this.getJurorEmailDetails();
+    }
+
+    @Override
+    public boolean isContactJurorByPhone() {
+        return this.getJurorPhoneDetails() != null && this.getJurorPhoneDetails();
     }
 }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/JurorPoolRepository.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/JurorPoolRepository.java
@@ -48,11 +48,11 @@ public interface JurorPoolRepository extends IJurorPoolRepository, JpaRepository
     JurorPool findByJurorJurorNumberAndPoolPoolNumberAndStatus(String jurorNumber, String poolNumber,
                                                                JurorStatus status);
 
-    List<JurorPool> findByJurorJurorNumberOrderByDateCreatedDesc(String jurorNumber);
 
     JurorPool findByOwnerAndJurorJurorNumberAndPoolPoolNumberAndIsActive(String owner, String jurorNumber,
                                                                          String poolNumber, boolean isActive);
 
+    @Deprecated
     JurorPool findByJurorJurorNumber(String jurorNumber);
 
     JurorPool findByJurorJurorNumberAndIsActiveAndOwner(String jurorNumber, boolean isActive, String owner);

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/juror/JurorThirdPartyRepository.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/juror/JurorThirdPartyRepository.java
@@ -1,0 +1,9 @@
+package uk.gov.hmcts.juror.api.moj.repository.juror;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import uk.gov.hmcts.juror.api.moj.domain.JurorThirdParty;
+
+@Repository
+public interface JurorThirdPartyRepository extends JpaRepository<JurorThirdParty, String> {
+}

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/JurorRecordServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/JurorRecordServiceImpl.java
@@ -18,7 +18,6 @@ import uk.gov.hmcts.juror.api.bureau.domain.DisCode;
 import uk.gov.hmcts.juror.api.bureau.service.BureauService;
 import uk.gov.hmcts.juror.api.config.bureau.BureauJwtPayload;
 import uk.gov.hmcts.juror.api.config.security.IsCourtUser;
-import uk.gov.hmcts.juror.api.juror.controller.request.JurorResponseDto;
 import uk.gov.hmcts.juror.api.juror.domain.CourtLocation;
 import uk.gov.hmcts.juror.api.juror.domain.ProcessingStatus;
 import uk.gov.hmcts.juror.api.juror.domain.WelshCourtLocationRepository;
@@ -190,6 +189,7 @@ public class JurorRecordServiceImpl implements JurorRecordService {
     private final WelshCourtLocationRepository welshCourtLocationRepository;
     private final JurorResponseAuditRepositoryMod jurorResponseAuditRepository;
     private final JurorPoolService jurorPoolService;
+    private final JurorThirdPartyService jurorThirdPartyService;
 
     @Override
     @Transactional
@@ -224,6 +224,11 @@ public class JurorRecordServiceImpl implements JurorRecordService {
         } else {
             juror.setReasonableAdjustmentCode(null);
             juror.setReasonableAdjustmentMessage(null);
+        }
+        if (requestDto.getThirdParty() == null) {
+            jurorThirdPartyService.deleteThirdParty(juror);
+        } else {
+            jurorThirdPartyService.createOrUpdateThirdParty(juror, requestDto.getThirdParty());
         }
 
         juror.setPendingTitle(requestDto.getPendingTitle());
@@ -326,10 +331,6 @@ public class JurorRecordServiceImpl implements JurorRecordService {
         if (jurorResponse != null) {
             jurorDetailsResponseDto.setReplyMethod(REPLY_METHOD_ONLINE);
             jurorDetailsResponseDto.setReplyProcessingStatus(jurorResponse.getProcessingStatus().getDescription());
-            // Todo keep this in for now but will need to revisit post UAT
-            if (jurorResponse.getThirdPartyFName() != null) {
-                jurorDetailsResponseDto.setThirdParty(getThirdPartyDetails(jurorResponse));
-            }
             return jurorDetailsResponseDto;
         }
 
@@ -338,7 +339,6 @@ public class JurorRecordServiceImpl implements JurorRecordService {
             jurorDetailsResponseDto.setReplyMethod(REPLY_METHOD_PAPER);
             jurorDetailsResponseDto.setReplyProcessingStatus(response.getProcessingStatus().getDescription());
         }
-
         return jurorDetailsResponseDto;
     }
 
@@ -1083,24 +1083,6 @@ public class JurorRecordServiceImpl implements JurorRecordService {
         juror.setUserEdtq(auditorUsername);
 
         log.trace("Exit updateJurorNameDetails");
-    }
-
-    private JurorResponseDto.ThirdParty getThirdPartyDetails(DigitalResponse jurorResponse) {
-
-        JurorResponseDto.ThirdParty thirdParty = new JurorResponseDto.ThirdParty();
-
-        thirdParty.setThirdPartyFName(jurorResponse.getThirdPartyFName());
-        thirdParty.setThirdPartyLName(jurorResponse.getThirdPartyLName());
-        thirdParty.setThirdPartyReason(jurorResponse.getThirdPartyReason());
-        thirdParty.setThirdPartyOtherReason(jurorResponse.getThirdPartyOtherReason());
-        thirdParty.setRelationship(jurorResponse.getRelationship());
-        thirdParty.setMainPhone(jurorResponse.getMainPhone());
-        thirdParty.setOtherPhone(jurorResponse.getOtherPhone());
-        thirdParty.setEmailAddress(jurorResponse.getEmailAddress());
-        thirdParty.setUseJurorEmailDetails(jurorResponse.getJurorEmailDetails());
-        thirdParty.setUseJurorPhoneDetails(jurorResponse.getJurorPhoneDetails());
-
-        return thirdParty;
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/JurorThirdPartyService.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/JurorThirdPartyService.java
@@ -1,0 +1,33 @@
+package uk.gov.hmcts.juror.api.moj.service;
+
+import uk.gov.hmcts.juror.api.moj.domain.Juror;
+
+public interface JurorThirdPartyService {
+    void deleteThirdParty(Juror juror);
+
+    void createOrUpdateThirdParty(Juror juror, ThirdPartyUpdateDto thirdPartyUpdate);
+
+
+    interface ThirdPartyUpdateDto {
+
+        String getOtherReason();
+
+        String getReason();
+
+        String getEmailAddress();
+
+        String getOtherPhone();
+
+        String getMainPhone();
+
+        String getRelationship();
+
+        String getLastName();
+
+        String getFirstName();
+
+        boolean isContactJurorByEmail();
+
+        boolean isContactJurorByPhone();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/JurorThirdPartyServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/JurorThirdPartyServiceImpl.java
@@ -1,0 +1,45 @@
+package uk.gov.hmcts.juror.api.moj.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import uk.gov.hmcts.juror.api.moj.domain.Juror;
+import uk.gov.hmcts.juror.api.moj.domain.JurorThirdParty;
+import uk.gov.hmcts.juror.api.moj.repository.juror.JurorThirdPartyRepository;
+
+@Service
+@RequiredArgsConstructor(onConstructor = @__(@Autowired))
+public class JurorThirdPartyServiceImpl implements JurorThirdPartyService {
+    private final JurorThirdPartyRepository jurorThirdPartyRepository;
+
+    @Override
+    @Transactional
+    public void deleteThirdParty(Juror juror) {
+        jurorThirdPartyRepository.deleteById(juror.getJurorNumber());
+        juror.setThirdParty(null);
+    }
+
+    @Override
+    @Transactional
+    public void createOrUpdateThirdParty(Juror juror, ThirdPartyUpdateDto thirdPartyUpdate) {
+        JurorThirdParty jurorThirdParty = getOrCreateJurorThirdParty(juror.getJurorNumber());
+        jurorThirdParty.setFirstName(thirdPartyUpdate.getFirstName());
+        jurorThirdParty.setLastName(thirdPartyUpdate.getLastName());
+        jurorThirdParty.setRelationship(thirdPartyUpdate.getRelationship());
+        jurorThirdParty.setMainPhone(thirdPartyUpdate.getMainPhone());
+        jurorThirdParty.setOtherPhone(thirdPartyUpdate.getOtherPhone());
+        jurorThirdParty.setEmailAddress(thirdPartyUpdate.getEmailAddress());
+        jurorThirdParty.setReason(thirdPartyUpdate.getReason());
+        jurorThirdParty.setOtherReason(thirdPartyUpdate.getOtherReason());
+        jurorThirdParty.setContactJurorByEmail(thirdPartyUpdate.isContactJurorByEmail());
+        jurorThirdParty.setContactJurorByPhone(thirdPartyUpdate.isContactJurorByPhone());
+
+        jurorThirdPartyRepository.save(jurorThirdParty);
+    }
+
+    private JurorThirdParty getOrCreateJurorThirdParty(String jurorNumber) {
+        return jurorThirdPartyRepository.findById(jurorNumber)
+            .orElseGet(() -> new JurorThirdParty(jurorNumber));
+    }
+}

--- a/src/main/resources/db/migrationv2/V2_24__juror_third_party_details.sql
+++ b/src/main/resources/db/migrationv2/V2_24__juror_third_party_details.sql
@@ -1,0 +1,32 @@
+CREATE TABLE juror_mod.juror_third_party (
+	juror_number varchar(9) NOT NULL,
+	first_name varchar(50) NULL,
+	last_name varchar(50) NULL,
+	relationship varchar(50) NULL,
+	main_phone varchar(50) NULL,
+	other_phone varchar(50) NULL,
+	email_address varchar(254) NULL,
+	reason varchar(1250) NULL,
+	other_reason varchar(1250) NULL,
+	contact_juror_by_phone bool not NULL,
+	contact_juror_by_email bool not null,
+	CONSTRAINT juror_third_party_pk PRIMARY KEY (juror_number)
+);
+
+CREATE TABLE juror_mod.juror_third_party_audit (
+    revision int8 NOT NULL,
+    rev_type int4 NULL,
+	juror_number varchar(9) NOT NULL,
+	first_name varchar(50) NULL,
+	last_name varchar(50) NULL,
+	relationship varchar(50) NULL,
+	main_phone varchar(50) NULL,
+	other_phone varchar(50) NULL,
+	email_address varchar(254) NULL,
+	reason varchar(1250) NULL,
+	other_reason varchar(1250) NULL,
+	contact_juror_by_phone bool NULL,
+	contact_juror_by_email bool null,
+	CONSTRAINT juror_third_party_audit_pkey PRIMARY KEY (revision, juror_number),
+    CONSTRAINT juror_third_party_fk_revision_number FOREIGN KEY (revision) REFERENCES juror_mod.rev_info(revision_number)
+);

--- a/src/test/java/uk/gov/hmcts/juror/api/juror/service/StraightThroughProcessorImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/juror/service/StraightThroughProcessorImplTest.java
@@ -25,6 +25,7 @@ import uk.gov.hmcts.juror.api.moj.repository.UserRepository;
 import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorDigitalResponseRepositoryMod;
 import uk.gov.hmcts.juror.api.moj.repository.jurorresponse.JurorResponseAuditRepositoryMod;
 import uk.gov.hmcts.juror.api.moj.service.JurorHistoryService;
+import uk.gov.hmcts.juror.api.moj.service.JurorPoolService;
 import uk.gov.hmcts.juror.api.moj.service.PrintDataService;
 import uk.gov.hmcts.juror.api.moj.utils.JurorPoolUtils;
 import uk.gov.hmcts.juror.api.validation.ResponseInspectorImpl;
@@ -46,35 +47,30 @@ import static uk.gov.hmcts.juror.api.JurorDigitalApplication.AUTO_USER;
 /**
  * Unit test of {@link StraightThroughProcessorImpl}.
  */
-@SuppressWarnings({"Duplicates", "PMD.TooManyMethods"})
+@SuppressWarnings({"Duplicates", "PMD.TooManyMethods", "PMD.ExcessiveImports"})
 @RunWith(MockitoJUnitRunner.class)
 public class StraightThroughProcessorImplTest {
 
     @Mock
     private JurorDigitalResponseRepositoryMod jurorResponseRepository;
-
     @Mock
     private JurorResponseAuditRepositoryMod jurorResponseAuditRepository;
-
     @Mock
     private JurorPoolRepository poolRepository;
     @Mock
     private JurorStatusRepository jurorStatusRepository;
-
     @Mock
     private ResponseMergeService mergeService;
-
     @Mock
     private JurorHistoryRepository partHistRepository;
-
     @Mock
     private UserRepository userRepository;
-
     @Mock
     private ResponseInspectorImpl responseInspector;
-
     @Mock
     private JurorHistoryService jurorHistoryService;
+    @Mock
+    private JurorPoolService jurorPoolService;
     @InjectMocks
     private StraightThroughProcessorImpl straightThroughProcessor;
 

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/JurorRecordServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/JurorRecordServiceTest.java
@@ -222,6 +222,8 @@ class JurorRecordServiceTest {
     private JurorPaymentsSummaryRepository jurorPaymentsSummaryRepository;
     @Mock
     private JurorPoolService jurorPoolService;
+    @Mock
+    private JurorThirdPartyService jurorThirdPartyService;
 
     @Mock
     private Clock clock;

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/service/SummonsReplyStatusUpdateServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/service/SummonsReplyStatusUpdateServiceImplTest.java
@@ -88,6 +88,8 @@ public class SummonsReplyStatusUpdateServiceImplTest {
     @Mock
     private JurorAuditChangeService jurorAuditChangeService;
     @Mock
+    private JurorThirdPartyService jurorThirdPartyService;
+    @Mock
     private JurorResponseService jurorResponseService;
 
     @InjectMocks


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-8053)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=708)


### Change description ###
When updating the third party details from the juror record the option is there but it will not save the changes even when save is selected in the application.

[~accountid:62306f3e50cceb0070797d12]  a design change is required to this section to allow the user to select how the juror should be contacted i.e contact via third party or contact via juror details.

We will need to update the edit juror details API to support the third party details section.
Add a new table for juror_third_party
Update the get juror details API to include third party details
Update the FE to send / load in this new data

Update digital and paper response processing to copy the response third party details onto the new table

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
