### PR TITLE
The persons attending details and summery to add an option to include panel/juror status jurors

### DIFF
--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/report/grouped/PersonAttendingDetailReportITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/report/grouped/PersonAttendingDetailReportITest.java
@@ -39,6 +39,7 @@ class PersonAttendingDetailReportITest extends AbstractGroupedReportControllerIT
             .date(LocalDate.now().plusDays(1))
             .locCode("415")
             .includeSummoned(false)
+            .includePanelMembers(false)
             .build());
     }
 

--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/report/standard/PersonAttendingSummaryReportITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/report/standard/PersonAttendingSummaryReportITest.java
@@ -36,6 +36,7 @@ class PersonAttendingSummaryReportITest extends AbstractStandardReportController
         return addReportType(StandardReportRequest.builder()
             .date(LocalDate.now().plusDays(1))
             .includeSummoned(false)
+            .includePanelMembers(false)
             .build());
     }
 

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/report/grouped/PersonAttendingDetailReport.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/report/grouped/PersonAttendingDetailReport.java
@@ -9,11 +9,11 @@ import uk.gov.hmcts.juror.api.moj.controller.reports.response.AbstractReportResp
 import uk.gov.hmcts.juror.api.moj.controller.reports.response.GroupedReportResponse;
 import uk.gov.hmcts.juror.api.moj.controller.reports.response.GroupedTableData;
 import uk.gov.hmcts.juror.api.moj.controller.reports.response.StandardReportResponse;
-import uk.gov.hmcts.juror.api.moj.domain.IJurorStatus;
 import uk.gov.hmcts.juror.api.moj.domain.QJurorPool;
 import uk.gov.hmcts.juror.api.moj.report.AbstractGroupedReport;
 import uk.gov.hmcts.juror.api.moj.report.DataType;
 import uk.gov.hmcts.juror.api.moj.report.ReportGroupBy;
+import uk.gov.hmcts.juror.api.moj.report.standard.PersonAttendingSummaryReport;
 import uk.gov.hmcts.juror.api.moj.repository.CourtLocationRepository;
 import uk.gov.hmcts.juror.api.moj.repository.PoolRequestRepository;
 import uk.gov.hmcts.juror.api.moj.utils.SecurityUtil;
@@ -51,12 +51,7 @@ public class PersonAttendingDetailReport extends AbstractGroupedReport {
     protected void preProcessQuery(JPAQuery<Tuple> query, StandardReportRequest request) {
         query.where(QJurorPool.jurorPool.nextDate.eq(request.getDate()));
         query.where(QJurorPool.jurorPool.pool.courtLocation.locCode.eq(SecurityUtil.getLocCode()));
-        if (request.getIncludeSummoned()) {
-            query.where(QJurorPool.jurorPool.status.status
-                .in(IJurorStatus.SUMMONED, IJurorStatus.RESPONDED));
-        } else {
-            query.where(QJurorPool.jurorPool.status.status.in(IJurorStatus.RESPONDED));
-        }
+        query.where(QJurorPool.jurorPool.status.status.in(PersonAttendingSummaryReport.getSupportedStatus(request)));
         query.orderBy(QJurorPool.jurorPool.juror.lastName.asc());
     }
 
@@ -92,6 +87,7 @@ public class PersonAttendingDetailReport extends AbstractGroupedReport {
     public interface RequestValidator extends
         Validators.AbstractRequestValidator,
         Validators.RequireDate,
-        Validators.RequireIncludeSummoned {
+        Validators.RequireIncludeSummoned,
+        Validators.RequireIncludePanelMembers {
     }
 }

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/report/standard/PersonAttendingSummaryReportTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/report/standard/PersonAttendingSummaryReportTest.java
@@ -69,6 +69,7 @@ class PersonAttendingSummaryReportTest extends AbstractStandardReportTestSupport
             .reportType(report.getName())
             .date(LocalDate.now())
             .includeSummoned(false)
+            .includePanelMembers(false)
             .build();
     }
 
@@ -110,7 +111,34 @@ class PersonAttendingSummaryReportTest extends AbstractStandardReportTestSupport
         verify(query, times(1))
             .where(QJurorPool.jurorPool.pool.courtLocation.locCode.eq(locCode));
         verify(query, times(1))
-            .where(QJurorPool.jurorPool.status.status.in(IJurorStatus.SUMMONED, IJurorStatus.RESPONDED));
+            .where(QJurorPool.jurorPool.status.status.in(IJurorStatus.RESPONDED, IJurorStatus.SUMMONED));
+        verify(query, times(1)).orderBy(QJurorPool.jurorPool.juror.lastName.asc());
+
+        verifyNoMoreInteractions(query);
+    }
+
+    @Test
+    void positivePreProcessQueryWithPanelAndJuror() {
+        String locCode = "415";
+        TestUtils.mockSecurityUtil(BureauJwtPayload.builder().locCode(locCode).userType(UserType.COURT).build());
+
+        StandardReportRequest requestMock = mock(StandardReportRequest.class);
+        when(requestMock.getDate()).thenReturn(LocalDate.now());
+
+        JPAQuery<Tuple> query = mock(JPAQuery.class,
+            withSettings().defaultAnswer(RETURNS_SELF));
+        StandardReportRequest request = getValidRequest();
+
+        request.setIncludePanelMembers(true);
+
+        report.preProcessQuery(query, request);
+        verify(query, times(1))
+            .where(QJurorPool.jurorPool.nextDate.eq(requestMock.getDate()));
+        verify(query, times(1))
+            .where(QJurorPool.jurorPool.pool.courtLocation.locCode.eq(locCode));
+        verify(query, times(1))
+            .where(
+                QJurorPool.jurorPool.status.status.in(IJurorStatus.RESPONDED, IJurorStatus.PANEL, IJurorStatus.JUROR));
         verify(query, times(1)).orderBy(QJurorPool.jurorPool.juror.lastName.asc());
 
         verifyNoMoreInteractions(query);
@@ -158,6 +186,14 @@ class PersonAttendingSummaryReportTest extends AbstractStandardReportTestSupport
         request.setIncludeSummoned(null);
         assertValidationFails(request, new ValidationFailure("includeSummoned", "must not be null"));
     }
+
+    @Test
+    void negativeMissingIncludePanelMembers() {
+        StandardReportRequest request = getValidRequest();
+        request.setIncludePanelMembers(null);
+        assertValidationFails(request, new ValidationFailure("includeSummoned", "must not be null"));
+    }
+
 
     @Test
     void negativeMissingDate() {


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-8135)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=746)


### Change description ###
Currently we include all jurors with a status responded panel and juror by default if they have the right next attendance date. Going forward we need to add a check box (as per the include summoned status) to include panel or juror status jurors and the default is of only responded jurors with the correct next attendance date:



!image-20240823-150358.png|width=1664,height=700,alt="image-20240823-150358.png"!

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
