### PR TITLE
JS-688 fix cannot see non excuse letters

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/api/moj/enumeration/letter/LetterType.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/enumeration/letter/LetterType.java
@@ -115,7 +115,7 @@ public enum LetterType {
         ReissueLetterService.DataType.EXTRACTED_FLAG,
         ReissueLetterService.DataType.FORM_CODE),
         tupleJPAQuery -> tupleJPAQuery
-            .where(QJurorPool.jurorPool.status.status.eq(IJurorStatus.SUMMONED))
+            .where(QJurorPool.jurorPool.status.status.in(IJurorStatus.SUMMONED, IJurorStatus.RESPONDED))
             .where(QJuror.juror.excusalRejected.eq("Y")),
         datePrintedComparator()),
 


### PR DESCRIPTION

https://tools.hmcts.net/jira/browse/JS-688


Cannot see non excuse letters (pending)



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
