### PR TITLE
task/JS-305 Pools to be separated on the persons attending summary report

### DIFF
--- a/src/integration-test/java/uk/gov/hmcts/juror/api/moj/report/standard/PersonAttendingSummaryReportITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/moj/report/standard/PersonAttendingSummaryReportITest.java
@@ -5,9 +5,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.test.context.jdbc.Sql;
 import uk.gov.hmcts.juror.api.moj.controller.reports.request.StandardReportRequest;
+import uk.gov.hmcts.juror.api.moj.controller.reports.response.GroupByResponse;
+import uk.gov.hmcts.juror.api.moj.controller.reports.response.GroupedReportResponse;
+import uk.gov.hmcts.juror.api.moj.controller.reports.response.GroupedTableData;
 import uk.gov.hmcts.juror.api.moj.controller.reports.response.StandardReportResponse;
-import uk.gov.hmcts.juror.api.moj.controller.reports.response.StandardTableData;
-import uk.gov.hmcts.juror.api.moj.report.AbstractStandardReportControllerITest;
+import uk.gov.hmcts.juror.api.moj.report.AbstractGroupedReportControllerITest;
 import uk.gov.hmcts.juror.api.moj.report.ReportHashMap;
 import uk.gov.hmcts.juror.api.moj.report.ReportLinkedMap;
 
@@ -20,7 +22,7 @@ import java.util.List;
     "/db/mod/reports/PersonAttendingSummaryReportITest_typical.sql"
 })
 @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")//False positive
-class PersonAttendingSummaryReportITest extends AbstractStandardReportControllerITest {
+class PersonAttendingSummaryReportITest extends AbstractGroupedReportControllerITest {
     @Autowired
     public PersonAttendingSummaryReportITest(TestRestTemplate template) {
         super(template, PersonAttendingSummaryReport.class);
@@ -89,134 +91,70 @@ class PersonAttendingSummaryReportITest extends AbstractStandardReportController
             .assertMojForbiddenResponse("User not allowed to access this report");
     }
 
-    private StandardReportResponse getTypicalResponse() {
-        return StandardReportResponse.builder()
-            .headings(new ReportHashMap<String, StandardReportResponse.DataTypeValue>()
-                .add("attendance_date", StandardReportResponse.DataTypeValue.builder()
-                    .displayName("Attendance date")
-                    .dataType("LocalDate")
-                    .value(DateTimeFormatter.ISO_DATE.format(LocalDate.now().plusDays(1)))
-                    .build())
-                .add("total_due", StandardReportResponse.DataTypeValue.builder()
-                    .displayName("Total due to attend")
-                    .dataType("Integer")
-                    .value(3)
-                    .build())
-                .add("court_name", StandardReportResponse.DataTypeValue.builder()
-                    .displayName("Court Name")
-                    .dataType("String")
-                    .value("CHESTER (415)")
-                    .build()))
-            .tableData(
-                StandardReportResponse.TableData.<StandardTableData>builder()
-                    .headings(List.of(
-                        StandardReportResponse.TableData.Heading.builder()
-                            .id("juror_number")
-                            .name("Juror Number")
-                            .dataType("String")
-                            .headings(null)
-                            .build(),
-                        StandardReportResponse.TableData.Heading.builder()
-                            .id("first_name")
-                            .name("First Name")
-                            .dataType("String")
-                            .headings(null)
-                            .build(),
-                        StandardReportResponse.TableData.Heading.builder()
-                            .id("last_name")
-                            .name("Last Name")
-                            .dataType("String")
-                            .headings(null)
-                            .build()))
-                    .data(StandardTableData.of(
-                        new ReportLinkedMap<String, Object>()
-                            .add("juror_number", "641500011")
-                            .add("first_name", "FNAMEONEONE")
-                            .add("last_name", "LNAMEONEONE"),
-                        new ReportLinkedMap<String, Object>()
-                            .add("juror_number", "641500003")
-                            .add("first_name", "FNAMETHREE")
-                            .add("last_name", "LNAMETHREE"),
-                        new ReportLinkedMap<String, Object>()
-                            .add("juror_number", "641500021")
-                            .add("first_name", "FNAMETWOONE")
-                            .add("last_name", "LNAMETWOONE")))
-                    .build())
-            .build();
+    private GroupedReportResponse getTypicalResponse() {
+        return buildResponse(new GroupedTableData()
+                              .add("415240601", List.of(
+                                  new ReportLinkedMap<String, Object>()
+                                      .add("juror_number", "641500011")
+                                      .add("first_name", "FNAMEONEONE")
+                                      .add("last_name", "LNAMEONEONE"),
+                                  new ReportLinkedMap<String, Object>()
+                                      .add("juror_number", "641500003")
+                                      .add("first_name", "FNAMETHREE")
+                                      .add("last_name", "LNAMETHREE"),
+                                  new ReportLinkedMap<String, Object>()
+                                      .add("juror_number", "641500021")
+                                      .add("first_name", "FNAMETWOONE")
+                                      .add("last_name", "LNAMETWOONE"))), LocalDate.now().plusDays(1));
+
     }
 
-    private StandardReportResponse getIncludeSummonsResponse() {
-        return StandardReportResponse.builder()
-            .headings(new ReportHashMap<String, StandardReportResponse.DataTypeValue>()
-                          .add("attendance_date", StandardReportResponse.DataTypeValue.builder()
-                              .displayName("Attendance date")
-                              .dataType("LocalDate")
-                              .value(DateTimeFormatter.ISO_DATE.format(LocalDate.now().plusDays(2)))
-                              .build())
-                          .add("total_due", StandardReportResponse.DataTypeValue.builder()
-                              .displayName("Total due to attend")
-                              .dataType("Integer")
-                              .value(2)
-                              .build())
-                          .add("court_name", StandardReportResponse.DataTypeValue.builder()
-                              .displayName("Court Name")
-                              .dataType("String")
-                              .value("CHESTER (415)")
-                              .build()))
-            .tableData(
-                StandardReportResponse.TableData.<StandardTableData>builder()
-                    .headings(List.of(
-                        StandardReportResponse.TableData.Heading.builder()
-                            .id("juror_number")
-                            .name("Juror Number")
-                            .dataType("String")
-                            .headings(null)
-                            .build(),
-                        StandardReportResponse.TableData.Heading.builder()
-                            .id("first_name")
-                            .name("First Name")
-                            .dataType("String")
-                            .headings(null)
-                            .build(),
-                        StandardReportResponse.TableData.Heading.builder()
-                            .id("last_name")
-                            .name("Last Name")
-                            .dataType("String")
-                            .headings(null)
-                            .build()))
-                    .data(StandardTableData.of(
-                        new ReportLinkedMap<String, Object>()
-                            .add("juror_number", "641500004")
-                            .add("first_name", "FNAMEFOUR")
-                            .add("last_name", "LNAMEFOUR"),
-                        new ReportLinkedMap<String, Object>()
-                            .add("juror_number", "641500007")
-                            .add("first_name", "FNAMESEVEN")
-                            .add("last_name", "LNAMESEVEN")))
-                    .build())
-            .build();
+    private GroupedReportResponse getIncludeSummonsResponse() {
+        return buildResponse(new GroupedTableData().add("415240601", List.of(
+            new ReportLinkedMap<String, Object>()
+                .add("juror_number", "641500004")
+                .add("first_name", "FNAMEFOUR")
+                .add("last_name", "LNAMEFOUR"),
+            new ReportLinkedMap<String, Object>()
+                .add("juror_number", "641500007")
+                .add("first_name", "FNAMESEVEN")
+                .add("last_name", "LNAMESEVEN"))),  LocalDate.now().plusDays(2));
     }
 
-    private StandardReportResponse getNoRecordsResponse() {
-        return StandardReportResponse.builder()
+    private GroupedReportResponse getNoRecordsResponse() {
+        return buildResponse(new GroupedTableData(), LocalDate.now().minusDays(100));
+    }
+
+
+    private GroupedReportResponse buildResponse(GroupedTableData data, LocalDate date) {
+        return GroupedReportResponse.builder()
+            .groupBy(GroupByResponse.builder()
+                         .name("POOL_NUMBER")
+                         .build())
             .headings(new ReportHashMap<String, StandardReportResponse.DataTypeValue>()
-                .add("attendance_date", StandardReportResponse.DataTypeValue.builder()
-                    .displayName("Attendance date")
-                    .dataType("LocalDate")
-                    .value(DateTimeFormatter.ISO_DATE.format(LocalDate.now().minusDays(100)))
-                    .build())
-                .add("total_due", StandardReportResponse.DataTypeValue.builder()
-                    .displayName("Total due to attend")
-                    .dataType("Integer")
-                    .value(0)
-                    .build())
-                .add("court_name", StandardReportResponse.DataTypeValue.builder()
-                    .displayName("Court Name")
-                    .dataType("String")
-                    .value("CHESTER (415)")
-                    .build()))
+                          .add(
+                              "attendance_date", StandardReportResponse.DataTypeValue.builder()
+                                  .displayName("Attendance date")
+                                  .dataType("LocalDate")
+                                  .value(DateTimeFormatter.ISO_DATE.format(date))
+                                  .build()
+                          )
+                          .add(
+                              "total_due", StandardReportResponse.DataTypeValue.builder()
+                                  .displayName("Total due to attend")
+                                  .dataType("Integer")
+                                  .value(data.getSize().intValue())
+                                  .build()
+                          )
+                          .add(
+                              "court_name", StandardReportResponse.DataTypeValue.builder()
+                                  .displayName("Court Name")
+                                  .dataType("String")
+                                  .value("CHESTER (415)")
+                                  .build()
+                          ))
             .tableData(
-                StandardReportResponse.TableData.<StandardTableData>builder()
+                GroupedReportResponse.TableData.<GroupedTableData>builder()
                     .headings(List.of(
                         StandardReportResponse.TableData.Heading.builder()
                             .id("juror_number")
@@ -235,8 +173,9 @@ class PersonAttendingSummaryReportITest extends AbstractStandardReportController
                             .name("Last Name")
                             .dataType("String")
                             .headings(null)
-                            .build()))
-                    .data(StandardTableData.of())
+                            .build()
+                    ))
+                    .data(data)
                     .build())
             .build();
     }

--- a/src/test/java/uk/gov/hmcts/juror/api/moj/report/standard/PersonAttendingSummaryReportTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/api/moj/report/standard/PersonAttendingSummaryReportTest.java
@@ -11,13 +11,14 @@ import uk.gov.hmcts.juror.api.config.bureau.BureauJwtPayload;
 import uk.gov.hmcts.juror.api.juror.domain.CourtLocation;
 import uk.gov.hmcts.juror.api.moj.controller.reports.request.StandardReportRequest;
 import uk.gov.hmcts.juror.api.moj.controller.reports.response.AbstractReportResponse;
+import uk.gov.hmcts.juror.api.moj.controller.reports.response.GroupedTableData;
 import uk.gov.hmcts.juror.api.moj.controller.reports.response.StandardReportResponse;
-import uk.gov.hmcts.juror.api.moj.controller.reports.response.StandardTableData;
 import uk.gov.hmcts.juror.api.moj.domain.IJurorStatus;
 import uk.gov.hmcts.juror.api.moj.domain.QJurorPool;
 import uk.gov.hmcts.juror.api.moj.domain.UserType;
-import uk.gov.hmcts.juror.api.moj.report.AbstractStandardReportTestSupport;
+import uk.gov.hmcts.juror.api.moj.report.AbstractGroupedReportTestSupport;
 import uk.gov.hmcts.juror.api.moj.report.DataType;
+import uk.gov.hmcts.juror.api.moj.report.ReportGroupBy;
 import uk.gov.hmcts.juror.api.moj.repository.CourtLocationRepository;
 import uk.gov.hmcts.juror.api.moj.repository.PoolRequestRepository;
 
@@ -34,16 +35,20 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
-class PersonAttendingSummaryReportTest extends AbstractStandardReportTestSupport<PersonAttendingSummaryReport> {
+class PersonAttendingSummaryReportTest extends AbstractGroupedReportTestSupport<PersonAttendingSummaryReport> {
 
     private CourtLocationRepository courtLocationRepository;
 
     public PersonAttendingSummaryReportTest() {
         super(QJurorPool.jurorPool,
-            PersonAttendingSummaryReport.RequestValidator.class,
-            DataType.JUROR_NUMBER,
-            DataType.FIRST_NAME,
-            DataType.LAST_NAME);
+              PersonAttendingSummaryReport.RequestValidator.class,
+              ReportGroupBy.builder()
+                  .dataType(DataType.POOL_NUMBER)
+                  .removeGroupByFromResponse(true)
+                  .build(),
+              DataType.JUROR_NUMBER,
+              DataType.FIRST_NAME,
+              DataType.LAST_NAME);
     }
 
     @BeforeEach
@@ -90,6 +95,7 @@ class PersonAttendingSummaryReportTest extends AbstractStandardReportTestSupport
             .where(QJurorPool.jurorPool.status.status.in(IJurorStatus.RESPONDED));
         verify(query, times(1)).orderBy(QJurorPool.jurorPool.juror.lastName.asc());
     }
+
 
     @Test
     void positivePreProcessQueryWithSummoned() {
@@ -145,10 +151,11 @@ class PersonAttendingSummaryReportTest extends AbstractStandardReportTestSupport
     }
 
     @Override
-    public Map<String, StandardReportResponse.DataTypeValue> positiveGetHeadingsTypical(
-        StandardReportRequest request,
-        AbstractReportResponse.TableData<StandardTableData> tableData,
-        StandardTableData data) {
+    public Map<String, AbstractReportResponse.DataTypeValue>
+        positiveGetHeadingsTypical(StandardReportRequest request,
+                                   AbstractReportResponse.TableData<GroupedTableData> tableData,
+                                   GroupedTableData data) {
+
         String locCode = "415";
         TestUtils.mockSecurityUtil(BureauJwtPayload.builder().locCode(locCode).userType(UserType.COURT).build());
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/JS-305

### Change description ###

 As a Court officer I want pools to be separated on the persons attending summary, as they are in the persons attending detailed list So that I can quickly and clearly identify jurors by their respective pools.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
