### PR TITLE
On deferral letters, the recipient's name is now showing on the address section, however, it has now removed the court location, just coming up as "undefined".

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/letter/CourtPrintLetterRepositoryImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/letter/CourtPrintLetterRepositoryImpl.java
@@ -248,6 +248,7 @@ public class CourtPrintLetterRepositoryImpl implements CourtPrintLetterRepositor
         expressions.add(COURT_LOCATION.signatory);
         expressions.add(COURT_LOCATION.locCode);
         expressions.add(COURT_LOCATION.postcode);
+        expressions.add(COURT_LOCATION.courtAttendTime);
 
         // Juror information
         expressions.add(JUROR_POOL.juror.firstName);

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/letter/court/CourtLetterPrintServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/letter/court/CourtLetterPrintServiceImpl.java
@@ -279,7 +279,7 @@ public class CourtLetterPrintServiceImpl implements CourtLetterPrintService {
         LocalDateTime attendanceTime = data.get(POOL_REQUEST.attendTime);
         builder.attendTime(attendanceTime != null
             ? attendanceTime.toLocalTime()
-            : null);
+            : data.get(COURT_LOCATION.courtAttendTime));
         builder.date(formatDate(LocalDate.now(), welsh));
 
         switch (dto.getLetterType()) {


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-8040)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=710)


### Change description ###
On deferral letters, the recipient's name is now showing on the address section, however, it has now removed the court location, just coming up as "_undefined_".  (SCREEN SHOT IN TEAM CHAT)

Example juror numbers - 345211175, 345207162 & 445202368

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
