### PR TITLE
JS-211 - Email address displayed in juror search results

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/request/JurorRecordFilterRequestQuery.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/request/JurorRecordFilterRequestQuery.java
@@ -61,9 +61,10 @@ public class JurorRecordFilterRequestQuery implements IsPageable {
     public enum SortField implements SortMethod.HasComparableExpression {
         JUROR_NUMBER(QJuror.juror.jurorNumber),
         JUROR_NAME(JurorRepository.JUROR_FULL_NAME),
+        EMAIL(QJuror.juror.email),
         POSTCODE(QJuror.juror.postcode),
         POOL_NUMBER(QJurorPool.jurorPool.pool.poolNumber),
-        COURT_NAME(QJurorPool.jurorPool.pool.poolRequest.courtLocation.name),
+        COURT_NAME(QJurorPool.jurorPool.pool.courtLocation.name),
         STATUS(QJurorPool.jurorPool.status.statusDesc);
 
         private final Expression<? extends Comparable<?>> comparableExpression;

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/domain/FilterJurorRecord.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/domain/FilterJurorRecord.java
@@ -41,4 +41,7 @@ public class FilterJurorRecord implements Serializable {
     @JsonProperty("loc_code")
     private String locCode;
 
+    @JsonProperty("h_email")
+    private String email;
+
 }

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/repository/JurorRepositoryImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/repository/JurorRepositoryImpl.java
@@ -120,6 +120,7 @@ public class JurorRepositoryImpl implements IJurorRepository {
         return partialQuery.distinct().select(
             JUROR.jurorNumber,
             JUROR.firstName.concat(" ").concat(JUROR.lastName).as(JUROR_FULL_NAME),
+            JUROR.email,
             JUROR.postcode,
             JUROR_POOL.pool.poolNumber,
             JUROR_POOL.pool.courtLocation.name,

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/service/JurorRecordServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/service/JurorRecordServiceImpl.java
@@ -1557,7 +1557,8 @@ public class JurorRecordServiceImpl implements JurorRecordService {
                     .poolNumber(tuple.get(QJurorPool.jurorPool.pool.poolNumber))
                     .courtName(tuple.get(QJurorPool.jurorPool.pool.courtLocation.name))
                     .status(tuple.get(QJurorPool.jurorPool.status.statusDesc))
-                    .locCode(tuple.get(QJurorPool.jurorPool.pool.courtLocation.locCode));
+                    .locCode(tuple.get(QJurorPool.jurorPool.pool.courtLocation.locCode))
+                    .email(tuple.get(QJuror.juror.email));
                 return builder.build();
             },
             ValidationConstants.MAX_ITEMS


### PR DESCRIPTION

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/JS-211


### Change description ###
Return juror email address in juror search allowing for sorting on email address


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
