### PR TITLE
Confirm attendance list is taking into account confirmed but returned trial attendances. This should only show the unconfirmed count.

### DIFF
--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorManagementControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/JurorManagementControllerITest.java
@@ -607,7 +607,7 @@ class JurorManagementControllerITest extends AbstractIntegrationTest {
             AttendanceDetailsResponse.Summary summary = response.getBody().getSummary();
             assertThat(summary)
                 .extracting(AttendanceDetailsResponse.Summary::getCheckedOut)
-                .isEqualTo(3L);
+                .isEqualTo(5L);
 
             assertThat(summary)
                 .extracting(AttendanceDetailsResponse.Summary::getPanelled)
@@ -1032,7 +1032,7 @@ class JurorManagementControllerITest extends AbstractIntegrationTest {
             AttendanceDetailsResponse.Summary summary = response.getBody().getSummary();
             assertThat(summary)
                 .extracting(AttendanceDetailsResponse.Summary::getCheckedIn)
-                .isEqualTo(4L);
+                .isEqualTo(5L);
 
             assertThat(summary)
                 .extracting(AttendanceDetailsResponse.Summary::getAbsent)

--- a/src/integration-test/resources/db/jurormanagement/UpdateAttendanceDetails.sql
+++ b/src/integration-test/resources/db/jurormanagement/UpdateAttendanceDetails.sql
@@ -31,10 +31,10 @@ insert into juror_mod.juror_pool (owner, juror_number, pool_number, next_date, d
 
 --JUROR_MOD.APPEARANCE
 insert into juror_mod.appearance (attendance_date,juror_number,loc_code,time_in,time_out,non_attendance,appearance_stage,attendance_type) values
-(current_date - interval '1 day','111111111','415','09:31:00',null,false,null,'FULL_DAY'),
-(current_date - interval '2 days','111111111','415','09:30:00',null,false,null,'FULL_DAY'),
+(current_date - interval '1 day','111111111','415','09:31:00',null,false,'CHECKED_IN','FULL_DAY'),
+(current_date - interval '2 days','111111111','415','09:30:00',null,false,'CHECKED_IN','FULL_DAY'),
 (current_date - interval '2 days','222222222','415','09:30:00',null,false,'CHECKED_IN','FULL_DAY'),
 (current_date - interval '2 days','333333333','415','09:30:00',null,false,'CHECKED_IN','FULL_DAY'),
-(current_date - interval '2 days','555555555','415',null,null,false,null,'FULL_DAY'),
+(current_date - interval '2 days','555555555','415','06:30:00',null,false,'CHECKED_IN','FULL_DAY'),
 (current_date - interval '2 days','666666666','415','09:30:00',null,false,'CHECKED_IN','FULL_DAY'),
 (current_date - interval '2 days','777777777','415','15:53','12:30',false,'CHECKED_IN','FULL_DAY');

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/IAppearanceRepositoryImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/IAppearanceRepositoryImpl.java
@@ -93,9 +93,10 @@ public class IAppearanceRepositoryImpl implements IAppearanceRepository {
             || commonData.getTag().equals(RetrieveAttendanceDetailsTag.PANELLED)) {
             query = query.where(APPEARANCE.appearanceStage.eq(AppearanceStage.CHECKED_IN));
         } else if (commonData.getTag().equals(RetrieveAttendanceDetailsTag.CONFIRM_ATTENDANCE)) {
-            // a confirmed juror can have appStage of CheckedIn or CheckedOut therefore cannot rely on appStage. A
-            // confirmed juror will always have TimeIn.
-            query = query.where(APPEARANCE.timeIn.isNotNull());
+            query = query.where(APPEARANCE.timeIn.isNotNull())
+                .where(APPEARANCE.appearanceStage.in(AppearanceStage.CHECKED_IN, AppearanceStage.CHECKED_OUT))
+                .where(APPEARANCE.attendanceAuditNumber.isNull())
+                .where(APPEARANCE.appearanceConfirmed.isFalse());
         }
 
         // execute the query and return the results
@@ -294,13 +295,13 @@ public class IAppearanceRepositoryImpl implements IAppearanceRepository {
         try {
             return
                 Optional.ofNullable((Appearance) AuditReaderFactory.get(entityManager)
-                .createQuery()
-                .forRevisionsOfEntity(Appearance.class, true, false)
-                .add(AuditEntity.property("jurorNumber").eq(jurorNumber))
-                .add(AuditEntity.property("locCode").eq(locCode))
-                .add(AuditEntity.property("attendanceDate").eq(attendanceDate))
-                .add(AuditEntity.property("version").eq(appearanceVersion))
-                .getSingleResult());
+                    .createQuery()
+                    .forRevisionsOfEntity(Appearance.class, true, false)
+                    .add(AuditEntity.property("jurorNumber").eq(jurorNumber))
+                    .add(AuditEntity.property("locCode").eq(locCode))
+                    .add(AuditEntity.property("attendanceDate").eq(attendanceDate))
+                    .add(AuditEntity.property("version").eq(appearanceVersion))
+                    .getSingleResult());
         } catch (NoResultException e) {
             return Optional.empty();
         }


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-8163)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=753)


### Change description ###
Bradford (402) reporting that they have 16 jurors checked in for the 29/08/2024 but the application is stating 40. 



!image-20240829-143433.png|width=560,height=337,alt="image-20240829-143433.png"!


Note: This would also override the Jury attendance audit number 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
