### PR TITLE
Third party details in the juror record does not save the details

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/request/JurorThirdPartyDto.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/request/JurorThirdPartyDto.java
@@ -74,4 +74,43 @@ public class JurorThirdPartyDto implements JurorThirdPartyService.ThirdPartyUpda
     @JsonProperty("contact_juror_by_email")
     private boolean contactJurorByEmail;
 
+    @Override
+    public String getThirdPartyOtherReason() {
+        return this.getOtherReason();
+    }
+
+    @Override
+    public String getThirdPartyReason() {
+        return this.getReason();
+    }
+
+    @Override
+    public String getThirdPartyEmailAddress() {
+        return this.getEmailAddress();
+    }
+
+    @Override
+    public String getThirdPartyOtherPhone() {
+        return this.getOtherPhone();
+    }
+
+    @Override
+    public String getThirdPartyMainPhone() {
+        return this.getMainPhone();
+    }
+
+    @Override
+    public String getThirdPartyRelationship() {
+        return this.getRelationship();
+    }
+
+    @Override
+    public String getThirdPartyLastName() {
+        return this.getLastName();
+    }
+
+    @Override
+    public String getThirdPartyFirstName() {
+        return this.getFirstName();
+    }
 }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/domain/jurorresponse/DigitalResponse.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/domain/jurorresponse/DigitalResponse.java
@@ -110,14 +110,35 @@ public class DigitalResponse extends AbstractJurorResponse
         super.setReplyType(new ReplyType("Digital", "Online response"));
     }
 
+
     @Override
-    public String getOtherReason() {
-        return this.getThirdPartyOtherReason();
+    public String getThirdPartyEmailAddress() {
+        return this.getEmailAddress();
     }
 
     @Override
-    public String getReason() {
-        return this.getThirdPartyReason();
+    public String getThirdPartyOtherPhone() {
+        return this.getOtherPhone();
+    }
+
+    @Override
+    public String getThirdPartyMainPhone() {
+        return this.getMainPhone();
+    }
+
+    @Override
+    public String getThirdPartyRelationship() {
+        return this.getRelationship();
+    }
+
+    @Override
+    public String getThirdPartyLastName() {
+        return this.getThirdPartyLName();
+    }
+
+    @Override
+    public String getThirdPartyFirstName() {
+        return this.getThirdPartyFName();
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/JurorThirdPartyService.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/JurorThirdPartyService.java
@@ -10,21 +10,21 @@ public interface JurorThirdPartyService {
 
     interface ThirdPartyUpdateDto {
 
-        String getOtherReason();
+        String getThirdPartyOtherReason();
 
-        String getReason();
+        String getThirdPartyReason();
 
-        String getEmailAddress();
+        String getThirdPartyEmailAddress();
 
-        String getOtherPhone();
+        String getThirdPartyOtherPhone();
 
-        String getMainPhone();
+        String getThirdPartyMainPhone();
 
-        String getRelationship();
+        String getThirdPartyRelationship();
 
-        String getLastName();
+        String getThirdPartyLastName();
 
-        String getFirstName();
+        String getThirdPartyFirstName();
 
         boolean isContactJurorByEmail();
 

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/JurorThirdPartyServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/JurorThirdPartyServiceImpl.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.juror.api.moj.domain.Juror;
 import uk.gov.hmcts.juror.api.moj.domain.JurorThirdParty;
 import uk.gov.hmcts.juror.api.moj.repository.juror.JurorThirdPartyRepository;
+import uk.gov.hmcts.juror.api.moj.utils.DataUtils;
 
 @Service
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
@@ -24,14 +25,14 @@ public class JurorThirdPartyServiceImpl implements JurorThirdPartyService {
     @Transactional
     public void createOrUpdateThirdParty(Juror juror, ThirdPartyUpdateDto thirdPartyUpdate) {
         JurorThirdParty jurorThirdParty = getOrCreateJurorThirdParty(juror.getJurorNumber());
-        jurorThirdParty.setFirstName(thirdPartyUpdate.getFirstName());
-        jurorThirdParty.setLastName(thirdPartyUpdate.getLastName());
-        jurorThirdParty.setRelationship(thirdPartyUpdate.getRelationship());
-        jurorThirdParty.setMainPhone(thirdPartyUpdate.getMainPhone());
-        jurorThirdParty.setOtherPhone(thirdPartyUpdate.getOtherPhone());
-        jurorThirdParty.setEmailAddress(thirdPartyUpdate.getEmailAddress());
-        jurorThirdParty.setReason(thirdPartyUpdate.getReason());
-        jurorThirdParty.setOtherReason(thirdPartyUpdate.getOtherReason());
+        jurorThirdParty.setFirstName(DataUtils.nullIfBlank(thirdPartyUpdate.getThirdPartyFirstName()));
+        jurorThirdParty.setLastName(DataUtils.nullIfBlank(thirdPartyUpdate.getThirdPartyLastName()));
+        jurorThirdParty.setRelationship(DataUtils.nullIfBlank(thirdPartyUpdate.getThirdPartyRelationship()));
+        jurorThirdParty.setMainPhone(DataUtils.nullIfBlank(thirdPartyUpdate.getThirdPartyMainPhone()));
+        jurorThirdParty.setOtherPhone(DataUtils.nullIfBlank(thirdPartyUpdate.getThirdPartyOtherPhone()));
+        jurorThirdParty.setEmailAddress(DataUtils.nullIfBlank(thirdPartyUpdate.getThirdPartyEmailAddress()));
+        jurorThirdParty.setReason(DataUtils.nullIfBlank(thirdPartyUpdate.getThirdPartyReason()));
+        jurorThirdParty.setOtherReason(DataUtils.nullIfBlank(thirdPartyUpdate.getThirdPartyOtherReason()));
         jurorThirdParty.setContactJurorByEmail(thirdPartyUpdate.isContactJurorByEmail());
         jurorThirdParty.setContactJurorByPhone(thirdPartyUpdate.isContactJurorByPhone());
 

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/SummonsReplyStatusUpdateServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/SummonsReplyStatusUpdateServiceImpl.java
@@ -410,43 +410,44 @@ public class SummonsReplyStatusUpdateServiceImpl implements SummonsReplyStatusUp
             } else {
                 jurorThirdPartyService.createOrUpdateThirdParty(juror,
                     new JurorThirdPartyService.ThirdPartyUpdateDto() {
+
                         @Override
-                        public String getOtherReason() {
+                        public String getThirdPartyOtherReason() {
                             return null;
                         }
 
                         @Override
-                        public String getReason() {
+                        public String getThirdPartyReason() {
                             return abstractJurorResponse.getThirdPartyReason();
                         }
 
                         @Override
-                        public String getEmailAddress() {
+                        public String getThirdPartyEmailAddress() {
                             return null;
                         }
 
                         @Override
-                        public String getOtherPhone() {
+                        public String getThirdPartyOtherPhone() {
                             return null;
                         }
 
                         @Override
-                        public String getMainPhone() {
+                        public String getThirdPartyMainPhone() {
                             return null;
                         }
 
                         @Override
-                        public String getRelationship() {
+                        public String getThirdPartyRelationship() {
                             return abstractJurorResponse.getRelationship();
                         }
 
                         @Override
-                        public String getLastName() {
+                        public String getThirdPartyLastName() {
                             return null;
                         }
 
                         @Override
-                        public String getFirstName() {
+                        public String getThirdPartyFirstName() {
                             return null;
                         }
 

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/utils/DataUtils.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/utils/DataUtils.java
@@ -143,4 +143,11 @@ public final class DataUtils {
         }
         return value.trim();
     }
+
+    public static String nullIfBlank(String value) {
+        if (value == null || value.trim().isBlank()) {
+            return null;
+        }
+        return value.trim();
+    }
 }


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-8053)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=726)


### Change description ###
When updating the third party details from the juror record the option is there but it will not save the changes even when save is selected in the application.

[~accountid:62306f3e50cceb0070797d12]  a design change is required to this section to allow the user to select how the juror should be contacted i.e contact via third party or contact via juror details.

We will need to update the edit juror details API to support the third party details section.
Add a new table for juror_third_party
Update the get juror details API to include third party details
Update the FE to send / load in this new data

Update digital and paper response processing to copy the response third party details onto the new table

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
