### PR TITLE
Juror location not showing when on a trial

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/trial/PanelRepository.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/trial/PanelRepository.java
@@ -33,5 +33,12 @@ public interface PanelRepository extends IPanelRepository, JpaRepository<Panel, 
     )
     Panel findActivePanel(String locCode, String jurorNumber);
 
+    @Query(
+        value = "SELECT * FROM juror_mod.juror_trial "
+            + "WHERE loc_code in ?1 AND juror_number = ?2 AND AND (result IS NULL OR result = 'J')",
+        nativeQuery = true
+    )
+    Panel findActivePanelByCourtGroup(List<String> locCode, String jurorNumber);
+
     long countByJurorJurorNumberAndTrialCourtLocationLocCode(String jurorNumber, String locCode);
 }


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-8092)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=724)


### Change description ###
Juror location not showing when on a trial

Change the logic to get the jurors location so that we don't depend on having an appear today, we get the last appearance on the record and the we can derive the appearance from that location.

Andy has discussed the issue with Ben

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
