### PR TITLE
task/JS-27 User cannot add jurors from deferral maintenance to pools

### DIFF
--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/DeferralMaintenanceControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/controller/DeferralMaintenanceControllerITest.java
@@ -1338,7 +1338,7 @@ public class DeferralMaintenanceControllerITest extends AbstractIntegrationTest 
             assertThat(dto.getDeferralPoolsSummary().size()).isEqualTo(1);
             assertThat(dto.getDeferralPoolsSummary().get(0).getDeferralOptions().size()).isEqualTo(1);
             assertThat(dto.getDeferralPoolsSummary().get(0).getWeekCommencing())
-                .isEqualTo(DateUtils.getStartOfWeekFromDate(LocalDate.now().plusWeeks(1)));
+                .isEqualTo(DateUtils.getStartOfWeekFromDate(LocalDate.now()));
             assertThat(dto.getDeferralPoolsSummary().get(0).getDeferralOptions().get(0).getUtilisation())
                 .isEqualTo(4);
         }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/deferralmaintenance/ManageDeferralsServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/deferralmaintenance/ManageDeferralsServiceImpl.java
@@ -340,7 +340,7 @@ public class ManageDeferralsServiceImpl implements ManageDeferralsService {
         final String reasonCode = request.getExcusalReasonCode();
 
         log.info("Processing postponement request for juror(s): {}", request.jurorNumbers);
-        
+
         request.jurorNumbers.forEach(jurorNumber ->
             ManageDeferralsService.checkIfJurorHasAttendances(jurorAppearanceService, jurorNumber)
         );
@@ -430,7 +430,7 @@ public class ManageDeferralsServiceImpl implements ManageDeferralsService {
     @Override
     public DeferralOptionsDto findActivePoolsForCourtLocation(BureauJwtPayload payload, String courtLocation) {
         DeferralOptionsDto.OptionSummaryDto poolSummary = new DeferralOptionsDto.OptionSummaryDto();
-        LocalDate weekCommencing = DateUtils.getStartOfWeekFromDate(LocalDate.now().plusWeeks(1));
+        LocalDate weekCommencing = DateUtils.getStartOfWeekFromDate(LocalDate.now());
         poolSummary.setWeekCommencing(weekCommencing);
 
         //MIN Date needed (start of the next working week), max date can be null which should get all of them


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/JS-27

### Change description ###

User cannot add jurors from deferral maintenance to pools in the current week

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
