### PR TITLE
Juror showing with a room location when they have not yet attended

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/response/JurorOverviewResponseDto.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/response/JurorOverviewResponseDto.java
@@ -127,7 +127,7 @@ public class JurorOverviewResponseDto {
         if (todayAppearance.isPresent() && todayAppearance.get().getTimeOut() != null) {
             this.location = null;
         } else {
-            this.location = getLocationFromPanel(panelRepository, jurorPool);
+            this.location = getLocationFromPanel(panelRepository, jurorPool, this.checkedInTodayTime != null);
         }
 
 
@@ -158,12 +158,16 @@ public class JurorOverviewResponseDto {
     }
 
     @JsonIgnore
-    private String getLocationFromPanel(PanelRepository panelRepository, JurorPool jurorPool) {
-        return getActivePanel(panelRepository, jurorPool)
-            .map(panel -> panel.getTrial().getCourtroom().getDescription())
-            .orElse(Optional.ofNullable(jurorPool.getCourt().getAssemblyRoom())
+    private String getLocationFromPanel(PanelRepository panelRepository, JurorPool jurorPool, boolean hasAppearance) {
+        Optional<String> locationFromPanel = getActivePanel(panelRepository, jurorPool)
+            .map(panel -> panel.getTrial().getCourtroom().getDescription());
+
+        if (locationFromPanel.isPresent() || !hasAppearance) {
+            return locationFromPanel.orElse(null);
+        }
+        return Optional.ofNullable(jurorPool.getCourt().getAssemblyRoom())
             .map(Courtroom::getDescription)
-            .orElse(null));
+            .orElse(null);
     }
 
     private Optional<Panel> getActivePanel(PanelRepository panelRepository, JurorPool jurorPool) {


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-8129)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=745)


### Change description ###
we need to update the logic so when a juror is in status juror or panel we always show the room location, but if in status responded we only show the room location if they are checked in.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
