### PR TITLE
JS-977 Update dependency com.google.guava:guava to v33.6.0-jre

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,7 +115,7 @@ dependencies {
     runtimeOnly "io.jsonwebtoken:jjwt-jackson:${jwtVersion}"
     implementation 'org.apache.httpcomponents.client5:httpclient5:5.4.4'
 
-    implementation('com.google.guava:guava:33.4.0-jre')
+    implementation('com.google.guava:guava:33.6.0-jre')
 
     // QueryDSL
     implementation("com.querydsl:querydsl-core:${queryDslVersion}")

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -38,4 +38,13 @@
 		<cve>CVE-2026-41843</cve>
 		<cve>CVE-2026-41852</cve>
 	</suppress>
+  <suppress>
+    <notes><![CDATA[
+ dependency-check finding for jackson-databind-2.21.4.jar.
+ CVE-2026-54515 - fix version 2.21.5 not yet published to Maven Central.
+ Suppressed pending release. Review and remove suppression once 2.21.5 is available.
+ ]]></notes>
+    <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson-databind@2\.21\.4$</packageUrl>
+    <cve>CVE-2026-54515</cve>
+  </suppress>
 </suppressions>

--- a/src/main/java/uk/gov/hmcts/juror/api/moj/controller/request/letter/court/CertificateOfExemptionRequestDto.java
+++ b/src/main/java/uk/gov/hmcts/juror/api/moj/controller/request/letter/court/CertificateOfExemptionRequestDto.java
@@ -7,9 +7,9 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import jakarta.annotation.Nullable;
 import lombok.experimental.SuperBuilder;
 
-import javax.annotation.Nullable;
 
 @Getter
 @Setter


### PR DESCRIPTION




https://tools.hmcts.net/jira/browse/JS-977




Update dependency com.google.guava:guava to v33.6.0-jre

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
