### PR TITLE
Hide "Expenses approval limits" for Court Managers and SJO's

### DIFF
--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/UserControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/UserControllerITest.java
@@ -963,7 +963,7 @@ public class UserControllerITest extends AbstractIntegrationTest {
                         .isActive(true)
                         .lastSignIn(null)
                         .userType(UserType.COURT)
-                        .approvalLimit(new BigDecimal("0.00"))
+                        .approvalLimit(null)
                         .roles(Set.of())
                         .courts(List.of(UserCourtDto.builder()
                             .primaryCourt(CourtDto.builder()
@@ -1171,8 +1171,7 @@ public class UserControllerITest extends AbstractIntegrationTest {
                         assertThat(user.getEmail()).isEqualTo(oldUser.getEmail());
                         assertThat(user.getName()).isEqualTo(oldUser.getName());
                         assertThat(user.isActive()).isEqualTo(oldUser.isActive());
-                        assertThat(user.getApprovalLimit()).isEqualTo(
-                            isCourtManager ? userDto.getApprovalLimit() : oldUser.getApprovalLimit());
+                        assertThat(user.getApprovalLimit()).isEqualTo(oldUser.getApprovalLimit());
                     }
                     assertThat(user.getRoles()).isEqualTo(Optional.ofNullable(userDto.getRoles()).orElse(Set.of()));
                     assertThat(user.getUpdatedBy()).isEqualTo(updatedBy);

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/utils/SecurityUtil.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/utils/SecurityUtil.java
@@ -172,7 +172,7 @@ public final class SecurityUtil {
     }
 
     public static boolean canEditApprovalLimit() {
-        return isAdministration() || isManager() && isCourt();
+        return isAdministration();
     }
 
     public static boolean isSystem() {


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-8094)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=721)


### Change description ###
Hide "Expenses approval limits" for Court Managers and SJO's

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
