### PR TITLE
JS-740a add filter to exporting email

### DIFF
--- a/src/integration-test/java/uk/gov/hmcts/juror/api/jurorer/controller/LaEmailAddressControllerITest.java
+++ b/src/integration-test/java/uk/gov/hmcts/juror/api/jurorer/controller/LaEmailAddressControllerITest.java
@@ -68,7 +68,7 @@ public class LaEmailAddressControllerITest extends AbstractIntegrationTest {
         private static final String URL = BASE_URL + "/email-addresses";
 
         @Test
-        @DisplayName("Should successfully export all LA email addresses")
+        @DisplayName("Should successfully export all LA email addresses (default - all users)")
         void exportEmailAddressesHappy() {
             ResponseEntity<ExportLaEmailAddressResponseDto> response = restTemplate.exchange(
                 new RequestEntity<>(httpHeaders, GET, URI.create(URL)),
@@ -88,6 +88,91 @@ public class LaEmailAddressControllerITest extends AbstractIntegrationTest {
             assertThat(testLas)
                 .as("Should return our 5 test Local Authorities")
                 .hasSize(5);
+        }
+
+        @Test
+        @DisplayName("Should export all users (active and inactive) when active_only=false")
+        void exportEmailAddressesAllUsers() {
+            ResponseEntity<ExportLaEmailAddressResponseDto> response = restTemplate.exchange(
+                new RequestEntity<>(httpHeaders, GET, URI.create(URL + "?active_only=false")),
+                ExportLaEmailAddressResponseDto.class);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+            // LA 004 has 1 inactive user, should be included when active_only=false
+            ExportLaEmailAddressResponseDto.LocalAuthorityEmailsDto la004 =
+                response.getBody().getLocalAuthorities().stream()
+                    .filter(la -> "004".equals(la.getLaCode()))
+                    .findFirst()
+                    .orElseThrow();
+
+            assertThat(la004.getEmailAddresses())
+                .as("LA 004 should have 1 email address (inactive user included)")
+                .hasSize(1);
+
+            ExportLaEmailAddressResponseDto.EmailAddressDto email = la004.getEmailAddresses().get(0);
+            assertThat(email.getUsername()).isEqualTo("inactive@la004.gov.uk");
+            assertThat(email.getActive())
+                .as("User should be marked as inactive")
+                .isFalse();
+        }
+
+        @Test
+        @DisplayName("Should export only active users when active_only=true")
+        void exportEmailAddressesActiveOnly() {
+            ResponseEntity<ExportLaEmailAddressResponseDto> response = restTemplate.exchange(
+                new RequestEntity<>(httpHeaders, GET, URI.create(URL + "?active_only=true")),
+                ExportLaEmailAddressResponseDto.class);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+            // LA 004 has 1 inactive user, should NOT be included when active_only=true
+            ExportLaEmailAddressResponseDto.LocalAuthorityEmailsDto la004 =
+                response.getBody().getLocalAuthorities().stream()
+                    .filter(la -> "004".equals(la.getLaCode()))
+                    .findFirst()
+                    .orElseThrow();
+
+            assertThat(la004.getEmailAddresses())
+                .as("LA 004 should have 0 email addresses (inactive user excluded)")
+                .isEmpty();
+
+            // LA 001 has 2 active users, both should be included
+            ExportLaEmailAddressResponseDto.LocalAuthorityEmailsDto la001 =
+                response.getBody().getLocalAuthorities().stream()
+                    .filter(la -> "001".equals(la.getLaCode()))
+                    .findFirst()
+                    .orElseThrow();
+
+            assertThat(la001.getEmailAddresses())
+                .as("LA 001 should have 2 active email addresses")
+                .hasSize(2)
+                .allMatch(ExportLaEmailAddressResponseDto.EmailAddressDto::getActive);
+        }
+
+        @Test
+        @DisplayName("Should default to active_only=false when parameter not provided")
+        void exportEmailAddressesDefaultParameter() {
+            ResponseEntity<ExportLaEmailAddressResponseDto> response = restTemplate.exchange(
+                new RequestEntity<>(httpHeaders, GET, URI.create(URL)),
+                ExportLaEmailAddressResponseDto.class);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+            // Should include inactive users by default (active_only defaults to false)
+            ExportLaEmailAddressResponseDto.LocalAuthorityEmailsDto la004 =
+                response.getBody().getLocalAuthorities().stream()
+                    .filter(la -> "004".equals(la.getLaCode()))
+                    .findFirst()
+                    .orElseThrow();
+
+            assertThat(la004.getEmailAddresses())
+                .as("Should include inactive users by default")
+                .hasSize(1);
+
+            assertThat(la004.getEmailAddresses().get(0).getActive())
+                .as("User should be inactive")
+                .isFalse();
         }
 
         @Test
@@ -210,10 +295,10 @@ public class LaEmailAddressControllerITest extends AbstractIntegrationTest {
         }
 
         @Test
-        @DisplayName("Should include both active and inactive users")
+        @DisplayName("Should include both active and inactive users when active_only=false")
         void exportEmailAddressesIncludesInactiveUsers() {
             ResponseEntity<ExportLaEmailAddressResponseDto> response = restTemplate.exchange(
-                new RequestEntity<>(httpHeaders, GET, URI.create(URL)),
+                new RequestEntity<>(httpHeaders, GET, URI.create(URL + "?active_only=false")),
                 ExportLaEmailAddressResponseDto.class);
 
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -256,6 +341,27 @@ public class LaEmailAddressControllerITest extends AbstractIntegrationTest {
                 .extracting(ExportLaEmailAddressResponseDto.EmailAddressDto::getUsername)
                 .as("Email addresses should be sorted alphabetically")
                 .containsExactly("user1@la001.gov.uk", "user2@la001.gov.uk");
+        }
+
+        @Test
+        @DisplayName("Should filter correctly with active_only=true for LA with mixed users")
+        void exportEmailAddressesActiveOnlyFiltersMixedUsers() {
+            // This test assumes test data includes an LA with both active and inactive users
+            // If LA 001 had 1 active and 1 inactive user, this would verify filtering
+
+            ResponseEntity<ExportLaEmailAddressResponseDto> response = restTemplate.exchange(
+                new RequestEntity<>(httpHeaders, GET, URI.create(URL + "?active_only=true")),
+                ExportLaEmailAddressResponseDto.class);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+            // All returned users should be active
+            response.getBody().getLocalAuthorities().stream()
+                .filter(la -> List.of("001", "002", "003", "004", "005").contains(la.getLaCode()))
+                .flatMap(la -> la.getEmailAddresses().stream())
+                .forEach(email -> assertThat(email.getActive())
+                    .as("All users should be active when active_only=true")
+                    .isTrue());
         }
 
         @Test

--- a/src/main/java/uk/gov/hmcts/juror/api/jurorer/controller/LaEmailAddressController.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/jurorer/controller/LaEmailAddressController.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.juror.api.jurorer.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.juror.api.jurorer.controller.dto.ExportLaEmailAddressResponseDto;
 import uk.gov.hmcts.juror.api.jurorer.service.LaUserService;
@@ -27,8 +29,13 @@ public class LaEmailAddressController {
     @GetMapping("/email-addresses")
     @Operation(summary = "Get a list of all email addresses associated with all Local Authorities")
     @PreAuthorize(SecurityUtil.IS_BUREAU)
-    public ResponseEntity<ExportLaEmailAddressResponseDto> exportEmailAddresses() {
-        ExportLaEmailAddressResponseDto response = userService.getAllLaEmailAddresses();
-        return new ResponseEntity<>(response, HttpStatus.OK);
+    public ResponseEntity<ExportLaEmailAddressResponseDto> exportEmailAddresses(
+        @RequestParam(value = "active_only", required = false, defaultValue = "false")
+        @Parameter(description = "Filter to only active users. If false, returns all users (active and inactive).",
+            example = "true")
+        boolean activeOnly
+    ) {
+        ExportLaEmailAddressResponseDto response = userService.getAllLaEmailAddresses(activeOnly);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/uk/gov/hmcts/juror/api/jurorer/service/LaUserService.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/jurorer/service/LaUserService.java
@@ -25,10 +25,10 @@ public interface LaUserService {
 
     /**
      * Get all email addresses grouped by Local Authority.
-     * Only includes active Local Authorities.
      *
-     * @return Export response with all LA email addresses
+     * @param activeOnly If true, only includes active users. If false, includes all users.
+     * @return Export response with LA email addresses filtered by active status
      */
-    ExportLaEmailAddressResponseDto getAllLaEmailAddresses();
+    ExportLaEmailAddressResponseDto getAllLaEmailAddresses(boolean activeOnly);
 
 }

--- a/src/main/java/uk/gov/hmcts/juror/api/jurorer/service/LaUserServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/jurorer/service/LaUserServiceImpl.java
@@ -148,8 +148,8 @@ public class LaUserServiceImpl implements LaUserService {
 
     @Override
     @Transactional(readOnly = true)
-    public ExportLaEmailAddressResponseDto getAllLaEmailAddresses() {
-        log.info("Exporting all LA email addresses");
+    public ExportLaEmailAddressResponseDto getAllLaEmailAddresses(boolean activeOnly) {
+        log.info("Exporting all LA email addresses (activeOnly: {})", activeOnly);
 
         // Get all Local Authorities and sort by name
         List<LocalAuthority> allLocalAuthorities = new ArrayList<>();
@@ -163,15 +163,29 @@ public class LaUserServiceImpl implements LaUserService {
                     // Get all users for this LA
                     List<LaUser> users = userRepository.findByLocalAuthority(la);
 
-                    // Map users to email DTOs, sorted by username
-                    List<ExportLaEmailAddressResponseDto.EmailAddressDto> emailAddresses =
-                        users.stream()
+                    // Filter users based on activeOnly parameter
+                    List<ExportLaEmailAddressResponseDto.EmailAddressDto> emailAddresses;
+
+                    if (activeOnly) {
+                        // Only include active users
+                        emailAddresses = users.stream()
+                            .filter(LaUser::isActive)  // Filter to active users only
                             .map(user -> ExportLaEmailAddressResponseDto.EmailAddressDto.builder()
                                 .username(user.getUsername())
                                 .active(user.isActive())
                                 .build())
                             .sorted(Comparator.comparing(ExportLaEmailAddressResponseDto.EmailAddressDto::getUsername))
                             .collect(Collectors.toList());
+                    } else {
+                        // Include all users (active and inactive)
+                        emailAddresses = users.stream()
+                            .map(user -> ExportLaEmailAddressResponseDto.EmailAddressDto.builder()
+                                .username(user.getUsername())
+                                .active(user.isActive())
+                                .build())
+                            .sorted(Comparator.comparing(ExportLaEmailAddressResponseDto.EmailAddressDto::getUsername))
+                            .collect(Collectors.toList());
+                    }
 
                     return ExportLaEmailAddressResponseDto.LocalAuthorityEmailsDto.builder()
                         .laCode(la.getLaCode())
@@ -182,7 +196,8 @@ public class LaUserServiceImpl implements LaUserService {
                 })
                 .collect(Collectors.toList());
 
-        log.info("Exported {} Local Authorities with email addresses", localAuthorityEmailsList.size());
+        log.info("Exported {} Local Authorities with email addresses (activeOnly: {})",
+                 localAuthorityEmailsList.size(), activeOnly);
 
         return ExportLaEmailAddressResponseDto.builder()
             .localAuthorities(localAuthorityEmailsList)


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/JS-740

add two links
One to download all emails, and one to download only active user/la emails.



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
