### PR TITLE
JS-590a Amend awaiting info counts

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/trial/PanelController.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/trial/PanelController.java
@@ -12,7 +12,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;


### PR DESCRIPTION



https://tools.hmcts.net/jira/browse/JS-590


Amend awaiting info count on assign replies screen to only count juror records owned by the bureau



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
