### PR TITLE
task/JS-168 Error when court user searches for excusal refused letter

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/letter/court/ExcusalRefusalLetterListRepositoryImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/letter/court/ExcusalRefusalLetterListRepositoryImpl.java
@@ -74,7 +74,9 @@ public class ExcusalRefusalLetterListRepositoryImpl implements IExcusalRefusalLe
         // run query to get the most recent excusal refused date for each juror
         List<Tuple> printedDates = getDatePrinted(owner, poolNumbers);
 
-        updateDatePrinted(searchCriteria, excusalRefusedLetterListMap, printedDates);
+        if (!printedDates.isEmpty()) {
+            updateDatePrinted(searchCriteria, excusalRefusedLetterListMap, printedDates);
+        }
 
         // sort by date printed (need unprinted letters to be at the top)
         return excusalRefusedLetterListMap.values().stream().sorted(DATE_PRINT_COMPARATOR).toList();
@@ -109,13 +111,19 @@ public class ExcusalRefusalLetterListRepositoryImpl implements IExcusalRefusalLe
             if (excusalRefusedLetterListMap.containsKey(jurorNumber)) {
                 ExcusalRefusedLetterList excusalRefusedLetterList = excusalRefusedLetterListMap.get(jurorNumber);
                 LocalDateTime datePrinted = tuple.get(QJurorHistory.jurorHistory.dateCreated);
-                LocalDate datePrintedDateOnly = datePrinted.toLocalDate();
-                if (datePrintedDateOnly.equals(excusalRefusedLetterList.getDateExcused())
-                    || datePrintedDateOnly.isAfter(excusalRefusedLetterList.getDateExcused())) {
-                    if (!searchCriteria.includePrinted()) {
-                        excusalRefusedLetterListMap.remove(jurorNumber);
-                    } else {
-                        excusalRefusedLetterList.setDatePrinted(datePrinted);
+
+                if (datePrinted == null) {
+                    // do nothing
+                    return;
+                } else {
+                    LocalDate datePrintedDateOnly = datePrinted.toLocalDate();
+                    if (datePrintedDateOnly.equals(excusalRefusedLetterList.getDateExcused())
+                        || datePrintedDateOnly.isAfter(excusalRefusedLetterList.getDateExcused())) {
+                        if (!searchCriteria.includePrinted()) {
+                            excusalRefusedLetterListMap.remove(jurorNumber);
+                        } else {
+                            excusalRefusedLetterList.setDatePrinted(datePrinted);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/JS-168

### Change description ###

Error when court user searches for excusal refused letter on pool number

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
