### PR TITLE
JS-576 Update get_all_active_pools_at_court function

### DIFF
--- a/src/main/resources/db/migrationv2/V2_87__update_get_all_active_pools_at_court.sql
+++ b/src/main/resources/db/migrationv2/V2_87__update_get_all_active_pools_at_court.sql
@@ -1,0 +1,74 @@
+-- DROP FUNCTION juror_mod.get_active_pools_at_court_location(text);
+-- JS-576 add criteria exclude bureau owned pools != 400
+
+CREATE OR REPLACE FUNCTION juror_mod.get_all_active_pools_at_court_location(p_loccode text)
+ RETURNS TABLE(pool_number character varying, total_possible_in_attendance bigint, in_attendance bigint, on_call bigint, total_possible_on_trial bigint, jurors_on_trial bigint, pool_type character varying, service_start_date date)
+ LANGUAGE plpgsql
+AS $function$
+begin
+
+    -- find jurors on call and possible number of jurors on trial and attendance, limit the search to 4 weeks to improve performance
+    return query with cte_first_query as (
+                                  select
+                                  	p.pool_no as pool_number,
+                                  	p.loc_code as loc_code,
+                                  	sum(case when jp.status = 2 and jp.on_call = true then 1 else 0 end) as on_call,
+                                  	sum(case when jp.status = 2 and (jp.on_call is null or jp.on_call = false) then 1 else 0 end) as total_possible_in_attendance, /* should this say possibly instead of possible? */
+                                  	sum(case when jp.status in (3, 4) then 1 else 0 end) as total_possible_on_trial, /* should this say possibly instead of possible? */
+                                  	p.pool_type,
+                                  	p.return_date as service_start_date
+                                  from
+                                  	juror_mod.juror_pool jp
+                                  join juror_mod.pool p
+                                  on
+                                  	jp.pool_number = p.pool_no
+                                  where
+                                  	p.loc_code = p_loccode
+                                  	and p.owner != '400'
+                                  	and jp.is_active = true
+                                  	and p.return_date >= current_date - interval '4 weeks'
+                                  group by
+                                  	pool_no
+                                      ),
+                                        cte_second_query as (
+
+                                  -- find jurors who are physically at court today
+                                  select
+                                  	p.pool_number as pool_no,
+                                  	sum(case when jp.status = 2 and a.appearance_stage = 'CHECKED_IN' then 1 else 0 end) as in_attendance,
+                                  	sum(case when jp.status in (3, 4) and jp.juror_number in (select juror_number from juror_mod.juror_trial jt where jt.result = 'J' or jt.result is null and jt.loc_code = p.loc_code) then 1 else 0 end) as jurors_on_trial
+                                  from
+                                  	cte_first_query p
+                                  join juror_mod.juror_pool jp
+                                  on
+                                  	jp.pool_number = p.pool_number
+                                  left join juror_mod.appearance a
+                                  on
+                                  	jp.juror_number = a.juror_number
+                                  	and jp.pool_number = a.pool_number /* might not have pool_number for migrated data - loc_code would be better here*/
+                                  where
+                                  	a.attendance_date = current_date
+                                  	and jp.is_active = true
+                                  	and jp.status in (2,3,4)
+                                  group by
+                                  	p.pool_number
+                                        )
+
+                                  select
+                                  	cte1.pool_number,
+                                  	cte1.total_possible_in_attendance,
+                                  	cte2.in_attendance,
+                                  	cte1.on_call,
+                                  	cte1.total_possible_on_trial,
+                                  	cte2.jurors_on_trial,
+                                  	cte1.pool_type,
+                                  	cte1.service_start_date
+                                  from
+                                  	cte_first_query cte1
+                                  left join cte_second_query cte2
+                                                 on
+                                  	cte1.pool_number = cte2.pool_no;
+
+END;
+$function$
+;


### PR DESCRIPTION



https://tools.hmcts.net/jira/browse/JS-576


The dismiss jurors list should only contain jurors at pools owned by the court. At the moment it contains jurors with the bureau as well leading to errors when selecting said jurors.



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
